### PR TITLE
feat: use single NEWTON_ITERATION_NUMBER env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "newton"
-version = "0.4.3"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/utils/env/mod.rs
+++ b/src/utils/env/mod.rs
@@ -18,7 +18,7 @@ impl EnvManager {
             execution_id.to_string(),
         );
         env_vars.insert(
-            format!("NEWTON_ITERATION_{}", iteration_number),
+            "NEWTON_ITERATION_NUMBER".to_string(),
             iteration_number.to_string(),
         );
 
@@ -56,14 +56,10 @@ impl EnvManager {
     }
 
     pub fn clear_newton_env_vars() {
-        if let Ok(exe_id) = std::env::var("NEWTON_EXECUTION_ID") {
-            std::env::remove_var(format!("NEWTON_EXECUTION_{}", exe_id.to_uppercase()));
-            std::env::remove_var(format!(
-                "NEWTON_ITERATION_{}",
-                std::env::var("NEWTON_ITERATION_NUMBER").unwrap_or_default()
-            ));
-            std::env::remove_var("NEWTON_EXECUTION_ID");
-            std::env::remove_var("NEWTON_ITERATION_NUMBER");
-        }
+        std::env::remove_var("NEWTON_EXECUTION_ID");
+        std::env::remove_var("NEWTON_ITERATION_NUMBER");
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/utils/env/tests.rs
+++ b/src/utils/env/tests.rs
@@ -1,0 +1,188 @@
+use super::EnvManager;
+use crate::core::entities::{ToolMetadata, ToolType};
+use std::collections::HashMap;
+use std::env;
+
+#[test]
+fn test_newton_iteration_number_env_var() {
+    let env_vars = EnvManager::set_newton_env_vars("exec123", 5, None, None, None);
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"5".to_string())
+    );
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_5"));
+}
+
+#[test]
+fn test_clear_newton_env_vars() {
+    env::set_var("NEWTON_EXECUTION_ID", "test123");
+    env::set_var("NEWTON_ITERATION_NUMBER", "3");
+
+    EnvManager::clear_newton_env_vars();
+
+    assert!(env::var("NEWTON_ITERATION_NUMBER").is_err());
+    assert!(env::var("NEWTON_EXECUTION_ID").is_err());
+}
+
+#[test]
+fn test_clear_newton_env_vars_no_execution_id() {
+    env::set_var("NEWTON_ITERATION_NUMBER", "3");
+
+    EnvManager::clear_newton_env_vars();
+
+    // Should clear NEWTON_ITERATION_NUMBER even if NEWTON_EXECUTION_ID is not set
+    assert!(env::var("NEWTON_ITERATION_NUMBER").is_err());
+}
+
+#[test]
+fn test_set_newton_env_vars_with_iteration() {
+    let env_vars = EnvManager::set_newton_env_vars("exec123", 3, None, None, None);
+
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"3".to_string())
+    );
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_3"));
+    assert_eq!(
+        env_vars.get("NEWTON_EXECUTION_EXEC123"),
+        Some(&"exec123".to_string())
+    );
+}
+
+#[test]
+fn test_set_newton_env_vars_multiple_iterations() {
+    // Test that iteration number is not hardcoded
+    let env_vars_1 = EnvManager::set_newton_env_vars("exec1", 1, None, None, None);
+    let env_vars_2 = EnvManager::set_newton_env_vars("exec2", 5, None, None, None);
+    let env_vars_3 = EnvManager::set_newton_env_vars("exec3", 10, None, None, None);
+
+    assert_eq!(
+        env_vars_1.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"1".to_string())
+    );
+    assert_eq!(
+        env_vars_2.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"5".to_string())
+    );
+    assert_eq!(
+        env_vars_3.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"10".to_string())
+    );
+}
+
+#[test]
+fn test_set_environment_variables() {
+    let mut env_vars = HashMap::new();
+    env_vars.insert("TEST_VAR_1".to_string(), "value1".to_string());
+    env_vars.insert("TEST_VAR_2".to_string(), "value2".to_string());
+
+    // Clean up first
+    env::remove_var("TEST_VAR_1");
+    env::remove_var("TEST_VAR_2");
+
+    EnvManager::set_environment_variables(&env_vars);
+
+    assert_eq!(env::var("TEST_VAR_1"), Ok("value1".to_string()));
+    assert_eq!(env::var("TEST_VAR_2"), Ok("value2".to_string()));
+
+    // Clean up
+    env::remove_var("TEST_VAR_1");
+    env::remove_var("TEST_VAR_2");
+}
+
+#[test]
+fn test_set_newton_env_vars_with_tools() {
+    let evaluator = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Evaluator,
+        arguments: vec![],
+        environment_variables: vec![],
+    };
+
+    let advisor = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Advisor,
+        arguments: vec![],
+        environment_variables: vec![("ADVISOR_VAR".to_string(), "advisor_value".to_string())],
+    };
+
+    let executor = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Executor,
+        arguments: vec![],
+        environment_variables: vec![("EXECUTOR_VAR".to_string(), "executor_value".to_string())],
+    };
+
+    let env_vars = EnvManager::set_newton_env_vars(
+        "exec123",
+        2,
+        Some(&evaluator),
+        Some(&advisor),
+        Some(&executor),
+    );
+
+    // Check iteration variable
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"2".to_string())
+    );
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_2"));
+
+    // Check tool type and name
+    assert_eq!(
+        env_vars.get("NEWTON_TOOL_TYPE"),
+        Some(&"executor".to_string())
+    );
+    assert_eq!(
+        env_vars.get("NEWTON_TOOL_NAME"),
+        Some(&"executor".to_string())
+    );
+
+    // Check custom environment variables
+    assert_eq!(
+        env_vars.get("ADVISOR_VAR"),
+        Some(&"advisor_value".to_string())
+    );
+    assert_eq!(
+        env_vars.get("EXECUTOR_VAR"),
+        Some(&"executor_value".to_string())
+    );
+}
+
+#[test]
+fn test_no_numbered_iteration_variables() {
+    // Ensure that numbered variables are never created
+    let env_vars = EnvManager::set_newton_env_vars("exec_test", 1, None, None, None);
+
+    for i in 1..=100 {
+        let numbered_var = format!("NEWTON_ITERATION_{}", i);
+        assert!(
+            !env_vars.contains_key(&numbered_var),
+            "Found unexpected variable: {}",
+            numbered_var
+        );
+    }
+}
+
+#[test]
+fn test_iteration_number_zero() {
+    let env_vars = EnvManager::set_newton_env_vars("exec0", 0, None, None, None);
+
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"0".to_string())
+    );
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_0"));
+}
+
+#[test]
+fn test_iteration_number_large() {
+    let large_iteration = 999999;
+    let env_vars = EnvManager::set_newton_env_vars("exec_large", large_iteration, None, None, None);
+
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&large_iteration.to_string())
+    );
+    assert!(!env_vars.contains_key(&format!("NEWTON_ITERATION_{}", large_iteration)));
+}

--- a/tests/iteration_tracking.rs
+++ b/tests/iteration_tracking.rs
@@ -1,0 +1,163 @@
+use newton::core::entities::{ToolMetadata, ToolType};
+use newton::utils::EnvManager;
+use std::env;
+
+#[test]
+fn test_iteration_tracking_across_workflow() {
+    // This test verifies that NEWTON_ITERATION_NUMBER is properly set during execution
+    // Since we can't easily test the full workflow without a complete setup,
+    // we'll test the core functionality through the EnvManager
+
+    let env_vars = EnvManager::set_newton_env_vars("test_exec_123", 1, None, None, None);
+
+    // Verify the iteration number is set correctly
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"1".to_string())
+    );
+
+    // Verify no numbered variables are created
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_1"));
+
+    // Test with different iteration numbers
+    for i in 1..=5 {
+        let env_vars =
+            EnvManager::set_newton_env_vars(&format!("test_exec_{}", i), i, None, None, None);
+
+        assert_eq!(
+            env_vars.get("NEWTON_ITERATION_NUMBER"),
+            Some(&i.to_string())
+        );
+        assert!(!env_vars.contains_key(&format!("NEWTON_ITERATION_{}", i)));
+    }
+}
+
+#[test]
+fn test_iteration_persistence_across_calls() {
+    // Test that iteration number is consistently set across multiple calls
+    let exec_id = "persistent_test";
+
+    // First iteration
+    let env_vars_1 = EnvManager::set_newton_env_vars(exec_id, 1, None, None, None);
+    assert_eq!(
+        env_vars_1.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"1".to_string())
+    );
+
+    // Second iteration
+    let env_vars_2 = EnvManager::set_newton_env_vars(exec_id, 2, None, None, None);
+    assert_eq!(
+        env_vars_2.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"2".to_string())
+    );
+
+    // Third iteration
+    let env_vars_3 = EnvManager::set_newton_env_vars(exec_id, 3, None, None, None);
+    assert_eq!(
+        env_vars_3.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"3".to_string())
+    );
+}
+
+#[test]
+fn test_iteration_with_tools() {
+    let evaluator = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Evaluator,
+        arguments: vec![],
+        environment_variables: vec![],
+    };
+
+    let advisor = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Advisor,
+        arguments: vec![],
+        environment_variables: vec![("TEST_ADVISOR_VAR".to_string(), "test_value".to_string())],
+    };
+
+    let executor = ToolMetadata {
+        tool_version: Some("1.0.0".to_string()),
+        tool_type: ToolType::Executor,
+        arguments: vec![],
+        environment_variables: vec![(
+            "TEST_EXECUTOR_VAR".to_string(),
+            "executor_value".to_string(),
+        )],
+    };
+
+    // Test iteration 7 with all tools
+    let env_vars = EnvManager::set_newton_env_vars(
+        "tools_test",
+        7,
+        Some(&evaluator),
+        Some(&advisor),
+        Some(&executor),
+    );
+
+    // Verify iteration number is correct
+    assert_eq!(
+        env_vars.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"7".to_string())
+    );
+    assert!(!env_vars.contains_key("NEWTON_ITERATION_7"));
+
+    // Verify tool-specific variables are also set
+    assert_eq!(
+        env_vars.get("NEWTON_TOOL_TYPE"),
+        Some(&"executor".to_string())
+    );
+    assert_eq!(
+        env_vars.get("NEWTON_TOOL_NAME"),
+        Some(&"executor".to_string())
+    );
+    assert_eq!(
+        env_vars.get("TEST_ADVISOR_VAR"),
+        Some(&"test_value".to_string())
+    );
+    assert_eq!(
+        env_vars.get("TEST_EXECUTOR_VAR"),
+        Some(&"executor_value".to_string())
+    );
+}
+
+#[test]
+fn test_environment_variable_cleanup() {
+    // Test that environment variables are properly cleaned up
+    env::set_var("NEWTON_EXECUTION_ID", "cleanup_test");
+    env::set_var("NEWTON_ITERATION_NUMBER", "999");
+
+    // Verify variables are set
+    assert_eq!(env::var("NEWTON_ITERATION_NUMBER"), Ok("999".to_string()));
+    assert_eq!(
+        env::var("NEWTON_EXECUTION_ID"),
+        Ok("cleanup_test".to_string())
+    );
+
+    // Clear variables
+    EnvManager::clear_newton_env_vars();
+
+    // Verify variables are cleared
+    assert!(env::var("NEWTON_ITERATION_NUMBER").is_err());
+    assert!(env::var("NEWTON_EXECUTION_ID").is_err());
+}
+
+#[test]
+fn test_iteration_number_edge_cases() {
+    // Test iteration number 0
+    let env_vars_0 = EnvManager::set_newton_env_vars("edge_test", 0, None, None, None);
+    assert_eq!(
+        env_vars_0.get("NEWTON_ITERATION_NUMBER"),
+        Some(&"0".to_string())
+    );
+    assert!(!env_vars_0.contains_key("NEWTON_ITERATION_0"));
+
+    // Test large iteration number
+    let large_iter = 1000000;
+    let env_vars_large =
+        EnvManager::set_newton_env_vars("large_test", large_iter, None, None, None);
+    assert_eq!(
+        env_vars_large.get("NEWTON_ITERATION_NUMBER"),
+        Some(&large_iter.to_string())
+    );
+    assert!(!env_vars_large.contains_key(&format!("NEWTON_ITERATION_{}", large_iter)));
+}


### PR DESCRIPTION
## Summary

Replaces numbered iteration environment variables (`NEWTON_ITERATION_1`, `NEWTON_ITERATION_2`, etc.) with a single `NEWTON_ITERATION_NUMBER` variable. Scripts and tools now read the current iteration from one env var instead of resolving the correct numbered key.

## Changes

- **`src/utils/env/mod.rs`**: EnvManager now sets `NEWTON_ITERATION_NUMBER` instead of `NEWTON_ITERATION_{n}`. `clear_newton_env_vars()` simplified to remove `NEWTON_EXECUTION_ID` and `NEWTON_ITERATION_NUMBER` only (no exe_id lookup).
- **`src/utils/env/tests.rs`**: Unit tests for iteration env var, clear behavior, and no legacy numbered vars.
- **`tests/iteration_tracking.rs`**: Integration tests for iteration tracking across the workflow.

## Benefits

- Single env var for iteration: `echo $NEWTON_ITERATION_NUMBER` instead of resolving `NEWTON_ITERATION_*`.
- Simpler cleanup; consistent with `NEWTON_EXECUTION_ID` pattern.
- Scripts in `.newton/` (advisor, executor) should use `${NEWTON_ITERATION_NUMBER:-1}` instead of reading `iteration.txt` or numbered vars.

## Breaking changes

- `NEWTON_ITERATION_1`, `NEWTON_ITERATION_2`, etc. are no longer set. Callers must use `NEWTON_ITERATION_NUMBER`.