### PR TITLE
Add context and template plumbing

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,4 @@
-use clap::Args;
+use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Args)]
@@ -110,6 +110,59 @@ pub struct RunArgs {
     /// Create PR on successful completion
     #[arg(long, help_heading = "Git Integration")]
     pub create_pr: bool,
+}
+
+#[derive(Args)]
+pub struct ContextArgs {
+    /// Path to the workspace to manipulate (defaults to current directory)
+    #[arg(value_name = "PATH", default_value = ".")]
+    pub workspace_path: PathBuf,
+
+    #[command(subcommand)]
+    pub command: ContextCommand,
+}
+
+#[derive(Subcommand)]
+pub enum ContextCommand {
+    /// Append a markdown context entry for the current iteration
+    Add {
+        /// Message describing the context addition
+        message: String,
+        /// Title for the context entry
+        #[arg(long)]
+        title: Option<String>,
+    },
+    /// Print the current context buffer
+    Show,
+    /// Clear all stored context entries
+    Clear,
+}
+
+#[derive(Args)]
+pub struct InitArgs {
+    /// Path where the workspace should be initialized
+    #[arg(value_name = "PATH", default_value = ".")]
+    pub workspace_path: PathBuf,
+
+    /// Template to render (defaults to basic)
+    #[arg(long, value_name = "TEMPLATE")]
+    pub template: Option<String>,
+
+    /// Project name used in rendered templates
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// Coding agent name to populate config
+    #[arg(long, value_name = "AGENT")]
+    pub coding_agent: Option<String>,
+
+    /// Coding agent model to populate config
+    #[arg(long, value_name = "MODEL")]
+    pub model: Option<String>,
+
+    /// Prompt for values interactively
+    #[arg(long)]
+    pub interactive: bool,
 }
 
 #[derive(Args)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::args::{ErrorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs},
+    cli::args::{ContextArgs, ErrorArgs, InitArgs, ReportArgs, RunArgs, StatusArgs, StepArgs},
     core::{
         ConfigLoader, ConfigValidator, DefaultErrorReporter, GitManager, OptimizationOrchestrator,
         SuccessPolicy,
@@ -8,6 +8,8 @@ use crate::{
     Result,
 };
 use std::collections::HashMap;
+
+use crate::cli::{context, init};
 
 pub async fn run(args: RunArgs) -> Result<()> {
     tracing::info!("Starting Newton Loop optimization run");
@@ -119,6 +121,7 @@ pub async fn run(args: RunArgs) -> Result<()> {
             exec_config,
             &additional_env,
             Some(&success_policy),
+            &newton_config,
         )
         .await;
 
@@ -314,4 +317,12 @@ pub async fn error(args: ErrorArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub async fn context(args: ContextArgs) -> Result<()> {
+    context::run(args).await
+}
+
+pub async fn init(args: InitArgs) -> Result<()> {
+    init::run(args).await
 }

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,0 +1,31 @@
+use crate::cli::args::{ContextArgs, ContextCommand};
+use crate::core::{ConfigLoader, ContextManager};
+use crate::Result;
+
+/// Handles `newton context ...` subcommands for managing the shared context buffer.
+pub async fn run(args: ContextArgs) -> Result<()> {
+    let config = ConfigLoader::load_from_workspace(&args.workspace_path)?;
+    let context_file = args.workspace_path.join(&config.context.file);
+
+    match args.command {
+        ContextCommand::Add { message, title } => {
+            let entry_title = title.unwrap_or_else(|| "User feedback".to_string());
+            ContextManager::add_context(&context_file, &entry_title, &message)?;
+            println!("Added context entry with title '{}'.", entry_title);
+        }
+        ContextCommand::Show => {
+            let contents = ContextManager::read_context(&context_file)?;
+            if contents.trim().is_empty() {
+                println!("Context is empty.");
+            } else {
+                println!("Current context:\n{}", contents);
+            }
+        }
+        ContextCommand::Clear => {
+            ContextManager::clear_context(&context_file)?;
+            println!("Context cleared.");
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,0 +1,208 @@
+use crate::cli::args::InitArgs;
+use crate::core::{ContextManager, NewtonConfig, TemplateInfo, TemplateManager, TemplateRenderer};
+use crate::Result;
+use anyhow::anyhow;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
+
+const AIKIT_DOCS_URL: &str = "https://aikit.readthedocs.io";
+const DEFAULT_LANGUAGE: &str = "rust";
+const DEFAULT_TEMPLATE: &str = "basic";
+
+/// Handles `newton init` by rendering templates, creating state, and scaffolding.
+pub async fn run(args: InitArgs) -> Result<()> {
+    ensure_aikit_installed()?;
+
+    let workspace_path = args.workspace_path;
+    let newton_dir = workspace_path.join(".newton");
+
+    if newton_dir.exists() {
+        return Err(anyhow!("Workspace already contains .newton directory"));
+    }
+
+    let templates = TemplateManager::list_templates(&workspace_path)?;
+    if templates.is_empty() {
+        return Err(anyhow!(
+            "No templates found under {}/.newton/templates/. Install a template via aikit ({}) before running init.",
+            workspace_path.display(),
+            AIKIT_DOCS_URL
+        ));
+    }
+
+    let template_name = select_template(args.template, args.interactive, &templates)?;
+    if !templates.iter().any(|t| t.name == template_name) {
+        return Err(anyhow!(
+            "Template '{}' is not installed. Available templates: {}",
+            template_name,
+            templates
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    let defaults = NewtonConfig::default();
+    let project_name = args
+        .name
+        .or_else(|| {
+            workspace_path
+                .file_name()
+                .and_then(OsStr::to_str)
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| defaults.project.name.clone());
+    let coding_agent = args
+        .coding_agent
+        .unwrap_or_else(|| defaults.executor.coding_agent.clone());
+    let coding_agent_model = args
+        .model
+        .unwrap_or_else(|| defaults.executor.coding_agent_model.clone());
+    let test_command = determine_test_command(&workspace_path);
+    let language = DEFAULT_LANGUAGE.to_string();
+
+    let project_name = if args.interactive && project_name.trim().is_empty() {
+        prompt_for_value("Project name", Some(&project_name))?
+    } else {
+        project_name
+    };
+
+    let coding_agent = if args.interactive {
+        prompt_for_value("Coding agent", Some(&coding_agent))?
+    } else {
+        coding_agent
+    };
+
+    let coding_agent_model = if args.interactive {
+        prompt_for_value("Coding agent model", Some(&coding_agent_model))?
+    } else {
+        coding_agent_model
+    };
+
+    let language = if args.interactive {
+        prompt_for_value("Language", Some(&language))?
+    } else {
+        language
+    };
+
+    let template_to_render = template_name.clone();
+
+    fs::create_dir_all(newton_dir.join("state"))?;
+    let context_file = newton_dir.join("state/context.md");
+    ContextManager::clear_context(&context_file)?;
+    fs::write(newton_dir.join("state/promise.txt"), "")?;
+    fs::write(newton_dir.join("state/executor_prompt.md"), "")?;
+
+    let mut variables = HashMap::new();
+    variables.insert("project_name".to_string(), project_name.clone());
+    variables.insert("coding_agent".to_string(), coding_agent.clone());
+    variables.insert("coding_agent_model".to_string(), coding_agent_model.clone());
+    variables.insert("test_command".to_string(), test_command.clone());
+    variables.insert("language".to_string(), language.clone());
+
+    TemplateRenderer::render_template(&workspace_path, &template_to_render, variables)?;
+
+    let config_path = workspace_path.join("newton.toml");
+    if !config_path.exists() {
+        let mut config = NewtonConfig::default();
+        config.project.name = project_name.clone();
+        config.project.template = Some(template_to_render.clone());
+        config.executor.coding_agent = coding_agent;
+        config.executor.coding_agent_model = coding_agent_model;
+        config.evaluator.test_command = Some(test_command.clone());
+        fs::write(&config_path, toml::to_string_pretty(&config)?)?;
+    }
+
+    let goal_path = workspace_path.join("GOAL.md");
+    if !goal_path.exists() {
+        fs::write(
+            &goal_path,
+            format!(
+                "# Goal for {}\n\nDescribe what you want Newton Loop to achieve.\n",
+                project_name
+            ),
+        )?;
+    }
+
+    println!(
+        "Initialized workspace with template '{}'",
+        template_to_render
+    );
+    println!("Newton CLI is ready. See GOAL.md to describe your objective.");
+
+    Ok(())
+}
+
+fn ensure_aikit_installed() -> Result<()> {
+    match Command::new("aikit").arg("--version").output() {
+        Ok(output) if output.status.success() => Ok(()),
+        _ => Err(anyhow!(
+            "aikit is required for template support. Install it first:\n  {}",
+            AIKIT_DOCS_URL
+        )),
+    }
+}
+
+fn select_template(
+    requested: Option<String>,
+    interactive: bool,
+    available: &[TemplateInfo],
+) -> Result<String> {
+    if let Some(name) = requested {
+        return Ok(name);
+    }
+    if interactive {
+        prompt_for_selection("Select a template", available)
+    } else {
+        Ok(DEFAULT_TEMPLATE.to_string())
+    }
+}
+
+fn prompt_for_selection(prompt: &str, available: &[TemplateInfo]) -> Result<String> {
+    println!("{}:", prompt);
+    for (idx, template) in available.iter().enumerate() {
+        println!("  {}) {}", idx + 1, template.name);
+    }
+    let selection = prompt_for_value("Enter the number of the template", None)?;
+    let index: usize = selection
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("Invalid selection"))?;
+    available
+        .get(index.saturating_sub(1))
+        .ok_or_else(|| anyhow!("Template selection out of range"))
+        .map(|t| t.name.clone())
+}
+
+fn prompt_for_value(prompt: &str, default: Option<&str>) -> Result<String> {
+    print!("{}", prompt);
+    if let Some(def) = default {
+        print!(" [{}]", def);
+    }
+    print!(": ");
+    io::stdout().flush()?;
+
+    let mut buffer = String::new();
+    io::stdin().read_line(&mut buffer)?;
+    let trimmed = buffer.trim();
+    if trimmed.is_empty() {
+        if let Some(def) = default {
+            return Ok(def.to_string());
+        }
+        return Err(anyhow!("Value cannot be empty"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn determine_test_command(workspace_path: &Path) -> String {
+    let run_tests = workspace_path.join("scripts/run-tests.sh");
+    if run_tests.exists() {
+        format!("./{}", run_tests.display())
+    } else {
+        "cargo test".to_string()
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,9 @@
 pub mod args;
 pub mod commands;
+pub mod context;
+pub mod init;
 
-pub use args::{ErrorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs};
+pub use args::{ContextArgs, ErrorArgs, InitArgs, ReportArgs, RunArgs, StatusArgs, StepArgs};
 use clap::{Parser, Subcommand};
 
 const HELP_TEMPLATE: &str = "\
@@ -57,6 +59,18 @@ pub enum Command {
         after_help = "Example:\n    newton error exec_123 --verbose"
     )]
     Error(ErrorArgs),
+    #[command(
+        about = "Add, view, or clear stored context entries",
+        long_about = "Context commands let you seed the Newton context buffer with notes that are fed into the executor prompt.",
+        after_help = "Examples:\n    newton context add \"Need to fix lint\"\n    newton context show"
+    )]
+    Context(ContextArgs),
+    #[command(
+        about = "Install template scaffolding for a workspace",
+        long_about = "Init renders template files (requires aikit) and sets up .newton/state so you can start running Newton.",
+        after_help = "Example:\n    newton init . --template basic"
+    )]
+    Init(InitArgs),
 }
 
 pub async fn run(args: Args) -> crate::Result<()> {
@@ -66,5 +80,7 @@ pub async fn run(args: Args) -> crate::Result<()> {
         Command::Status(status_args) => commands::status(status_args).await,
         Command::Report(report_args) => commands::report(report_args).await,
         Command::Error(error_args) => commands::error(error_args).await,
+        Command::Context(context_args) => commands::context(context_args).await,
+        Command::Init(init_args) => commands::init(init_args).await,
     }
 }

--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -1,0 +1,157 @@
+#![allow(clippy::result_large_err)]
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use chrono::{SecondsFormat, Utc};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+const CONTEXT_HEADER: &str = "# Newton Loop Context\n\n";
+
+/// Manages the lifecycle of the Newton context board, which stores
+/// markdown notes that persist for the duration of a workspace run.
+pub struct ContextManager;
+
+impl ContextManager {
+    /// Add a new entry to the workspace context log.
+    pub fn add_context(context_file: &Path, title: &str, message: &str) -> Result<(), AppError> {
+        Self::ensure_header(context_file)?;
+        Self::append_entry(context_file, title, message)
+    }
+
+    /// Append a context entry with timestamped heading and body.
+    pub fn append_context(context_file: &Path, title: &str, message: &str) -> Result<(), AppError> {
+        Self::ensure_header(context_file)?;
+        Self::append_entry(context_file, title, message)
+    }
+
+    /// Read the current context buffer for inclusion in prompts.
+    pub fn read_context(context_file: &Path) -> Result<String, AppError> {
+        if !context_file.exists() {
+            return Ok(String::new());
+        }
+        std::fs::read_to_string(context_file).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to read context file {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+
+    /// Reset the context file to an empty header so new entries can be added.
+    pub fn clear_context(context_file: &Path) -> Result<(), AppError> {
+        if let Some(parent) = context_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(context_file, CONTEXT_HEADER).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to clear context file {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+
+    fn ensure_header(context_file: &Path) -> Result<(), AppError> {
+        if context_file.exists() {
+            return Ok(());
+        }
+        if let Some(parent) = context_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(context_file, CONTEXT_HEADER).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to init context file {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+
+    fn append_entry(context_file: &Path, title: &str, message: &str) -> Result<(), AppError> {
+        let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(context_file)
+            .map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "Failed to open context file {}: {}",
+                        context_file.display(),
+                        e
+                    ),
+                )
+            })?;
+        writeln!(file, "## Context added at {}", timestamp).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to write context header to {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })?;
+        writeln!(file, "{}\n", title).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to write context title to {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })?;
+        writeln!(file, "{}\n", message).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to write context body to {}: {}",
+                    context_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_add_and_read_context() {
+        let tmp = TempDir::new().unwrap();
+        let context_file = tmp.path().join("state/context.md");
+
+        ContextManager::add_context(&context_file, "Title", "Details").unwrap();
+        let contents = ContextManager::read_context(&context_file).unwrap();
+        assert!(contents.contains("Title"));
+        assert!(contents.contains("Details"));
+    }
+
+    #[test]
+    fn test_clear_context() {
+        let tmp = TempDir::new().unwrap();
+        let context_file = tmp.path().join("state/context.md");
+
+        ContextManager::add_context(&context_file, "After", "Clear").unwrap();
+        ContextManager::clear_context(&context_file).unwrap();
+        let contents = ContextManager::read_context(&context_file).unwrap();
+        assert_eq!(contents, CONTEXT_HEADER);
+    }
+}

--- a/src/core/entities/mod.rs
+++ b/src/core/entities/mod.rs
@@ -172,4 +172,7 @@ pub struct IterationMetadata {
     pub report_path: Option<PathBuf>,
     pub artifacts_generated: usize,
     pub artifacts_deleted: usize,
+    pub evaluator_score: Option<f64>,
+    pub promise_value: Option<String>,
+    pub should_stop: bool,
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod context;
 pub mod entities;
 pub mod error;
 pub mod git;
@@ -6,14 +7,18 @@ pub mod history_recorder;
 pub mod logger;
 pub mod orchestrator;
 pub mod performance;
+pub mod promise;
+pub mod prompt;
 pub mod results_processor;
 pub mod success_policy;
+pub mod template;
 pub mod tool_executor;
 pub mod types;
 pub mod workspace;
 
 pub use crate::tools::ToolResult;
 pub use config::{ConfigLoader, ConfigValidator, NewtonConfig};
+pub use context::ContextManager;
 pub use entities::{
     ArtifactMetadata, ErrorCategory, ExecutionStatus, IterationPhase, OptimizationExecution,
     ToolType,
@@ -23,6 +28,9 @@ pub use git::{BranchManager, CommitManager, GitManager, PullRequestManager};
 pub use history_recorder::ExecutionHistoryRecorder;
 pub use orchestrator::OptimizationOrchestrator;
 pub use performance::PerformanceProfiler;
+pub use promise::PromiseDetector;
+pub use prompt::PromptBuilder;
 pub use results_processor::{OutputFormat, ResultsProcessor};
 pub use success_policy::SuccessPolicy;
+pub use template::{TemplateInfo, TemplateManager, TemplateRenderer};
 pub use types::*;

--- a/src/core/promise/mod.rs
+++ b/src/core/promise/mod.rs
@@ -1,0 +1,104 @@
+#![allow(clippy::result_large_err)]
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use std::fs;
+use std::path::Path;
+
+/// Parses and persists promise markers emitted by executor tools.
+pub struct PromiseDetector;
+
+impl PromiseDetector {
+    /// Search executor text for the first `<promise>...</promise>` entry that is complete.
+    pub fn detect_promise(executor_output: &str) -> Option<String> {
+        let mut search_start = 0;
+        while let Some(start) = executor_output[search_start..].find("<promise>") {
+            let start_index = search_start + start + "<promise>".len();
+            if let Some(end_index_relative) = executor_output[start_index..].find("</promise>") {
+                let end_index = start_index + end_index_relative;
+                let value = executor_output[start_index..end_index].trim().to_string();
+                if Self::is_complete(&value) {
+                    return Some(value);
+                }
+                search_start = end_index + "</promise>".len();
+            } else {
+                break;
+            }
+        }
+        None
+    }
+
+    /// Persist the detected promise value to the configured promise file.
+    pub fn write_promise(promise_file: &Path, value: &str) -> Result<(), AppError> {
+        if let Some(parent) = promise_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(promise_file, value).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to write promise file {}: {}",
+                    promise_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+
+    /// Read the persisted promise entry from disk.
+    pub fn read_promise(promise_file: &Path) -> Result<String, AppError> {
+        if !promise_file.exists() {
+            return Ok(String::new());
+        }
+        fs::read_to_string(promise_file).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to read promise file {}: {}",
+                    promise_file.display(),
+                    e
+                ),
+            )
+        })
+    }
+
+    /// Determine whether the provided promise value signals completion.
+    pub fn is_complete(promise_value: &str) -> bool {
+        !promise_value.is_empty() && promise_value.to_lowercase().contains("complete")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_detect_promise_complete() {
+        let output = "Some log <promise>COMPLETE</promise> more";
+        assert_eq!(
+            PromiseDetector::detect_promise(output),
+            Some("COMPLETE".into())
+        );
+    }
+
+    #[test]
+    fn test_detect_promise_incomplete() {
+        let output = "<promise>working</promise>";
+        assert!(PromiseDetector::detect_promise(output).is_none());
+    }
+
+    #[test]
+    fn test_write_and_read_promise() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state/promise.txt");
+        PromiseDetector::write_promise(&path, "COMPLETE").unwrap();
+        let stored = PromiseDetector::read_promise(&path).unwrap();
+        assert_eq!(stored, "COMPLETE");
+    }
+
+    #[test]
+    fn test_is_complete_case_insensitive() {
+        assert!(PromiseDetector::is_complete("coMplEte"));
+    }
+}

--- a/src/core/prompt/mod.rs
+++ b/src/core/prompt/mod.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::result_large_err)]
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROMISE_INSTRUCTION: &str =
+    "---\n\nIMPORTANT: When the task is GENUINELY COMPLETE, output:\n<promise>COMPLETE</promise>\n";
+
+/// Constructs executor prompts from the goal, advisor notes, context, and
+/// completion instructions.
+pub struct PromptBuilder;
+
+impl PromptBuilder {
+    /// Build the executor prompt that joins the goal, advisor notes, context,
+    /// and completion reminder.
+    pub fn build_prompt(
+        workspace_path: &Path,
+        advisor_recommendations: Option<&str>,
+        context: Option<&str>,
+    ) -> Result<String, AppError> {
+        let goal = Self::read_goal(workspace_path)?;
+        let mut prompt = String::from("# Goal\n\n");
+        prompt.push_str(goal.trim());
+        prompt.push_str("\n\n");
+
+        if let Some(recommendations) = advisor_recommendations {
+            let trimmed = recommendations.trim();
+            if !trimmed.is_empty() {
+                prompt.push_str("## Advisor Recommendations\n\n");
+                prompt.push_str(trimmed);
+                prompt.push_str("\n\n");
+            }
+        }
+
+        if let Some(context_text) = context {
+            let trimmed = context_text.trim();
+            if !trimmed.is_empty() {
+                prompt.push_str("## Context\n\n");
+                prompt.push_str(trimmed);
+                prompt.push_str("\n\n");
+            }
+        }
+
+        prompt.push_str(PROMISE_INSTRUCTION);
+        Ok(prompt)
+    }
+
+    /// Read the goal description either from `NEWTON_GOAL_FILE` or the workspace.
+    pub fn read_goal(workspace_path: &Path) -> Result<String, AppError> {
+        let goal_path = env::var("NEWTON_GOAL_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| workspace_path.join("GOAL.md"));
+        if !goal_path.exists() {
+            return Err(AppError::new(
+                ErrorCategory::ValidationError,
+                format!("Goal file not found at {}", goal_path.display()),
+            ));
+        }
+        fs::read_to_string(goal_path).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!("Failed to read goal file: {}", e),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_build_prompt_includes_sections() {
+        std::env::remove_var("NEWTON_GOAL_FILE");
+        let tmp = TempDir::new().unwrap();
+        let goal_path = tmp.path().join("GOAL.md");
+        fs::write(&goal_path, "Reduce bugs\n").unwrap();
+
+        let prompt = PromptBuilder::build_prompt(
+            tmp.path(),
+            Some("- Keep tests green"),
+            Some("Context entry"),
+        )
+        .unwrap();
+
+        assert!(prompt.contains("# Goal"));
+        assert!(prompt.contains("Reduce bugs"));
+        assert!(prompt.contains("Advisor Recommendations"));
+        assert!(prompt.contains("Context entry"));
+        assert!(prompt.contains("<promise>COMPLETE</promise>"));
+    }
+
+    #[test]
+    fn test_read_goal_missing() {
+        std::env::remove_var("NEWTON_GOAL_FILE");
+        let tmp = TempDir::new().unwrap();
+        let err = PromptBuilder::read_goal(tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("Goal file not found"));
+    }
+}

--- a/src/core/template/mod.rs
+++ b/src/core/template/mod.rs
@@ -1,0 +1,321 @@
+#![allow(clippy::result_large_err)]
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Information about a discovered template under `.newton/templates/`.
+pub struct TemplateInfo {
+    /// Template name (directory name).
+    pub name: String,
+    /// Path to the template directory.
+    pub path: PathBuf,
+}
+
+/// Represents a template that can be rendered into a workspace.
+pub struct Template {
+    /// Template name.
+    pub name: String,
+    /// Directory that contains the template artifacts.
+    pub path: PathBuf,
+}
+
+/// Discovers templates that live inside `.newton/templates/` inside a workspace.
+pub struct TemplateManager;
+
+impl TemplateManager {
+    /// List the templates that are currently installed in the workspace.
+    pub fn list_templates(workspace_path: &Path) -> Result<Vec<TemplateInfo>, AppError> {
+        let templates_dir = workspace_path.join(".newton/templates");
+        if !templates_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut infos = Vec::new();
+        for entry in fs::read_dir(&templates_dir).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to scan templates directory {}: {}",
+                    templates_dir.display(),
+                    e
+                ),
+            )
+        })? {
+            let entry = entry.map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "Failed to inspect template entry in {}: {}",
+                        templates_dir.display(),
+                        e
+                    ),
+                )
+            })?;
+
+            if entry
+                .file_type()
+                .map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!(
+                            "Failed to read template entry metadata {}: {}",
+                            entry.path().display(),
+                            e
+                        ),
+                    )
+                })?
+                .is_dir()
+            {
+                let name = entry.file_name().to_string_lossy().to_string();
+                infos.push(TemplateInfo {
+                    name,
+                    path: entry.path(),
+                });
+            }
+        }
+
+        Ok(infos)
+    }
+
+    /// Get a specific template by name.
+    pub fn get_template(workspace_path: &Path, name: &str) -> Result<Template, AppError> {
+        let templates = Self::list_templates(workspace_path)?;
+        for info in templates {
+            if info.name == name {
+                return Ok(Template {
+                    name: info.name,
+                    path: info.path,
+                });
+            }
+        }
+        Err(AppError::new(
+            ErrorCategory::ValidationError,
+            format!(
+                "Template '{}' not found under {}/.newton/templates/",
+                name,
+                workspace_path.display()
+            ),
+        ))
+    }
+}
+
+/// Responsible for copying a template into the workspace and rendering variables.
+pub struct TemplateRenderer;
+
+impl TemplateRenderer {
+    /// Render the named template into the workspace, substituting template variables.
+    pub fn render_template(
+        workspace_path: &Path,
+        template_name: &str,
+        variables: HashMap<String, String>,
+    ) -> Result<(), AppError> {
+        let template = TemplateManager::get_template(workspace_path, template_name)?;
+
+        // Ensure the target `.newton` directory exists.
+        let target_root = workspace_path.join(".newton");
+        fs::create_dir_all(&target_root).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to create workspace .newton directory {}: {}",
+                    target_root.display(),
+                    e
+                ),
+            )
+        })?;
+
+        Self::render_directory(&template.path, &template.path, workspace_path, &variables)
+    }
+
+    fn render_directory(
+        template_root: &Path,
+        current: &Path,
+        workspace_path: &Path,
+        variables: &HashMap<String, String>,
+    ) -> Result<(), AppError> {
+        for entry in fs::read_dir(current).map_err(|e| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "Failed to read template directory {}: {}",
+                    current.display(),
+                    e
+                ),
+            )
+        })? {
+            let entry = entry.map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "Failed to evaluate template entry {}: {}",
+                        current.display(),
+                        e
+                    ),
+                )
+            })?;
+            let path = entry.path();
+            let rel_path = path
+                .strip_prefix(template_root)
+                .map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!(
+                            "Failed to compute relative template path {}: {}",
+                            path.display(),
+                            e
+                        ),
+                    )
+                })?
+                .to_path_buf();
+
+            if path.is_dir() {
+                let dir_target = workspace_path.join(".newton").join(&rel_path);
+                fs::create_dir_all(&dir_target).map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!(
+                            "Failed to create target directory {}: {}",
+                            dir_target.display(),
+                            e
+                        ),
+                    )
+                })?;
+                Self::render_directory(template_root, &path, workspace_path, variables)?;
+                continue;
+            }
+
+            let target_path = if rel_path == Path::new("newton.toml") {
+                workspace_path.join("newton.toml")
+            } else {
+                workspace_path.join(".newton").join(&rel_path)
+            };
+
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!("Failed to create target parent {}: {}", parent.display(), e),
+                    )
+                })?;
+            }
+
+            let mut contents = fs::read_to_string(&path).map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!("Failed to read template file {}: {}", path.display(), e),
+                )
+            })?;
+
+            for (key, value) in variables {
+                contents = contents.replace(&format!("{{{{{}}}}}", key), value);
+            }
+
+            fs::write(&target_path, contents).map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "Failed to write rendered file {}: {}",
+                        target_path.display(),
+                        e
+                    ),
+                )
+            })?;
+
+            if target_path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("sh"))
+                .unwrap_or(false)
+            {
+                Self::make_executable(&target_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(unused_variables)]
+    fn make_executable(target_path: &Path) -> Result<(), AppError> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(target_path)
+                .map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!(
+                            "Failed to read permissions for {}: {}",
+                            target_path.display(),
+                            e
+                        ),
+                    )
+                })?
+                .permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(target_path, perms).map_err(|e| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "Failed to set executable bit on {}: {}",
+                        target_path.display(),
+                        e
+                    ),
+                )
+            })?;
+        }
+        #[cfg(windows)]
+        {
+            // Windows uses file extensions to determine executability.
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn list_templates_returns_empty_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let templates = TemplateManager::list_templates(tmp.path()).unwrap();
+        assert!(templates.is_empty());
+    }
+
+    #[test]
+    fn render_template_replaces_values_and_copies_files() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let template_dir = workspace.join(".newton/templates/basic");
+        fs::create_dir_all(&template_dir).unwrap();
+        fs::write(
+            template_dir.join("executor.sh"),
+            "#!/bin/bash\necho {{project_name}}\n",
+        )
+        .unwrap();
+        fs::write(
+            template_dir.join("newton.toml"),
+            "[project]\nname = \"{{project_name}}\"\n",
+        )
+        .unwrap();
+
+        let mut vars = HashMap::new();
+        vars.insert("project_name".to_string(), "TestProj".to_string());
+
+        TemplateRenderer::render_template(workspace, "basic", vars).unwrap();
+
+        let executor = workspace.join(".newton/executor.sh");
+        assert!(executor.exists());
+        let contents = fs::read_to_string(&executor).unwrap();
+        assert!(contents.contains("TestProj"));
+
+        let toml = workspace.join("newton.toml");
+        assert!(toml.exists());
+        let toml_contents = fs::read_to_string(&toml).unwrap();
+        assert!(toml_contents.contains("TestProj"));
+    }
+}

--- a/tests/bin/aikit
+++ b/tests/bin/aikit
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "aikit 1.0\n"

--- a/tests/snapshots/snapshots/test_cli_commands_snapshots__help_output.snap
+++ b/tests/snapshots/snapshots/test_cli_commands_snapshots__help_output.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/snapshots/test_cli_commands_snapshots.rs
-expression: stdout
+assertion_line: 35
+expression: normalized
 ---
 newton [VERSION]
 Newton Loop optimization framework in Rust
@@ -15,9 +16,11 @@ OPTIONS:
   -V, --version
           Print version
 WORKFLOW COMMANDS:
-  run     Execute a full optimization loop
-  step    Advance loop by one cycle
-  status  Inspect progress of an execution
-  report  Summarize learnings from an execution
-  error   Diagnose failures during optimization
-  help    Print this message or the help of the given subcommand(s)
+  run      Execute a full optimization loop
+  step     Advance loop by one cycle
+  status   Inspect progress of an execution
+  report   Summarize learnings from an execution
+  error    Diagnose failures during optimization
+  context  Add, view, or clear stored context entries
+  init     Install template scaffolding for a workspace
+  help     Print this message or the help of the given subcommand(s)

--- a/tests/unit/test_cli_context.rs
+++ b/tests/unit/test_cli_context.rs
@@ -1,0 +1,37 @@
+use newton::cli::{args::{ContextArgs, ContextCommand}, commands};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn context_add_show_clear_cycle() {
+    let temp_dir = TempDir::new().unwrap();
+    let workspace = temp_dir.path().to_path_buf();
+
+    let add_args = ContextArgs {
+        workspace_path: workspace.clone(),
+        command: ContextCommand::Add {
+            message: "First entry".to_string(),
+            title: Some("Testing".to_string()),
+        },
+    };
+
+    commands::context(add_args).await.unwrap();
+
+    let context_file = workspace.join(".newton/state/context.md");
+    let contents = std::fs::read_to_string(&context_file).unwrap();
+    assert!(contents.contains("First entry"));
+
+    let show_args = ContextArgs {
+        workspace_path: workspace.clone(),
+        command: ContextCommand::Show,
+    };
+    commands::context(show_args).await.unwrap();
+
+    let clear_args = ContextArgs {
+        workspace_path: workspace.clone(),
+        command: ContextCommand::Clear,
+    };
+    commands::context(clear_args).await.unwrap();
+
+    let cleared = std::fs::read_to_string(&context_file).unwrap();
+    assert!(cleared.contains("# Newton Loop Context"));
+}

--- a/tests/unit/test_cli_init.rs
+++ b/tests/unit/test_cli_init.rs
@@ -1,0 +1,51 @@
+use newton::cli::{args::InitArgs, commands};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+struct PathGuard {
+    original: String,
+}
+
+impl PathGuard {
+    fn new(original: String) -> Self {
+        PathGuard { original }
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        env::set_var("PATH", &self.original);
+    }
+}
+
+#[tokio::test]
+async fn init_command_renders_template_assets() {
+    let temp_dir = TempDir::new().unwrap();
+    let workspace = temp_dir.path().to_path_buf();
+    let template_dir = workspace.join(".newton/templates/basic");
+    fs::create_dir_all(&template_dir).unwrap();
+    fs::write(template_dir.join("executor.sh"), "#!/bin/bash\necho hi\n").unwrap();
+    fs::write(template_dir.join("newton.toml"), "[project]\nname = \"{{project_name}}\"\n").unwrap();
+
+    let current_path = env::var("PATH").unwrap_or_default();
+    let bin_path = env::current_dir().unwrap().join("tests/bin");
+    env::set_var("PATH", format!("{}:{}", bin_path.display(), current_path));
+    let _guard = PathGuard::new(current_path);
+
+    let args = InitArgs {
+        workspace_path: workspace.clone(),
+        template: Some("basic".to_string()),
+        name: Some("DemoProject".to_string()),
+        coding_agent: Some("opencode".to_string()),
+        model: Some("glm".to_string()),
+        interactive: false,
+    };
+
+    commands::init(args).await.unwrap();
+
+    assert!(workspace.join(".newton/executor.sh").exists());
+    assert!(workspace.join("newton.toml").exists());
+    assert!(workspace.join("GOAL.md").exists());
+}


### PR DESCRIPTION
## Summary
- add context/prompt/promise helpers and integrate them into the orchestrator so executor prompts are built from GOAL/advisor/context, context can be cleared, and promises drive loop termination
- expose  and  commands plus a template manager that renders tailored scripts and configs, and add CLI tests and helper scripts for the new workflows
- update docs/snapshots to advertise the new commands and ensure the CLI help reflects the new surface

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test