### PR TITLE
Add monitor TUI monitor command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,10 +98,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -121,10 +142,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
@@ -184,7 +217,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -215,10 +248,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "difflib"
@@ -227,10 +336,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -270,6 +415,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +487,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,11 +521,26 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -329,6 +567,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,9 +593,100 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -365,6 +713,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +822,15 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -387,10 +846,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -422,9 +896,21 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -457,28 +943,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "newton"
-version = "0.5.10"
+version = "0.5.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "chrono",
  "clap",
+ "crossterm 0.28.1",
+ "futures",
  "insta",
+ "percent-encoding",
  "predicates",
  "rand",
+ "ratatui",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -486,9 +1013,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tungstenite",
+ "url",
  "uuid",
 ]
 
@@ -529,6 +1059,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +1126,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +1148,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -657,12 +1258,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "crossterm 0.27.0",
+ "indoc",
+ "itertools",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -695,16 +1313,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -712,6 +1432,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scc"
@@ -723,16 +1449,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -787,6 +1555,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +1593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1617,28 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "mio 1.1.1",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -857,6 +1670,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -866,10 +1689,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -883,6 +1734,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,7 +1780,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -931,6 +1820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,11 +1837,11 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -956,6 +1855,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -978,6 +1897,33 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1020,6 +1966,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1096,10 +2048,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1126,12 +2152,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1160,6 +2207,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1193,6 +2254,44 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1255,6 +2354,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1278,6 +2395,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1315,6 +2447,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1327,6 +2465,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1336,6 +2480,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1363,6 +2513,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1372,6 +2528,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1387,6 +2549,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1396,6 +2564,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1419,10 +2593,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1438,6 +2651,60 @@ name = "zerocopy-derive"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ uuid = { version = "1.6", features = ["v4", "serde"] }
 toml = "0.8"
 tempfile = "3.10"
 rand = "0.8"
+percent-encoding = "2.1"
+ratatui = { version = "0.23" }
+crossterm = "0.28"
+tokio-tungstenite = { version = "0.20", features = ["__rustls-tls"] }
+tungstenite = { version = "0.20", features = ["__rustls-tls"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+url = "2"
+futures = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -250,6 +250,22 @@ newton error abc-123 --verbose
 - Execution logs
 - Recovery recommendations
 
+### `monitor`
+
+Stream live ailoop channels for every project/branch in the workspace via a terminal UI that highlights blocking questions and authorizations, keeps a queue of pending prompts, lets you answer/approve/deny directly in the terminal, and provides filtering (`/`), layout toggle (`V`), queue tab (`Q`), and help (`?`).
+
+**Behavior:**
+`newton monitor` walks up from the current directory to find the workspace root containing `.newton`, then reads `ailoop_server_http_url` and `ailoop_server_ws_url` from the first `.newton/configs/*.conf` file that exposes both keys (alphabetically) or from `.newton/configs/monitor.conf` when present. It connects to the configured HTTP and WebSocket endpoints, backfills up to 50 messages per channel, subscribes to channels, and renders a ratatui interface with tiles/list stream views, a 30% queue panel, a filter status line, and optional queue-only mode.
+
+**Options:**
+- `--http-url <URL>`: Override the HTTP base URL for this session.
+- `--ws-url <URL>`: Override the WebSocket URL for this session.
+
+**Example:**
+```bash
+newton monitor
+```
+
 ## Advanced Usage
 
 ### Custom Tool Configuration

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -190,6 +190,17 @@ pub enum ReportFormat {
     Json,
 }
 
+#[derive(Args, Clone, Debug)]
+pub struct MonitorArgs {
+    /// Explicit HTTP URL for the ailoop server (default from .newton/configs/)
+    #[arg(long, value_name = "URL")]
+    pub http_url: Option<String>,
+
+    /// Explicit WebSocket URL for the ailoop server (default from .newton/configs/)
+    #[arg(long, value_name = "URL")]
+    pub ws_url: Option<String>,
+}
+
 #[derive(Args)]
 pub struct ErrorArgs {
     /// Execution ID whose failures should be analyzed

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,10 +1,11 @@
 use crate::{
-    cli::args::{BatchArgs, ErrorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs},
+    cli::args::{BatchArgs, ErrorArgs, MonitorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs},
     core::{
         batch_config::{find_workspace_root, BatchProjectConfig},
         ConfigLoader, ConfigValidator, DefaultErrorReporter, OptimizationOrchestrator,
         SuccessPolicy,
     },
+    monitor,
     utils::serialization::{FileUtils, JsonSerializer},
     Result,
 };
@@ -99,6 +100,12 @@ pub async fn run(args: RunArgs) -> Result<()> {
 
     result?;
     Ok(())
+}
+
+/// Launch the interactive Newton monitor TUI that watches ailoop channels.
+pub async fn monitor(args: MonitorArgs) -> Result<()> {
+    tracing::info!("Starting Newton monitor TUI");
+    monitor::run(args).await
 }
 
 async fn sleep_if_needed(duration_secs: u64) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,7 @@
 pub mod args;
 pub mod commands;
 
-pub use args::{BatchArgs, ErrorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs};
+pub use args::{BatchArgs, ErrorArgs, MonitorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs};
 use clap::{Parser, Subcommand};
 
 const HELP_TEMPLATE: &str = "\
@@ -63,6 +63,12 @@ pub enum Command {
         after_help = "Example:\n    newton error exec_123 --verbose"
     )]
     Error(ErrorArgs),
+    #[command(
+        about = "Monitor live ailoop channels via a terminal UI",
+        long_about = "Monitor listens to every project/branch channel from the workspace using a WebSocket/HTTP mix and lets you answer questions or approve authorizations in a queue.",
+        after_help = "Example:\n    newton monitor"
+    )]
+    Monitor(MonitorArgs),
 }
 
 pub async fn run(args: Args) -> crate::Result<()> {
@@ -73,5 +79,6 @@ pub async fn run(args: Args) -> crate::Result<()> {
         Command::Status(status_args) => commands::status(status_args).await,
         Command::Report(report_args) => commands::report(report_args).await,
         Command::Error(error_args) => commands::error(error_args).await,
+        Command::Monitor(monitor_args) => commands::monitor(monitor_args).await,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod core;
+pub mod monitor;
 pub mod tools;
 pub mod utils;
 

--- a/src/monitor/client.rs
+++ b/src/monitor/client.rs
@@ -1,0 +1,263 @@
+use crate::monitor::config::MonitorEndpoints;
+use crate::monitor::event::{
+    ConnectionState, ConnectionStatus, MonitorCommand, MonitorEvent, ResponseType,
+};
+use crate::monitor::message::MonitorMessage;
+use futures::{SinkExt, StreamExt};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::time::Duration as StdDuration;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::error;
+use uuid::Uuid;
+
+/// ASCII set for encoding path segments (slashes included).
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS.add(b' ').add(b'/').add(b'?').add(b'#');
+
+/// HTTP + WebSocket client targeting the configured ailoop instance.
+#[derive(Clone)]
+pub struct AiloopClient {
+    http: reqwest::Client,
+    endpoints: MonitorEndpoints,
+}
+
+impl AiloopClient {
+    /// Build a new client using the resolved endpoints.
+    pub fn new(endpoints: MonitorEndpoints) -> Self {
+        AiloopClient {
+            http: reqwest::Client::new(),
+            endpoints,
+        }
+    }
+
+    /// Return the configured WebSocket URL.
+    pub fn ws_url(&self) -> &reqwest::Url {
+        &self.endpoints.ws_url
+    }
+
+    /// Fetch all known channels from the server.
+    pub async fn fetch_channels(&self) -> crate::Result<Vec<String>> {
+        let url = join_path(&self.endpoints.http_url, &["api", "channels"])?;
+        let resp = self.http.get(url).send().await?;
+        let value: Value = resp.json().await?;
+        if let Some(arr) = value.as_array() {
+            return Ok(arr
+                .iter()
+                .filter_map(|entry| entry.as_str().map(|s| s.to_string()))
+                .collect());
+        }
+        if let Some(entries) = value.get("channels").and_then(|section| section.as_array()) {
+            return Ok(entries
+                .iter()
+                .filter_map(|entry| entry.as_str().map(|s| s.to_string()))
+                .collect());
+        }
+        Ok(Vec::new())
+    }
+
+    /// Fetch the most recent messages for a channel (used for backfill/polling).
+    pub async fn fetch_channel_messages(
+        &self,
+        channel: &str,
+        limit: usize,
+    ) -> crate::Result<Vec<MonitorMessage>> {
+        let encoded = encode_segment(channel);
+        let mut url = join_path(
+            &self.endpoints.http_url,
+            &["api", "channels", &encoded, "messages"],
+        )?;
+        let limit = limit.min(200);
+        url.push_str(&format!("?limit={limit}"));
+        let resp = self.http.get(url).send().await?;
+        let messages = resp.json::<Vec<MonitorMessage>>().await?;
+        Ok(messages)
+    }
+
+    /// Post an answer/approval to a queued message.
+    pub async fn post_response(
+        &self,
+        message_id: Uuid,
+        answer: Option<String>,
+        response_type: ResponseType,
+    ) -> crate::Result<()> {
+        let url = format!(
+            "{}/api/v1/messages/{}/response",
+            self.endpoints.http_url.as_str().trim_end_matches('/'),
+            message_id
+        );
+        let payload = ResponsePayload {
+            answer,
+            response_type: response_type.as_str(),
+        };
+        let resp = self.http.post(&url).json(&payload).send().await?;
+        let status = resp.status();
+        if status != StatusCode::OK {
+            let text = resp.text().await.unwrap_or_else(|_| "".to_string());
+            return Err(anyhow::anyhow!(
+                "ailoop response POST failed: {} {}",
+                status,
+                text
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct ResponsePayload<'a> {
+    answer: Option<String>,
+    response_type: &'a str,
+}
+
+fn encode_segment(segment: &str) -> String {
+    utf8_percent_encode(segment, PATH_SEGMENT_ENCODE_SET).to_string()
+}
+
+fn join_path(base: &reqwest::Url, segments: &[&str]) -> crate::Result<String> {
+    let mut url = base.as_str().trim_end_matches('/').to_string();
+    for segment in segments {
+        if !segment.is_empty() {
+            url.push('/');
+            url.push_str(segment);
+        }
+    }
+    Ok(url)
+}
+
+/// Run a synchronous backfill that harvests existing messages before the UI starts.
+pub async fn initial_backfill(
+    client: &AiloopClient,
+    event_tx: &UnboundedSender<MonitorEvent>,
+) -> crate::Result<()> {
+    let channels = client.fetch_channels().await?;
+    for channel in channels {
+        if let Ok(messages) = client.fetch_channel_messages(&channel, 50).await {
+            for message in messages {
+                let _ = event_tx.send(MonitorEvent::Message(message));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Spawn a WebSocket loop that reconnects with exponential backoff.
+pub async fn websocket_loop(client: AiloopClient, event_tx: UnboundedSender<MonitorEvent>) {
+    let mut backoff = StdDuration::from_secs(1);
+    loop {
+        let _ = event_tx.send(MonitorEvent::ConnectionStatus(ConnectionStatus {
+            state: ConnectionState::Connecting,
+            detail: Some("connecting".to_string()),
+        }));
+        match connect_async(client.ws_url()).await {
+            Ok((stream, _)) => {
+                let _ = event_tx.send(MonitorEvent::ConnectionStatus(ConnectionStatus {
+                    state: ConnectionState::Connected,
+                    detail: Some("connected".to_string()),
+                }));
+                backoff = StdDuration::from_secs(1);
+                let (mut writer, mut reader) = stream.split();
+                while let Some(message) = reader.next().await {
+                    match message {
+                        Ok(Message::Text(txt)) => {
+                            if let Ok(parsed) = serde_json::from_str::<MonitorMessage>(&txt) {
+                                let _ = event_tx.send(MonitorEvent::Message(parsed));
+                            }
+                        }
+                        Ok(Message::Binary(bytes)) => {
+                            if let Ok(txt) = String::from_utf8(bytes) {
+                                if let Ok(parsed) = serde_json::from_str::<MonitorMessage>(&txt) {
+                                    let _ = event_tx.send(MonitorEvent::Message(parsed));
+                                }
+                            }
+                        }
+                        Ok(Message::Ping(payload)) => {
+                            let _ = writer.send(Message::Pong(payload)).await;
+                        }
+                        Ok(Message::Close(_)) => break,
+                        Err(err) => {
+                            error!("WebSocket error: {}", err);
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Err(err) => {
+                let _ = event_tx.send(MonitorEvent::ConnectionStatus(ConnectionStatus {
+                    state: ConnectionState::Disconnected,
+                    detail: Some(format!("ws connect failed: {}", err)),
+                }));
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = std::cmp::min(backoff * 2, StdDuration::from_secs(60));
+    }
+}
+
+/// Fallback polling loop that keeps message buffers fresh in case viewer subscribe is ignored.
+pub async fn polling_loop(client: AiloopClient, event_tx: UnboundedSender<MonitorEvent>) {
+    let mut interval = tokio::time::interval(StdDuration::from_secs(5));
+    let mut seen = HashSet::new();
+    loop {
+        interval.tick().await;
+        match client.fetch_channels().await {
+            Ok(channels) => {
+                for channel in channels {
+                    match client.fetch_channel_messages(&channel, 20).await {
+                        Ok(messages) => {
+                            for message in messages {
+                                if seen.insert(message.id) {
+                                    let _ = event_tx.send(MonitorEvent::Message(message));
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            error!("polling messages failed for {}: {}", channel, err);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                error!("polling channels failed: {}", err);
+            }
+        }
+    }
+}
+
+/// Handle commands issued by the UI (answer/approve/deny).
+pub async fn command_loop(
+    client: AiloopClient,
+    mut command_rx: UnboundedReceiver<MonitorCommand>,
+    event_tx: UnboundedSender<MonitorEvent>,
+) {
+    while let Some(command) = command_rx.recv().await {
+        match command {
+            MonitorCommand::Respond {
+                message_id,
+                answer,
+                response_type,
+            } => {
+                if let Err(err) = client
+                    .post_response(message_id, answer, response_type)
+                    .await
+                {
+                    error!("failed to post response: {}", err);
+                    let _ = event_tx.send(MonitorEvent::ConnectionStatus(ConnectionStatus {
+                        state: ConnectionState::Disconnected,
+                        detail: Some(format!("response failed: {}", err)),
+                    }));
+                } else {
+                    let _ = event_tx.send(MonitorEvent::ConnectionStatus(ConnectionStatus {
+                        state: ConnectionState::Connected,
+                        detail: Some("response posted".to_string()),
+                    }));
+                }
+            }
+        }
+    }
+}

--- a/src/monitor/config.rs
+++ b/src/monitor/config.rs
@@ -1,0 +1,144 @@
+use crate::core::batch_config::parse_conf;
+use crate::Result;
+use anyhow::anyhow;
+use std::fs;
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// Resolved ailoop endpoints that the monitor will connect to.
+#[derive(Debug, Clone)]
+pub struct MonitorEndpoints {
+    /// HTTP base URL for the ailoop server.
+    pub http_url: Url,
+    /// WebSocket URL for the ailoop server.
+    pub ws_url: Url,
+    /// Underlying workspace root that provided the configuration.
+    pub workspace_root: PathBuf,
+}
+
+/// Optional overrides passed through `newton monitor`.
+#[derive(Debug, Clone, Default)]
+pub struct MonitorOverrides {
+    /// Explicit HTTP URL to use instead of the config file.
+    pub http_url: Option<String>,
+    /// Explicit WebSocket URL to use instead of the config file.
+    pub ws_url: Option<String>,
+}
+
+/// Load the HTTP/WS URLs using the workspace `.newton/configs/` layout.
+pub fn load_monitor_endpoints(
+    workspace_root: &Path,
+    overrides: MonitorOverrides,
+) -> Result<MonitorEndpoints> {
+    let configs_dir = workspace_root.join(".newton").join("configs");
+    if !configs_dir.is_dir() {
+        return Err(anyhow!(
+            "Workspace {} must contain .newton/configs",
+            workspace_root.display()
+        ));
+    }
+
+    let mut accumulator = ConfigPair::from_overrides(overrides);
+
+    let monitor_conf = configs_dir.join("monitor.conf");
+    if monitor_conf.is_file() {
+        if let Some(overridden) = parse_config_entry(&monitor_conf)? {
+            accumulator.merge(overridden);
+        }
+    }
+
+    if !accumulator.ready() {
+        let mut entries: Vec<_> = fs::read_dir(&configs_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|entry| entry.path().is_file())
+            .collect();
+        entries.sort_by_key(|entry| entry.file_name());
+
+        for entry in entries {
+            if entry.path() == monitor_conf {
+                continue;
+            }
+            if let Some(pair) = parse_config_entry(&entry.path())? {
+                accumulator.merge(pair);
+                if accumulator.ready() {
+                    break;
+                }
+            }
+        }
+    }
+
+    if accumulator.ready() {
+        accumulator
+            .into_endpoints(workspace_root.to_path_buf())
+            .map_err(|e| anyhow!("parsing monitor endpoints: {}", e))
+    } else {
+        Err(anyhow!(
+            "Could not find a config under {} that defines both ailoop_server_http_url and ailoop_server_ws_url",
+            configs_dir.display()
+        ))
+    }
+}
+
+struct ConfigPair {
+    http_url: Option<String>,
+    ws_url: Option<String>,
+}
+
+impl ConfigPair {
+    fn from_overrides(overrides: MonitorOverrides) -> Self {
+        ConfigPair {
+            http_url: overrides.http_url,
+            ws_url: overrides.ws_url,
+        }
+    }
+
+    fn merge(&mut self, other: ConfigPair) {
+        if self.http_url.is_none() {
+            self.http_url = other.http_url;
+        }
+        if self.ws_url.is_none() {
+            self.ws_url = other.ws_url;
+        }
+    }
+
+    fn ready(&self) -> bool {
+        self.http_url.is_some() && self.ws_url.is_some()
+    }
+
+    fn into_endpoints(self, workspace_root: PathBuf) -> Result<MonitorEndpoints> {
+        let http_url = Url::parse(
+            self.http_url
+                .as_ref()
+                .ok_or_else(|| anyhow!("missing HTTP URL"))?,
+        )?;
+        let ws_url = Url::parse(
+            self.ws_url
+                .as_ref()
+                .ok_or_else(|| anyhow!("missing WebSocket URL"))?,
+        )?;
+        Ok(MonitorEndpoints {
+            http_url,
+            ws_url,
+            workspace_root,
+        })
+    }
+}
+
+fn parse_config_entry(path: &Path) -> Result<Option<ConfigPair>> {
+    let settings = parse_conf(path)?;
+
+    let http_url = settings
+        .get("ailoop_server_http_url")
+        .map(|v| v.trim().to_string());
+    let ws_url = settings
+        .get("ailoop_server_ws_url")
+        .map(|v| v.trim().to_string());
+
+    if http_url.as_ref().map(|s| s.is_empty()).unwrap_or(true)
+        || ws_url.as_ref().map(|s| s.is_empty()).unwrap_or(true)
+    {
+        return Ok(None);
+    }
+
+    Ok(Some(ConfigPair { http_url, ws_url }))
+}

--- a/src/monitor/event.rs
+++ b/src/monitor/event.rs
@@ -1,0 +1,65 @@
+use crate::monitor::message::MonitorMessage;
+use uuid::Uuid;
+
+/// Commands emitted by the UI that require HTTP requests.
+#[derive(Debug)]
+pub enum MonitorCommand {
+    /// Respond to a question or authorization via POST /api/v1/messages/:id/response.
+    Respond {
+        /// Original message being answered/approved.
+        message_id: Uuid,
+        /// Optional textual answer (used for `text` responses).
+        answer: Option<String>,
+        /// How the response should be treated by ailoop.
+        response_type: ResponseType,
+    },
+}
+
+/// Response types recognized by the ailoop POST API.
+#[derive(Debug, Copy, Clone)]
+pub enum ResponseType {
+    Text,
+    AuthorizationApproved,
+    AuthorizationDenied,
+    Timeout,
+    Cancelled,
+}
+
+impl ResponseType {
+    /// Convert to the canonical string used by the API.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ResponseType::Text => "text",
+            ResponseType::AuthorizationApproved => "authorization_approved",
+            ResponseType::AuthorizationDenied => "authorization_denied",
+            ResponseType::Timeout => "timeout",
+            ResponseType::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Events flowing from the networking layer into the UI.
+#[derive(Debug)]
+pub enum MonitorEvent {
+    /// WebSocket/HTTP connection status change.
+    ConnectionStatus(ConnectionStatus),
+    /// Message received from a channel or from backfill/polling.
+    Message(MonitorMessage),
+}
+
+/// Current connection health for display in the UI.
+#[derive(Debug, Clone)]
+pub struct ConnectionStatus {
+    /// Enumerated state of the WebSocket.
+    pub state: ConnectionState,
+    /// Descriptive detail (error message, health check result, etc.).
+    pub detail: Option<String>,
+}
+
+/// Low-level state for the WebSocket connection.
+#[derive(Debug, Clone, Copy)]
+pub enum ConnectionState {
+    Connecting,
+    Connected,
+    Disconnected,
+}

--- a/src/monitor/message.rs
+++ b/src/monitor/message.rs
@@ -1,0 +1,260 @@
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+/// Structured representation of messages coming from ailoop.
+#[derive(Debug, Clone)]
+pub struct MonitorMessage {
+    /// Unique identifier of the message.
+    pub id: Uuid,
+    /// Full channel name (project/branch).
+    pub channel: String,
+    /// Parsed kind of message content.
+    pub kind: MessageKind,
+    /// Primary text displayed in stream tiles/lists.
+    pub summary: String,
+    /// Optional longer text (e.g. question text).
+    pub text: Option<String>,
+    /// Optional contextual details (e.g. authorization context or response).
+    pub detail: Option<String>,
+    /// Timestamp indicating when the message was emitted.
+    pub timestamp: DateTime<Utc>,
+    /// References another message when this is a response.
+    pub correlation_id: Option<Uuid>,
+    /// Timeout in seconds for blocking content (question/authorization).
+    pub timeout_seconds: Option<u64>,
+    /// Choices attached to a question.
+    pub choices: Vec<String>,
+    /// Response metadata for response messages.
+    pub response_type: Option<String>,
+}
+
+impl MonitorMessage {
+    /// Whether this message should appear in the queue (blocking).
+    pub fn is_blocking(&self) -> bool {
+        matches!(
+            self.kind,
+            MessageKind::Question | MessageKind::Authorization
+        )
+    }
+
+    /// Pretty string describing the timeout threshold (if any).
+    pub fn timeout_description(&self) -> Option<String> {
+        self.timeout_seconds.map(|seconds| format!("{}s", seconds))
+    }
+}
+
+impl<'de> Deserialize<'de> for MonitorMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        parse_message(value).map_err(serde::de::Error::custom)
+    }
+}
+
+fn parse_message(value: Value) -> Result<MonitorMessage, anyhow::Error> {
+    use anyhow::Context;
+
+    let id =
+        string_field(&value, &["id", "message_id"]).ok_or_else(|| anyhow::anyhow!("missing id"))?;
+    let id = Uuid::parse_str(&id).context("invalid message id")?;
+
+    let channel = string_field(&value, &["channel", "channel_id"])
+        .ok_or_else(|| anyhow::anyhow!("missing channel"))?;
+
+    let correlation_id = string_field(&value, &["correlation_id", "correlationId"])
+        .and_then(|val| Uuid::parse_str(&val).ok());
+
+    let timestamp = timestamp_field(&value).unwrap_or_else(Utc::now);
+
+    let content = value
+        .get("content")
+        .cloned()
+        .unwrap_or_else(|| value.clone());
+
+    let type_hint = string_field(&content, &["type"])
+        .or_else(|| string_field(&value, &["type"]))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let kind = MessageKind::from_type(&type_hint);
+    let text = string_field(&content, &["text", "message", "body"]);
+    let detail = string_field(&content, &["context", "action", "status"]);
+    let timeout_seconds = numeric_field(&content, &["timeout_seconds", "timeoutSeconds"]);
+    let choices = array_field_strings(&content, &["choices"]);
+    let response_type = string_field(&content, &["response_type", "responseType"]);
+
+    let summary = build_summary(
+        &kind,
+        text.as_deref(),
+        detail.as_deref(),
+        &choices,
+        response_type.as_deref(),
+    );
+
+    Ok(MonitorMessage {
+        id,
+        channel,
+        kind,
+        summary,
+        text,
+        detail,
+        timestamp,
+        correlation_id,
+        timeout_seconds,
+        choices,
+        response_type,
+    })
+}
+
+fn build_summary(
+    kind: &MessageKind,
+    text: Option<&str>,
+    detail: Option<&str>,
+    choices: &[String],
+    response_type: Option<&str>,
+) -> String {
+    match kind {
+        MessageKind::Question => {
+            let question = text.unwrap_or("Question");
+            if choices.is_empty() {
+                format!("Question: {}", question)
+            } else {
+                let choice_list = choices.join(", ");
+                format!("Question: {} [{}]", question, choice_list)
+            }
+        }
+        MessageKind::Authorization => {
+            let action = detail.unwrap_or("Authorization required");
+            format!("Authorization: {}", action)
+        }
+        MessageKind::Notification => {
+            format!("Notification: {}", text.unwrap_or("Notification"))
+        }
+        MessageKind::Response => {
+            let target = response_type.unwrap_or("response");
+            format!("Response: {}", target)
+        }
+        MessageKind::Navigate => {
+            format!("Navigate: {}", text.unwrap_or("Navigate"))
+        }
+        MessageKind::WorkflowProgress => {
+            format!("Workflow progress: {}", text.unwrap_or("In-flight"))
+        }
+        MessageKind::WorkflowCompleted => {
+            format!("Workflow completed: {}", text.unwrap_or("Done"))
+        }
+        MessageKind::Stdout => {
+            format!("stdout: {}", text.unwrap_or(""))
+        }
+        MessageKind::Stderr => {
+            format!("stderr: {}", text.unwrap_or(""))
+        }
+        MessageKind::TaskCreate => {
+            format!("Task created: {}", text.unwrap_or("Task"))
+        }
+        MessageKind::TaskUpdate => {
+            format!("Task update: {}", text.unwrap_or("Task updated"))
+        }
+        MessageKind::TaskDependencyAdd => {
+            format!("Dependency added: {}", text.unwrap_or("Dependency change"))
+        }
+        MessageKind::TaskDependencyRemove => {
+            format!(
+                "Dependency removed: {}",
+                text.unwrap_or("Dependency change")
+            )
+        }
+        MessageKind::Unknown(label) => label.clone(),
+    }
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(|v| v.as_str().map(|s| s.trim().to_string()))
+}
+
+fn timestamp_field(value: &Value) -> Option<DateTime<Utc>> {
+    if let Some(ts) = value.get("timestamp").and_then(|v| v.as_str()) {
+        if let Ok(dt) = DateTime::parse_from_rfc3339(ts) {
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+    if let Some(ts_num) = value.get("timestamp").and_then(|v| v.as_i64()) {
+        if let Some(dt) = Utc.timestamp_opt(ts_num, 0).single() {
+            return Some(dt);
+        }
+    }
+    None
+}
+
+fn numeric_field(value: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(|v| v.as_u64())
+}
+
+fn array_field_strings(value: &Value, keys: &[&str]) -> Vec<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(|item| match item {
+            Value::Array(arr) => Some(
+                arr.iter()
+                    .filter_map(|entry| {
+                        entry.as_str().map(|s| s.trim().to_string()).or_else(|| {
+                            entry
+                                .get("text")
+                                .and_then(|x| x.as_str())
+                                .map(|s| s.trim().to_string())
+                        })
+                    })
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Enumeration of message content variants emitted by the ailoop server.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageKind {
+    Question,
+    Authorization,
+    Notification,
+    Response,
+    Navigate,
+    WorkflowProgress,
+    WorkflowCompleted,
+    Stdout,
+    Stderr,
+    TaskCreate,
+    TaskUpdate,
+    TaskDependencyAdd,
+    TaskDependencyRemove,
+    Unknown(String),
+}
+
+impl MessageKind {
+    fn from_type(type_name: &str) -> Self {
+        match type_name {
+            "question" => MessageKind::Question,
+            "authorization" => MessageKind::Authorization,
+            "notification" => MessageKind::Notification,
+            "response" => MessageKind::Response,
+            "navigate" => MessageKind::Navigate,
+            "workflow_progress" | "workflow_progress_update" => MessageKind::WorkflowProgress,
+            "workflow_completed" => MessageKind::WorkflowCompleted,
+            "stdout" => MessageKind::Stdout,
+            "stderr" => MessageKind::Stderr,
+            "task_create" => MessageKind::TaskCreate,
+            "task_update" => MessageKind::TaskUpdate,
+            "task_dependency_add" => MessageKind::TaskDependencyAdd,
+            "task_dependency_remove" => MessageKind::TaskDependencyRemove,
+            other => MessageKind::Unknown(other.to_string()),
+        }
+    }
+}

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -1,0 +1,52 @@
+pub mod client;
+pub mod config;
+pub mod event;
+pub mod message;
+pub mod state;
+pub mod ui;
+
+use crate::cli::args::MonitorArgs;
+use crate::core::batch_config::find_workspace_root;
+use crate::monitor::client::{
+    command_loop, initial_backfill, polling_loop, websocket_loop, AiloopClient,
+};
+use crate::monitor::config::{load_monitor_endpoints, MonitorOverrides};
+use crate::Result;
+use std::env;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// Run the monitor command, wiring up the network layer and TUI.
+pub async fn run(args: MonitorArgs) -> Result<()> {
+    let current_dir = env::current_dir()?;
+    let workspace_root = find_workspace_root(&current_dir)?;
+
+    let overrides = MonitorOverrides {
+        http_url: args.http_url,
+        ws_url: args.ws_url,
+    };
+
+    let endpoints = load_monitor_endpoints(&workspace_root, overrides)?;
+
+    let (event_tx, event_rx) = unbounded_channel();
+    let (command_tx, command_rx) = unbounded_channel();
+
+    let client = AiloopClient::new(endpoints.clone());
+    if let Err(err) = initial_backfill(&client, &event_tx).await {
+        tracing::warn!("monitor backfill failed: {}", err);
+    }
+
+    let ws_handle = tokio::spawn(websocket_loop(client.clone(), event_tx.clone()));
+    let poll_handle = tokio::spawn(polling_loop(client.clone(), event_tx.clone()));
+    let command_handle = tokio::spawn(command_loop(client.clone(), command_rx, event_tx.clone()));
+
+    tokio::task::spawn_blocking(move || {
+        ui::run_tui(endpoints, workspace_root, event_rx, command_tx)
+    })
+    .await??;
+
+    ws_handle.abort();
+    poll_handle.abort();
+    command_handle.abort();
+
+    Ok(())
+}

--- a/src/monitor/state.rs
+++ b/src/monitor/state.rs
@@ -1,0 +1,386 @@
+use crate::monitor::event::{ConnectionStatus, MonitorEvent};
+use crate::monitor::message::MonitorMessage;
+use chrono::{DateTime, Utc};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration as StdDuration, Instant};
+use uuid::Uuid;
+
+const CHANNEL_BUFFER_CAPACITY: usize = 200;
+const FLASH_DURATION: StdDuration = StdDuration::from_millis(600);
+
+/// Mutable state shared between the network event pump and the UI renderer.
+pub struct MonitorState {
+    /// Messages grouped by channel.
+    pub channels: HashMap<String, ChannelState>,
+    /// Queue of blocking items that still need answers/approvals.
+    pub queue: VecDeque<QueueItem>,
+    /// Index of the focused queue item.
+    pub queue_index: usize,
+    /// Last seen connection status (WS).
+    pub connection_status: ConnectionStatus,
+    /// Whether the stream should render in tiles or list layout.
+    pub layout: StreamLayout,
+    /// Filter applied to the stream view only.
+    pub filter: Filter,
+    /// Current filter input buffer when `/` is active.
+    pub filter_input: String,
+    /// Text being typed while answering a question.
+    pub answer_buffer: String,
+    /// Current input mode in the UI.
+    pub input_mode: InputMode,
+    /// Whether the standalone queue tab is visible.
+    pub queue_tab: bool,
+    /// Whether the help overlay is visible.
+    pub help_visible: bool,
+    /// Whether the UI should exit.
+    pub should_exit: bool,
+    /// Timestamp until which the flash effect remains active.
+    flash_until: Option<Instant>,
+    /// Pending queue IDs for deduplication.
+    pending_queue_ids: HashSet<Uuid>,
+}
+
+impl MonitorState {
+    /// Create initial monitor state with a default connection status.
+    pub fn new(connection_status: ConnectionStatus) -> Self {
+        MonitorState {
+            channels: HashMap::new(),
+            queue: VecDeque::new(),
+            queue_index: 0,
+            connection_status,
+            layout: StreamLayout::Tiles,
+            filter: Filter::default(),
+            filter_input: String::new(),
+            answer_buffer: String::new(),
+            input_mode: InputMode::Normal,
+            queue_tab: false,
+            help_visible: false,
+            flash_until: None,
+            pending_queue_ids: HashSet::new(),
+            should_exit: false,
+        }
+    }
+
+    /// Apply an incoming event from the networking layer.
+    pub fn apply_event(&mut self, event: MonitorEvent) {
+        match event {
+            MonitorEvent::ConnectionStatus(status) => {
+                self.connection_status = status;
+            }
+            MonitorEvent::Message(message) => {
+                self.last_seen_message(message);
+            }
+        }
+    }
+
+    fn last_seen_message(&mut self, message: MonitorMessage) {
+        let now = Utc::now();
+        self.insert_channel_message(message.clone());
+
+        if message.is_blocking() && !self.pending_queue_ids.contains(&message.id) {
+            self.pending_queue_ids.insert(message.id);
+            self.queue.push_back(QueueItem::new(message.clone()));
+            self.ensure_queue_index();
+            self.trigger_flash();
+            self.move_focus_to_new();
+        }
+
+        if let Some(correlation) = message.correlation_id {
+            self.remove_queue_item(&correlation);
+        }
+
+        let mut flash = false;
+        for item in &mut self.queue {
+            if item.check_near_timeout(now) {
+                flash = true;
+            }
+        }
+        if flash {
+            self.trigger_flash();
+        }
+    }
+
+    fn insert_channel_message(&mut self, message: MonitorMessage) {
+        let key = message.channel.clone();
+        let channel = self.channels.entry(key.clone()).or_insert_with(|| {
+            let (project, branch) = split_channel(&key);
+            ChannelState::new(project, branch)
+        });
+        channel.push(message);
+    }
+
+    fn move_focus_to_new(&mut self) {
+        self.queue_index = self.queue.len().saturating_sub(1);
+    }
+
+    fn ensure_queue_index(&mut self) {
+        if self.queue.is_empty() {
+            self.queue_index = 0;
+        } else if self.queue_index >= self.queue.len() {
+            self.queue_index = self.queue.len() - 1;
+        }
+    }
+
+    fn remove_queue_item(&mut self, correlation_id: &Uuid) {
+        if let Some(position) = self
+            .queue
+            .iter()
+            .position(|item| item.message.id == *correlation_id)
+        {
+            let removed = self.queue.remove(position);
+            if let Some(item) = removed {
+                self.pending_queue_ids.remove(&item.message.id);
+            }
+            self.ensure_queue_index();
+        }
+    }
+
+    fn trigger_flash(&mut self) {
+        self.flash_until = Some(Instant::now() + FLASH_DURATION);
+    }
+
+    /// Whether the flash indicator is currently visible.
+    pub fn flash_active(&self) -> bool {
+        self.flash_until
+            .map(|deadline| Instant::now() <= deadline)
+            .unwrap_or(false)
+    }
+
+    /// Advance to the next queue item (wrap-around).
+    pub fn next_queue(&mut self) {
+        if self.queue.is_empty() {
+            return;
+        }
+        self.queue_index = (self.queue_index + 1) % self.queue.len();
+    }
+
+    /// Move focus to the previous queue item.
+    pub fn previous_queue(&mut self) {
+        if self.queue.is_empty() {
+            return;
+        }
+        if self.queue_index == 0 {
+            self.queue_index = self.queue.len() - 1;
+        } else {
+            self.queue_index -= 1;
+        }
+    }
+
+    /// Toggle between tiles and list layout.
+    pub fn toggle_layout(&mut self) {
+        self.layout = match self.layout {
+            StreamLayout::Tiles => StreamLayout::List,
+            StreamLayout::List => StreamLayout::Tiles,
+        };
+    }
+
+    /// Set the filter text (parsed as `project` or `project/branch`).
+    pub fn apply_filter(&mut self, raw: &str) {
+        self.filter.parse(raw);
+    }
+
+    /// Clear the current filter.
+    pub fn clear_filter(&mut self) {
+        self.filter.clear();
+    }
+
+    /// Show the queue tab overlay.
+    pub fn toggle_queue_tab(&mut self) {
+        self.queue_tab = !self.queue_tab;
+    }
+
+    /// Select the focused queue item (if any).
+    pub fn selected_queue(&self) -> Option<&QueueItem> {
+        self.queue.get(self.queue_index)
+    }
+
+    /// Update near-timeout tracking and flash timers.
+    pub fn tick(&mut self) {
+        let now = Utc::now();
+        let mut flash = false;
+        for item in &mut self.queue {
+            if item.check_near_timeout(now) {
+                flash = true;
+            }
+        }
+        if flash {
+            self.trigger_flash();
+        }
+        if let Some(deadline) = self.flash_until {
+            if Instant::now() > deadline {
+                self.flash_until = None;
+            }
+        }
+    }
+
+    /// Mark the UI as ready to exit.
+    pub fn request_exit(&mut self) {
+        self.should_exit = true;
+    }
+
+    /// Check if the UI loop should stop.
+    pub fn exit_requested(&self) -> bool {
+        self.should_exit
+    }
+}
+
+/// A channel grouping that holds the latest messages.
+pub struct ChannelState {
+    pub project: String,
+    pub branch: String,
+    pub messages: VecDeque<MonitorMessage>,
+}
+
+impl ChannelState {
+    fn new(project: String, branch: String) -> Self {
+        ChannelState {
+            project,
+            branch,
+            messages: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, item: MonitorMessage) {
+        if self.messages.len() >= CHANNEL_BUFFER_CAPACITY {
+            self.messages.pop_front();
+        }
+        self.messages.push_back(item);
+    }
+}
+
+/// An outstanding blocking item shown in the queue.
+pub struct QueueItem {
+    pub message: MonitorMessage,
+    flash_until: Option<Instant>,
+    alerted_near_timeout: bool,
+}
+
+impl QueueItem {
+    fn new(message: MonitorMessage) -> Self {
+        QueueItem {
+            message,
+            flash_until: Some(Instant::now() + FLASH_DURATION),
+            alerted_near_timeout: false,
+        }
+    }
+
+    /// Whether the near-timeout threshold has just been breached.
+    fn check_near_timeout(&mut self, now: DateTime<Utc>) -> bool {
+        if self.alerted_near_timeout {
+            return false;
+        }
+        if let Some(timeout) = self.message.timeout_seconds {
+            let elapsed = now.signed_duration_since(self.message.timestamp);
+            if elapsed.num_seconds() < 0 {
+                return false;
+            }
+            let elapsed = match elapsed.to_std() {
+                Ok(dur) => dur,
+                Err(_) => return false,
+            };
+            let timeout_dur = StdDuration::from_secs(timeout);
+            if elapsed >= timeout_dur {
+                return false;
+            }
+            let remaining = timeout_dur
+                .checked_sub(elapsed)
+                .unwrap_or_else(|| StdDuration::from_secs(0));
+            let threshold = near_timeout_threshold(timeout_dur);
+            if remaining <= threshold {
+                self.alerted_near_timeout = true;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Whether this queue item currently has the flash flag.
+    pub fn is_flashing(&self) -> bool {
+        self.flash_until
+            .map(|deadline| Instant::now() <= deadline)
+            .unwrap_or(false)
+    }
+}
+
+fn near_timeout_threshold(timeout: StdDuration) -> StdDuration {
+    let ten_percent = StdDuration::from_secs((timeout.as_secs_f64() * 0.1).ceil() as u64);
+    std::cmp::min(
+        StdDuration::from_secs(30),
+        ten_percent.max(StdDuration::from_secs(1)),
+    )
+}
+
+/// Layout mode for the stream view.
+#[derive(Debug, Copy, Clone)]
+pub enum StreamLayout {
+    Tiles,
+    List,
+}
+
+/// Parsed filter that matches project/branch names.
+#[derive(Debug, Default)]
+pub struct Filter {
+    project: Option<String>,
+    branch: Option<String>,
+}
+
+impl Filter {
+    pub fn parse(&mut self, raw: &str) {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            self.clear();
+            return;
+        }
+        if let Some((project, branch)) = raw.split_once('/') {
+            self.project = Some(project.trim().to_string());
+            self.branch = Some(branch.trim().to_string());
+        } else {
+            self.project = Some(raw.to_string());
+            self.branch = None;
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.project = None;
+        self.branch = None;
+    }
+
+    pub fn matches(&self, project: &str, branch: &str) -> bool {
+        if let Some(ref project_filter) = self.project {
+            if project_filter != project {
+                return false;
+            }
+        }
+        if let Some(ref branch_filter) = self.branch {
+            if branch_filter != branch {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn display(&self) -> String {
+        match (&self.project, &self.branch) {
+            (Some(project), Some(branch)) => format!("{}/{}", project, branch),
+            (Some(project), None) => project.clone(),
+            _ => String::new(),
+        }
+    }
+}
+
+/// Input mode for the TUI.
+#[derive(Debug, Clone)]
+pub enum InputMode {
+    Normal,
+    Filter,
+    Answer { target: Uuid },
+    Authorization { target: Uuid },
+}
+
+fn split_channel(channel: &str) -> (String, String) {
+    if let Some(pos) = channel.find('/') {
+        (channel[..pos].to_string(), channel[pos + 1..].to_string())
+    } else {
+        ("uncategorized".to_string(), channel.to_string())
+    }
+}

--- a/src/monitor/ui.rs
+++ b/src/monitor/ui.rs
@@ -1,0 +1,642 @@
+use crate::monitor::config::MonitorEndpoints;
+use crate::monitor::event::{
+    ConnectionState, ConnectionStatus, MonitorCommand, MonitorEvent, ResponseType,
+};
+use crate::monitor::message::{MessageKind, MonitorMessage};
+use crate::monitor::state::{InputMode, MonitorState, QueueItem, StreamLayout};
+use chrono::Utc;
+use crossterm::{
+    event::{self, Event as CEvent, KeyCode, KeyEvent, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Corner, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    Frame, Terminal,
+};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use uuid::Uuid;
+
+/// Run the TUI loop and keep the terminal interface responsive.
+pub fn run_tui(
+    endpoints: MonitorEndpoints,
+    workspace_root: PathBuf,
+    mut event_rx: UnboundedReceiver<MonitorEvent>,
+    command_tx: UnboundedSender<MonitorCommand>,
+) -> crate::Result<()> {
+    let mut stdout = io::stdout();
+    enable_raw_mode()?;
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut state = MonitorState::new(ConnectionStatus {
+        state: ConnectionState::Connecting,
+        detail: Some("initializing".to_string()),
+    });
+
+    loop {
+        state.tick();
+        while let Ok(event) = event_rx.try_recv() {
+            state.apply_event(event);
+        }
+
+        terminal.draw(|frame| draw_ui(frame, &state, &endpoints, workspace_root.as_path()))?;
+
+        if state.exit_requested() {
+            break;
+        }
+
+        if event::poll(Duration::from_millis(120))? {
+            if let CEvent::Key(key) = event::read()? {
+                handle_key(key, &mut state, &command_tx);
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    Ok(())
+}
+
+fn draw_ui<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    state: &MonitorState,
+    endpoints: &MonitorEndpoints,
+    workspace_root: &Path,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(
+            [
+                Constraint::Length(4),
+                Constraint::Min(0),
+                Constraint::Length(3),
+            ]
+            .as_ref(),
+        )
+        .split(frame.size());
+
+    render_header(frame, chunks[0], state, endpoints, workspace_root);
+    render_body(frame, chunks[1], state);
+    render_status(frame, chunks[2], state);
+}
+
+fn render_header<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    state: &MonitorState,
+    endpoints: &MonitorEndpoints,
+    workspace_root: &Path,
+) {
+    let connection = match state.connection_status.state {
+        ConnectionState::Connected => "Connected",
+        ConnectionState::Connecting => "Connecting",
+        ConnectionState::Disconnected => "Disconnected",
+    };
+
+    let connection_detail = state
+        .connection_status
+        .detail
+        .as_deref()
+        .unwrap_or_default();
+
+    let layout_name = match state.layout {
+        StreamLayout::Tiles => "Tiles",
+        StreamLayout::List => "List",
+    };
+
+    let content = vec![
+        Line::from(vec![
+            Span::styled("Workspace: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(workspace_root.display().to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "Connection: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(connection, Style::default().fg(Color::LightGreen)),
+            Span::raw(format!(" {}", connection_detail)),
+            Span::raw(" | "),
+            Span::styled("Filter: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw({
+                let filter_display = state.filter.display();
+                if filter_display.is_empty() {
+                    "None".to_string()
+                } else {
+                    filter_display
+                }
+            }),
+            Span::raw(" | "),
+            Span::styled("View: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(layout_name),
+        ]),
+        Line::from(vec![
+            Span::styled("HTTP: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(truncate_str(endpoints.http_url.as_str(), 40)),
+            Span::raw(" "),
+            Span::styled("WS: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(truncate_str(endpoints.ws_url.as_str(), 40)),
+        ]),
+    ];
+
+    let header = Paragraph::new(content)
+        .block(
+            Block::default()
+                .title("Newton Monitor")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(header, area);
+}
+
+fn render_body<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    state: &MonitorState,
+) {
+    if state.queue_tab {
+        render_queue(frame, area, state);
+    } else {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+            .split(area);
+        render_stream(frame, cols[0], state);
+        render_queue(frame, cols[1], state);
+    }
+
+    if state.help_visible {
+        render_help(frame, area);
+    }
+}
+
+fn render_stream<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    state: &MonitorState,
+) {
+    let channels: Vec<_> = state
+        .channels
+        .values()
+        .filter(|channel| state.filter.matches(&channel.project, &channel.branch))
+        .collect();
+
+    if channels.is_empty() {
+        let block = Block::default()
+            .title("Stream (empty)")
+            .borders(Borders::ALL);
+        let empty = Paragraph::new("No channels match the current filter.")
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let items = if matches!(state.layout, StreamLayout::Tiles) {
+        channels
+            .iter()
+            .map(|channel| {
+                let mut lines = vec![Line::from(vec![Span::styled(
+                    format!("{} / {}", channel.project, channel.branch),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )])];
+                for message in channel.messages.iter().rev().take(4).rev() {
+                    lines.push(render_message_span(message));
+                }
+                ListItem::new(lines)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        let mut entries = Vec::new();
+        for channel in &channels {
+            for message in channel.messages.iter() {
+                entries.push((channel, message));
+            }
+        }
+        entries.sort_by_key(|(_, message)| message.timestamp);
+        entries
+            .into_iter()
+            .rev()
+            .take(80)
+            .map(|(channel, message)| {
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("[{} / {}] ", channel.project, channel.branch),
+                        Style::default().fg(Color::LightBlue),
+                    ),
+                    Span::styled(
+                        message.summary.clone(),
+                        Style::default().fg(message_color(message)),
+                    ),
+                ]);
+                ListItem::new(vec![line])
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let title = match state.layout {
+        StreamLayout::Tiles => "Stream (Tiles)",
+        StreamLayout::List => "Stream (List)",
+    };
+    let list = List::new(items)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .start_corner(Corner::TopLeft);
+    frame.render_widget(list, area);
+}
+
+fn render_queue<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    state: &MonitorState,
+) {
+    let items = state
+        .queue
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| {
+            let mut lines = Vec::new();
+            lines.push(Line::from(vec![Span::styled(
+                format!("{} ", item.message.channel),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            lines.push(Line::from(Span::raw(item.message.summary.clone())));
+            if let Some(remaining) = render_remaining(item) {
+                lines.push(Line::from(vec![Span::styled(
+                    format!(" ({})", remaining),
+                    Style::default().fg(Color::Red),
+                )]));
+            }
+            ListItem::new(lines).style(render_queue_style(idx, state))
+        })
+        .collect::<Vec<_>>();
+
+    let position = if state.queue.is_empty() {
+        0
+    } else {
+        state.queue_index + 1
+    };
+    let title = format!("Queue ({}/{})", position, state.queue.len());
+    let block = Block::default().title(title).borders(Borders::ALL);
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+fn render_status<B: ratatui::backend::Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    state: &MonitorState,
+) {
+    let mut spans = Vec::new();
+
+    match state.input_mode {
+        InputMode::Filter => {
+            spans.push(Span::styled(
+                format!("/ {}", state.filter_input),
+                Style::default().fg(Color::Magenta),
+            ));
+        }
+        InputMode::Answer { .. } => {
+            spans.push(Span::styled(
+                format!("Answer: {}", state.answer_buffer),
+                Style::default().fg(Color::Green),
+            ));
+        }
+        InputMode::Authorization { .. } => {
+            spans.push(Span::raw("[a] Approve  [d] Deny  [Esc] Skip"));
+        }
+        InputMode::Normal => {
+            spans.push(Span::raw(
+                "Enter/a: act  n/Tab: next  /: filter  V: toggle view  Q: queue tab  ?: help",
+            ));
+        }
+    }
+
+    let footer = Paragraph::new(Line::from(spans))
+        .block(Block::default().borders(Borders::ALL).title("Status"))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(footer, area);
+}
+
+fn render_help<B: ratatui::backend::Backend>(frame: &mut Frame<B>, area: Rect) {
+    let help_lines = vec![
+        Line::from(Span::styled(
+            "Keybindings",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from("q / Ctrl+C: Quit"),
+        Line::from("n / Tab: Next queue item"),
+        Line::from("Enter/a: Answer (question) or Approve (authorization)"),
+        Line::from("d: Deny authorization"),
+        Line::from("/: Filter stream (project or project/branch)"),
+        Line::from("V: Toggle tiles/list"),
+        Line::from("Q: Toggle queue-only view"),
+        Line::from("?: Toggle this help overlay"),
+        Line::from("Esc: Cancel input / close queue tab"),
+    ];
+    let overlay = Paragraph::new(help_lines)
+        .block(
+            Block::default()
+                .title("Help")
+                .borders(Borders::ALL)
+                .style(Style::default().bg(Color::Black)),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(overlay, area);
+}
+
+fn handle_key(
+    key: KeyEvent,
+    state: &mut MonitorState,
+    command_tx: &UnboundedSender<MonitorCommand>,
+) {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+        state.request_exit();
+        return;
+    }
+
+    if matches!(key.code, KeyCode::Char('?')) {
+        state.help_visible = !state.help_visible;
+        return;
+    }
+
+    if state.help_visible {
+        if matches!(key.code, KeyCode::Esc) {
+            state.help_visible = false;
+        }
+        return;
+    }
+
+    match state.input_mode.clone() {
+        InputMode::Filter => handle_filter_input(key, state),
+        InputMode::Answer { target } => handle_answer_input(key, state, command_tx, target),
+        InputMode::Authorization { target } => {
+            handle_authorization_input(key, state, command_tx, target)
+        }
+        InputMode::Normal => handle_normal_input(key, state, command_tx),
+    }
+}
+
+fn handle_filter_input(key: KeyEvent, state: &mut MonitorState) {
+    match key.code {
+        KeyCode::Char(c) => {
+            state.filter_input.push(c);
+        }
+        KeyCode::Backspace => {
+            state.filter_input.pop();
+        }
+        KeyCode::Enter => {
+            let input = state.filter_input.clone();
+            state.apply_filter(&input);
+            state.filter_input.clear();
+            state.input_mode = InputMode::Normal;
+        }
+        KeyCode::Esc => {
+            state.filter_input.clear();
+            state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+    }
+}
+
+fn handle_answer_input(
+    key: KeyEvent,
+    state: &mut MonitorState,
+    command_tx: &UnboundedSender<MonitorCommand>,
+    target: Uuid,
+) {
+    match key.code {
+        KeyCode::Char(c) => {
+            state.answer_buffer.push(c);
+        }
+        KeyCode::Backspace => {
+            state.answer_buffer.pop();
+        }
+        KeyCode::Enter => {
+            let answer = state.answer_buffer.trim().to_string();
+            let _ = command_tx.send(MonitorCommand::Respond {
+                message_id: target,
+                answer: Some(answer),
+                response_type: ResponseType::Text,
+            });
+            state.answer_buffer.clear();
+            state.input_mode = InputMode::Normal;
+            state.next_queue();
+        }
+        KeyCode::Esc => {
+            state.answer_buffer.clear();
+            state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+    }
+}
+
+fn handle_authorization_input(
+    key: KeyEvent,
+    state: &mut MonitorState,
+    command_tx: &UnboundedSender<MonitorCommand>,
+    target: Uuid,
+) {
+    match key.code {
+        KeyCode::Char('a') => {
+            send_response(
+                command_tx,
+                target,
+                None,
+                ResponseType::AuthorizationApproved,
+            );
+            state.input_mode = InputMode::Normal;
+            state.next_queue();
+        }
+        KeyCode::Char('d') => {
+            send_response(command_tx, target, None, ResponseType::AuthorizationDenied);
+            state.input_mode = InputMode::Normal;
+            state.next_queue();
+        }
+        KeyCode::Esc => {
+            state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+    }
+}
+
+fn handle_normal_input(
+    key: KeyEvent,
+    state: &mut MonitorState,
+    command_tx: &UnboundedSender<MonitorCommand>,
+) {
+    match key.code {
+        KeyCode::Char('q') => {
+            state.request_exit();
+        }
+        KeyCode::Char('/') => {
+            state.input_mode = InputMode::Filter;
+            state.filter_input = state.filter.display();
+        }
+        KeyCode::Char('n') | KeyCode::Tab | KeyCode::Down | KeyCode::Char('j') => {
+            state.next_queue();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.previous_queue();
+        }
+        KeyCode::Char('g') => {
+            state.queue_index = 0;
+        }
+        KeyCode::Char('G') => {
+            if !state.queue.is_empty() {
+                state.queue_index = state.queue.len() - 1;
+            }
+        }
+        KeyCode::Char('V') | KeyCode::Char('v') => {
+            state.toggle_layout();
+        }
+        KeyCode::Char('Q') => {
+            state.toggle_queue_tab();
+        }
+        KeyCode::Char('a') => {
+            if let Some(item) = state.queue.get(state.queue_index) {
+                match item.message.kind {
+                    MessageKind::Question => {
+                        state.input_mode = InputMode::Answer {
+                            target: item.message.id,
+                        };
+                        state.answer_buffer.clear();
+                    }
+                    MessageKind::Authorization => {
+                        send_response(
+                            command_tx,
+                            item.message.id,
+                            None,
+                            ResponseType::AuthorizationApproved,
+                        );
+                        state.next_queue();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        KeyCode::Char('d') => {
+            if let Some(item) = state.queue.get(state.queue_index) {
+                if item.message.kind == MessageKind::Authorization {
+                    send_response(
+                        command_tx,
+                        item.message.id,
+                        None,
+                        ResponseType::AuthorizationDenied,
+                    );
+                    state.next_queue();
+                }
+            }
+        }
+        KeyCode::Enter => {
+            if let Some(item) = state.queue.get(state.queue_index) {
+                if item.message.kind == MessageKind::Question {
+                    state.input_mode = InputMode::Answer {
+                        target: item.message.id,
+                    };
+                    state.answer_buffer.clear();
+                } else if item.message.kind == MessageKind::Authorization {
+                    state.input_mode = InputMode::Authorization {
+                        target: item.message.id,
+                    };
+                }
+            }
+        }
+        KeyCode::Esc => {
+            if state.queue_tab {
+                state.queue_tab = false;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn send_response(
+    command_tx: &UnboundedSender<MonitorCommand>,
+    message_id: uuid::Uuid,
+    answer: Option<String>,
+    response_type: ResponseType,
+) {
+    let _ = command_tx.send(MonitorCommand::Respond {
+        message_id,
+        answer,
+        response_type,
+    });
+}
+
+fn render_message_span(message: &MonitorMessage) -> Line<'_> {
+    let timestamp = message.timestamp.format("%H:%M:%S").to_string();
+    Line::from(vec![
+        Span::styled(
+            format!("[{}] ", timestamp),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            message.summary.clone(),
+            Style::default().fg(message_color(message)),
+        ),
+    ])
+}
+
+fn render_queue_style(idx: usize, state: &MonitorState) -> Style {
+    let mut style = Style::default();
+    if idx == state.queue_index {
+        style = style
+            .bg(Color::LightYellow)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD);
+    }
+    if let Some(item) = state.queue.get(idx) {
+        if item.is_flashing() {
+            style = style.add_modifier(Modifier::ITALIC);
+        }
+    }
+    style
+}
+
+fn render_remaining(item: &QueueItem) -> Option<String> {
+    if let (Some(timeout), Ok(elapsed)) = (
+        item.message.timeout_seconds,
+        Utc::now()
+            .signed_duration_since(item.message.timestamp)
+            .to_std(),
+    ) {
+        if elapsed >= std::time::Duration::from_secs(timeout) {
+            return Some("timed out".to_string());
+        }
+        let remaining = timeout.saturating_sub(elapsed.as_secs());
+        return Some(format!("{}s left", remaining));
+    }
+    None
+}
+
+fn message_color(message: &MonitorMessage) -> Color {
+    match message.kind {
+        MessageKind::Question | MessageKind::Authorization => Color::Yellow,
+        MessageKind::Stderr => Color::Red,
+        MessageKind::Stdout => Color::White,
+        _ => Color::LightBlue,
+    }
+}
+
+fn truncate_str(value: &str, max: usize) -> String {
+    if value.len() <= max {
+        value.to_string()
+    } else {
+        format!("{}…", &value[..max.saturating_sub(1)])
+    }
+}

--- a/tests/snapshots/snapshots/test_cli_commands_snapshots__help_output.snap
+++ b/tests/snapshots/snapshots/test_cli_commands_snapshots__help_output.snap
@@ -15,10 +15,11 @@ OPTIONS:
   -V, --version
           Print version
 WORKFLOW COMMANDS:
-  run     Execute a full optimization loop
-  batch   Process queued work items for a project
-  step    Advance loop by one cycle
-  status  Inspect progress of an execution
-  report  Summarize learnings from an execution
-  error   Diagnose failures during optimization
-  help    Print this message or the help of the given subcommand(s)
+  run      Execute a full optimization loop
+  batch    Process queued work items for a project
+  step     Advance loop by one cycle
+  status   Inspect progress of an execution
+  report   Summarize learnings from an execution
+  error    Diagnose failures during optimization
+  monitor  Monitor live ailoop channels via a terminal UI
+  help     Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
## Summary
- introduce the  workflow with CLI wiring and docs
- implement the monitor runtime with HTTP/WS client, state machine, and ratatui UI
- document the command, configuration sources, and keybindings so users can follow the new workflow

## Testing
- cargo fmt
- cargo clippy
- cargo test