### PR TITLE
Install release target on active toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Add target to toolchain
         shell: bash
-        run: rustup target add ${{ matrix.target }} --toolchain $(rustup show active-toolchain | cut -d' ' -f1)
+        run: |
+          ACTIVE_TOOLCHAIN=$(rustup show active-toolchain | cut -d' ' -f1)
+          rustup target add ${{ matrix.target }} --toolchain "$ACTIVE_TOOLCHAIN"
 
       - name: Verify version matches tag
         shell: bash


### PR DESCRIPTION
## Summary
- install the matrix target on the selected toolchain so the override from rust-toolchain.toml has it available for every release job
- keep the rest of the release workflow unchanged

## Testing
- cargo fmt
- cargo clippy
- cargo test