### PR TITLE
Add batch control hooks and tool overrides

### DIFF
--- a/skills/newton-cli-commands/references/batch.md
+++ b/skills/newton-cli-commands/references/batch.md
@@ -42,6 +42,21 @@ post_fail_script = ./scripts/notify-failure.sh
 
 Failed plans are moved into `.newton/plan/<project_id>/failed/` (created automatically). Hooks execute before the move happens, so scripts can react to the plan that just ran. `post_success_script` failures update `failed/` so you can capture retries, while `post_fail_script` always runs before a failure is recorded.
 
+### Additional configuration keys
+New batch workflows can opt in to tighter control with these optional `.conf` keys:
+
+- `evaluator_cmd`, `advisor_cmd`, `executor_cmd`: Override the default scripts located at `project_root/.newton/scripts/{evaluator,advisor}.sh` and `workspace_root/.newton/scripts/executor.sh` (derived by `newton init` when omitted).
+- `pre_run_script`: Run once per plan before `newton run` (commonly `.newton/scripts/pre-run.sh`, which prepares the feature branch and clears `NEWTON_CONTROL_FILE`).
+- `resume`: Set to `true`/`1` to preserve the task state directories instead of wiping them between runs.
+- `max_iterations`, `max_time`, and `verbose`: Control the loop limits and echo verbosity passed through to `newton run`.
+- `control_file`: Filename (default `newton_control.json`) stored under `NEWTON_STATE_DIR`. Evaluators write `{"done": true}` to `$NEWTON_CONTROL_FILE` to signal success; every other exit (limits, missing file, or `done: false`) triggers failure.
+
+Batch forwards these environment variables to hooks and tools when processing a plan:
+
+- `NEWTON_STATE_DIR`, `NEWTON_CONTROL_FILE`, `NEWTON_WS_ROOT`, `NEWTON_CODER_CMD`, `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`, `NEWTON_PROJECT_ROOT`, `NEWTON_PROJECT_ID`, `NEWTON_TASK_ID`, `NEWTON_GOAL_FILE`, `NEWTON_RESUME`, and `CODING_AGENT`/`CODING_AGENT_MODEL`.
+
+Feature branches are determined by `branch:` frontmatter in the plan spec; if missing, batch uses `feature/<task_id>` (underscores become dashes). `NEWTON_BRANCH_NAME` and `NEWTON_BASE_BRANCH` stay available so hooks and scripts can create PRs or cleanup the correct refs.
+
 ## Hooks
 Add a `[hooks]` table to the target workspace or project `newton.toml`:
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -120,6 +120,42 @@ impl RunArgs {
             feedback: None,
         }
     }
+
+    /// Produce batch arguments when tooling overrides and limits should come from config.
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_batch_with_tools(
+        project_root: PathBuf,
+        goal_file: Option<PathBuf>,
+        evaluator_cmd: Option<String>,
+        advisor_cmd: Option<String>,
+        executor_cmd: Option<String>,
+        max_iterations: Option<usize>,
+        max_time: Option<u64>,
+        verbose: bool,
+        control_file_path: Option<PathBuf>,
+    ) -> Self {
+        RunArgs {
+            path: project_root,
+            max_iterations: max_iterations.unwrap_or(5),
+            max_time: max_time.unwrap_or(3600),
+            evaluator_cmd,
+            advisor_cmd,
+            executor_cmd,
+            evaluator_status_file: PathBuf::from("artifacts/evaluator_status.md"),
+            advisor_recommendations_file: PathBuf::from("artifacts/advisor_recommendations.md"),
+            executor_log_file: PathBuf::from("artifacts/executor_log.md"),
+            tool_timeout_seconds: 30,
+            evaluator_timeout: None,
+            advisor_timeout: None,
+            executor_timeout: None,
+            verbose,
+            config: None,
+            goal: None,
+            goal_file,
+            control_file: control_file_path,
+            feedback: None,
+        }
+    }
 }
 
 #[derive(Args)]

--- a/src/core/batch_config.rs
+++ b/src/core/batch_config.rs
@@ -15,11 +15,38 @@ pub struct BatchProjectConfig {
     /// Coding agent model override used while running the project.
     pub coding_model: String,
 
+    /// Evaluator tool invocation.
+    pub evaluator_cmd: Option<String>,
+
+    /// Advisor tool invocation.
+    pub advisor_cmd: Option<String>,
+
+    /// Executor tool invocation.
+    pub executor_cmd: Option<String>,
+
+    /// Optional hook run once before executing the Newton run.
+    pub pre_run_script: Option<String>,
+
     /// Optional hook executed after a successful plan run.
     pub post_success_script: Option<String>,
 
     /// Optional hook executed after a failed plan run.
     pub post_fail_script: Option<String>,
+
+    /// Whether to resume from an existing state directory.
+    pub resume: bool,
+
+    /// Maximum iterations (limit from config).
+    pub max_iterations: Option<usize>,
+
+    /// Maximum time (seconds) (limit from config).
+    pub max_time: Option<u64>,
+
+    /// Enable verbose logging for the run.
+    pub verbose: bool,
+
+    /// Control file name stored under the state directory. Defaults to `newton_control.json` when None.
+    pub control_file: Option<String>,
 }
 
 impl BatchProjectConfig {
@@ -67,8 +94,17 @@ impl BatchProjectConfig {
             ));
         }
 
+        let project_scripts = project_newton.join("scripts");
+        let workspace_scripts = workspace_root.join(".newton").join("scripts");
+
         let post_success_script = settings
             .get("post_success_script")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        let pre_run_script = settings
+            .get("pre_run_script")
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
@@ -79,12 +115,70 @@ impl BatchProjectConfig {
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
 
+        let evaluator_cmd = resolve_tool_command(
+            &settings,
+            "evaluator_cmd",
+            &project_root,
+            project_scripts.join("evaluator.sh"),
+        );
+        let advisor_cmd = resolve_tool_command(
+            &settings,
+            "advisor_cmd",
+            &project_root,
+            project_scripts.join("advisor.sh"),
+        );
+        let executor_cmd = resolve_tool_command(
+            &settings,
+            "executor_cmd",
+            workspace_root,
+            workspace_scripts.join("executor.sh"),
+        );
+
+        let resume = parse_flag(&settings, "resume");
+
+        let verbose = parse_flag(&settings, "verbose");
+
+        let max_iterations = settings
+            .get("max_iterations")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse::<usize>()
+                    .map_err(|e| anyhow::anyhow!("invalid max_iterations value '{}': {}", s, e))
+            })
+            .transpose()?;
+
+        let max_time = settings
+            .get("max_time")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse::<u64>()
+                    .map_err(|e| anyhow::anyhow!("invalid max_time value '{}': {}", s, e))
+            })
+            .transpose()?;
+
+        let control_file = settings
+            .get("control_file")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
         Ok(BatchProjectConfig {
             project_root,
             coding_agent,
             coding_model,
+            evaluator_cmd,
+            advisor_cmd,
+            executor_cmd,
+            pre_run_script,
             post_success_script,
             post_fail_script,
+            resume,
+            max_iterations,
+            max_time,
+            verbose,
+            control_file,
         })
     }
 }
@@ -104,7 +198,7 @@ pub fn parse_conf(path: &Path) -> Result<HashMap<String, String>> {
         if let Some(pos) = line.find('=') {
             let key = line[..pos].trim();
             let value = line[pos + 1..].trim();
-            if key.is_empty() || value.is_empty() {
+            if key.is_empty() {
                 continue;
             }
             map.insert(key.to_string(), value.to_string());
@@ -129,4 +223,33 @@ pub fn find_workspace_root(start_path: &Path) -> Result<PathBuf> {
     Err(anyhow::anyhow!(
         "workspace root not found; use --workspace PATH"
     ))
+}
+
+fn resolve_tool_command(
+    settings: &HashMap<String, String>,
+    key: &str,
+    base: &Path,
+    default_cmd: PathBuf,
+) -> Option<String> {
+    if let Some(value) = settings.get(key) {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let candidate_path = PathBuf::from(trimmed);
+        let command_path = if candidate_path.is_absolute() {
+            candidate_path
+        } else {
+            base.join(candidate_path)
+        };
+        return Some(command_path.display().to_string());
+    }
+    Some(default_cmd.display().to_string())
+}
+
+fn parse_flag(settings: &HashMap<String, String>, key: &str) -> bool {
+    settings
+        .get(key)
+        .map(|v| matches!(v.trim().to_lowercase().as_str(), "1" | "true"))
+        .unwrap_or(false)
 }

--- a/src/core/entities/mod.rs
+++ b/src/core/entities/mod.rs
@@ -34,6 +34,7 @@ pub enum ExecutionStatus {
     Failed,
     Cancelled,
     Timeout,
+    MaxIterationsReached,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/src/core/success_policy/mod.rs
+++ b/src/core/success_policy/mod.rs
@@ -31,7 +31,11 @@ impl SuccessPolicy {
     /// * `workspace_path` - The workspace root directory
     /// * `control_file_name` - The control file name (relative to workspace)
     pub fn new(workspace_path: &Path, control_file_name: &str) -> Self {
-        let control_file_path = workspace_path.join(control_file_name);
+        Self::from_path(workspace_path.join(control_file_name))
+    }
+
+    /// Create a success policy that reads a control file from a full path.
+    pub fn from_path(control_file_path: PathBuf) -> Self {
         Self { control_file_path }
     }
 

--- a/tests/integration/test_batch.rs
+++ b/tests/integration/test_batch.rs
@@ -1,11 +1,60 @@
 use assert_cmd::Command;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
+
+fn create_stub_tool_scripts(workspace_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let project_root = workspace_path.join("project-root");
+    let project_scripts = project_root.join(".newton").join("scripts");
+    fs::create_dir_all(&project_scripts)?;
+
+    let evaluator = project_scripts.join("evaluator.sh");
+    fs::write(
+        &evaluator,
+        r#"#!/bin/sh
+set -e
+if [ -n "$NEWTON_CONTROL_FILE" ]; then
+  printf '%s\n' '{"done": true}' > "$NEWTON_CONTROL_FILE"
+fi
+exit 0
+"#,
+    )?;
+    set_executable(&evaluator)?;
+
+    let advisor = project_scripts.join("advisor.sh");
+    fs::write(&advisor, "#!/bin/sh\nexit 0\n")?;
+    set_executable(&advisor)?;
+
+    let workspace_scripts = workspace_path.join(".newton").join("scripts");
+    fs::create_dir_all(&workspace_scripts)?;
+
+    let executor = workspace_scripts.join("executor.sh");
+    fs::write(&executor, "#!/bin/sh\nexit 0\n")?;
+    set_executable(&executor)?;
+
+    let coder = workspace_scripts.join("coder.sh");
+    fs::write(&coder, "#!/bin/sh\nexit 0\n")?;
+    set_executable(&coder)?;
+
+    Ok(())
+}
+
+fn set_executable(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
 
 #[test]
 fn batch_once_moves_plan_to_completed() -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = TempDir::new()?;
     let workspace_path = workspace_dir.path();
+    create_stub_tool_scripts(workspace_path)?;
 
     let project_root = workspace_path.join("project-root");
     fs::create_dir_all(project_root.join(".newton"))?;
@@ -54,6 +103,7 @@ fn batch_once_moves_plan_to_completed() -> Result<(), Box<dyn std::error::Error>
 fn batch_success_script_moves_plan_to_completed() -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = TempDir::new()?;
     let workspace_path = workspace_dir.path();
+    create_stub_tool_scripts(workspace_path)?;
 
     let project_root = workspace_path.join("project-root");
     fs::create_dir_all(project_root.join(".newton/hooks"))?;
@@ -111,6 +161,7 @@ fn batch_success_script_moves_plan_to_completed() -> Result<(), Box<dyn std::err
 fn batch_success_script_failure_moves_plan_to_failed() -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = TempDir::new()?;
     let workspace_path = workspace_dir.path();
+    create_stub_tool_scripts(workspace_path)?;
 
     let project_root = workspace_path.join("project-root");
     fs::create_dir_all(project_root.join(".newton"))?;
@@ -167,6 +218,7 @@ fn batch_success_script_failure_moves_plan_to_failed() -> Result<(), Box<dyn std
 fn batch_failure_runs_post_fail_script() -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = TempDir::new()?;
     let workspace_path = workspace_dir.path();
+    create_stub_tool_scripts(workspace_path)?;
 
     let project_root = workspace_path.join("project-root");
     fs::create_dir_all(project_root.join(".newton/hooks"))?;
@@ -221,6 +273,7 @@ fn batch_failure_runs_post_fail_script() -> Result<(), Box<dyn std::error::Error
 fn batch_success_hook_receives_result_env_var() -> Result<(), Box<dyn std::error::Error>> {
     let workspace_dir = TempDir::new()?;
     let workspace_path = workspace_dir.path();
+    create_stub_tool_scripts(workspace_path)?;
 
     let project_root = workspace_path.join("project-root");
     fs::create_dir_all(project_root.join(".newton/hooks"))?;

--- a/tests/integration/test_comprehensive_coverage.rs
+++ b/tests/integration/test_comprehensive_coverage.rs
@@ -34,7 +34,7 @@ async fn test_full_orchestrator_workflow() {
     assert!(result.is_ok());
 
     let execution = result.unwrap();
-    assert_eq!(execution.status, ExecutionStatus::Completed);
+    assert_eq!(execution.status, ExecutionStatus::MaxIterationsReached);
     assert_eq!(execution.total_iterations_completed, 2);
     assert!(execution.completed_at.is_some());
 }

--- a/tests/unit/test_batch_config.rs
+++ b/tests/unit/test_batch_config.rs
@@ -120,3 +120,147 @@ fn find_workspace_root_missing_fails() {
 
     assert!(find_workspace_root(&nested).is_err());
 }
+
+#[test]
+fn batch_project_config_derives_default_tools() {
+    let workspace = TempDir::new().unwrap();
+    let project_root = workspace.path().join("workspace-project");
+    fs::create_dir_all(project_root.join(".newton").join("scripts")).unwrap();
+    fs::create_dir_all(workspace.path().join(".newton").join("scripts")).unwrap();
+
+    let configs_dir = workspace.path().join(".newton").join("configs");
+    fs::create_dir_all(&configs_dir).unwrap();
+    let conf_path = configs_dir.join("proj.conf");
+    let content = r#"
+        project_root = ./workspace-project
+        coding_agent = opencode
+        coding_model = glm-4.7
+    "#;
+    fs::write(&conf_path, content).unwrap();
+
+    let config = BatchProjectConfig::load(workspace.path(), "proj").unwrap();
+
+    let expected_evaluator = project_root
+        .join(".newton")
+        .join("scripts")
+        .join("evaluator.sh");
+    let expected_advisor = project_root
+        .join(".newton")
+        .join("scripts")
+        .join("advisor.sh");
+    let expected_executor = workspace
+        .join(".newton")
+        .join("scripts")
+        .join("executor.sh");
+
+    assert_eq!(
+        config.evaluator_cmd,
+        Some(expected_evaluator.display().to_string())
+    );
+    assert_eq!(
+        config.advisor_cmd,
+        Some(expected_advisor.display().to_string())
+    );
+    assert_eq!(
+        config.executor_cmd,
+        Some(expected_executor.display().to_string())
+    );
+}
+
+#[test]
+fn batch_project_config_tool_overrides_respect_relative_paths() {
+    let workspace = TempDir::new().unwrap();
+    let project_root = workspace.path().join("workspace-project");
+    fs::create_dir_all(project_root.join(".newton").join("scripts")).unwrap();
+    fs::create_dir_all(workspace.path().join(".newton").join("scripts")).unwrap();
+
+    let configs_dir = workspace.path().join(".newton").join("configs");
+    fs::create_dir_all(&configs_dir).unwrap();
+    let conf_path = configs_dir.join("proj.conf");
+    let content = r#"
+        project_root = ./workspace-project
+        coding_agent = opencode
+        coding_model = glm-4.7
+        evaluator_cmd = ./custom/evaluator.sh
+        advisor_cmd =
+        executor_cmd = tools/executor.sh
+    "#;
+    fs::write(&conf_path, content).unwrap();
+
+    let config = BatchProjectConfig::load(workspace.path(), "proj").unwrap();
+    assert_eq!(
+        config.evaluator_cmd,
+        Some(
+            project_root
+                .join("custom")
+                .join("evaluator.sh")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(config.advisor_cmd.is_none());
+    assert_eq!(
+        config.executor_cmd,
+        Some(
+            workspace
+                .join("tools")
+                .join("executor.sh")
+                .display()
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn batch_project_config_parses_additional_settings() {
+    let workspace = TempDir::new().unwrap();
+    let project_root = workspace.path().join("workspace-project");
+    fs::create_dir_all(project_root.join(".newton")).unwrap();
+    fs::create_dir_all(project_root.join(".newton").join("scripts")).unwrap();
+    fs::create_dir_all(workspace.path().join(".newton").join("scripts")).unwrap();
+
+    let configs_dir = workspace.path().join(".newton").join("configs");
+    fs::create_dir_all(&configs_dir).unwrap();
+    let conf_path = configs_dir.join("proj.conf");
+    let content = r#"
+        project_root = ./workspace-project
+        coding_agent = opencode
+        coding_model = glm-4.7
+        resume = true
+        verbose = 1
+        max_iterations = 8
+        max_time = 1200
+        control_file = custom_control.json
+    "#;
+    fs::write(&conf_path, content).unwrap();
+
+    let config = BatchProjectConfig::load(workspace.path(), "proj").unwrap();
+    assert!(config.resume);
+    assert!(config.verbose);
+    assert_eq!(config.max_iterations, Some(8));
+    assert_eq!(config.max_time, Some(1200));
+    assert_eq!(config.control_file.as_deref(), Some("custom_control.json"));
+}
+
+#[test]
+fn batch_project_config_resume_accepts_one() {
+    let workspace = TempDir::new().unwrap();
+    let project_root = workspace.path().join("workspace-project");
+    fs::create_dir_all(project_root.join(".newton")).unwrap();
+    fs::create_dir_all(project_root.join(".newton").join("scripts")).unwrap();
+    fs::create_dir_all(workspace.path().join(".newton").join("scripts")).unwrap();
+
+    let configs_dir = workspace.path().join(".newton").join("configs");
+    fs::create_dir_all(&configs_dir).unwrap();
+    let conf_path = configs_dir.join("proj.conf");
+    let content = r#"
+        project_root = ./workspace-project
+        coding_agent = opencode
+        coding_model = glm-4.7
+        resume = 1
+    "#;
+    fs::write(&conf_path, content).unwrap();
+
+    let config = BatchProjectConfig::load(workspace.path(), "proj").unwrap();
+    assert!(config.resume);
+}

--- a/tests/unit/test_cli_commands.rs
+++ b/tests/unit/test_cli_commands.rs
@@ -1,11 +1,14 @@
 use newton::cli::{commands, ErrorArgs, ReportArgs, RunArgs, StatusArgs, StepArgs};
 use newton::core::entities::ExecutionConfiguration;
+use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
 #[tokio::test]
 async fn test_run_command_success() {
     let temp_dir = TempDir::new().unwrap();
+    let control_file = temp_dir.path().join("newton_control.json");
+    fs::write(&control_file, r#"{"done": true}"#).unwrap();
     let args = RunArgs {
         path: temp_dir.path().to_path_buf(),
         max_iterations: 1,
@@ -24,7 +27,7 @@ async fn test_run_command_success() {
         config: None,
         goal: None,
         goal_file: None,
-        control_file: None,
+        control_file: Some(control_file.clone()),
         feedback: None,
     };
 


### PR DESCRIPTION
## Summary
- document the new batch configuration keys, environment variables, and branch derivation so hooks have parity with the gonewton skill
- update the CLI batch runner to manage control files, pre/post hooks, tool overrides, resume state, and success policy signals
- add new config parsing helpers, execution status tracking, and regression tests that cover the extended workflow

## Testing
- cargo fmt
- cargo clippy
- cargo test