### PR TITLE
refactor: improve config loader environment override handling

### DIFF
--- a/src/core/config/snapshots/newton__core__config__loader__tests__env_overrides.snap
+++ b/src/core/config/snapshots/newton__core__config__loader__tests__env_overrides.snap
@@ -1,0 +1,27 @@
+---
+source: src/core/config/loader.rs
+expression: result
+---
+NewtonConfig {
+    project: ProjectConfig {
+        name: "env-project",
+        template: None,
+    },
+    executor: ExecutorConfig {
+        coding_agent: "env-agent",
+        coding_agent_model: "zai-coding-plan/glm-4.7",
+        auto_commit: true,
+    },
+    evaluator: EvaluatorConfig {
+        test_command: None,
+        score_threshold: 85.0,
+    },
+    advisor: AdvisorConfig,
+    context: ContextConfig {
+        clear_after_use: true,
+        file: ".newton/state/context.md",
+    },
+    promise: PromiseConfig {
+        file: ".newton/state/promise.txt",
+    },
+}


### PR DESCRIPTION
## Summary
Refactor the `apply_env_overrides` method in `loader.rs` to use a data-driven approach with a descriptor table instead of repetitive if-let blocks. This improves code maintainability and makes it easier to add new environment variable overrides in the future.

## Changes
- Replace individual if-let blocks with a declarative override descriptor table using closures
- Consolidate test assertions using helper functions (`assert_validate_error`) and snapshot testing
- Simplify test cases by using loops over test data arrays
- Add snapshot test for environment overrides validation
- Add type alias `EnvOverride` to satisfy clippy::type_complexity lint

## Benefits
- **Reduced code duplication**: The new approach eliminates ~50 lines of repetitive if-let code
- **Easier maintenance**: Adding new environment variables only requires adding one line to the descriptor table
- **Improved testability**: Snapshot tests ensure consistent behavior and make it easier to validate changes
- **Better code organization**: Test helper functions reduce duplication in test assertions

## Test plan
- [x] All existing unit tests pass
- [x] New snapshot test validates environment override behavior
- [x] Pre-commit hooks (formatting, clippy, tests) pass
- [x] Pre-push checks (full test suite, documentation build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)