### PR TITLE
feat: add configurable coder_cmd to batch configuration

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -436,10 +436,16 @@ pub async fn batch(args: BatchArgs) -> Result<()> {
 
         let branch_name = derive_branch_name(&spec_path, &task_id);
         let base_branch = detect_base_branch(&batch_config.project_root);
-        let coder_cmd = workspace_root
-            .join(".newton")
-            .join("scripts")
-            .join("coder.sh");
+        let coder_cmd = batch_config
+            .coder_cmd
+            .as_ref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                workspace_root
+                    .join(".newton")
+                    .join("scripts")
+                    .join("coder.sh")
+            });
 
         let context = BatchTaskContext {
             batch_config: batch_config.clone(),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -160,6 +160,18 @@ fn write_default_config(newton_dir: &Path, project_root: &Path) -> Result<()> {
     writeln!(config_file, "project_root={}", project_root.display())?;
     writeln!(config_file, "coding_agent={}", coding_agent)?;
     writeln!(config_file, "coding_model={}", coding_model)?;
+    writeln!(config_file)?;
+
+    // Script paths (optional - defaults to .newton/scripts/*.sh)
+    writeln!(
+        config_file,
+        "# Can be absolute paths or relative to project/workspace root"
+    )?;
+    writeln!(config_file, "# evaluator_cmd=.newton/scripts/evaluator.sh")?;
+    writeln!(config_file, "# advisor_cmd=.newton/scripts/advisor.sh")?;
+    writeln!(config_file, "# executor_cmd=.newton/scripts/executor.sh")?;
+    writeln!(config_file, "# coder_cmd=.newton/scripts/coder.sh")?;
+    writeln!(config_file)?;
 
     // Optionally add script paths if they exist
     let post_success_script = newton_dir.join("scripts/post-success.sh");

--- a/src/core/batch_config.rs
+++ b/src/core/batch_config.rs
@@ -24,6 +24,9 @@ pub struct BatchProjectConfig {
     /// Executor tool invocation.
     pub executor_cmd: Option<String>,
 
+    /// Coder tool invocation (used in batch mode).
+    pub coder_cmd: Option<String>,
+
     /// Optional hook run once before executing the Newton run.
     pub pre_run_script: Option<String>,
 
@@ -133,6 +136,12 @@ impl BatchProjectConfig {
             workspace_root,
             workspace_scripts.join("executor.sh"),
         );
+        let coder_cmd = resolve_tool_command(
+            &settings,
+            "coder_cmd",
+            workspace_root,
+            workspace_scripts.join("coder.sh"),
+        );
 
         let resume = parse_flag(&settings, "resume");
 
@@ -171,6 +180,7 @@ impl BatchProjectConfig {
             evaluator_cmd,
             advisor_cmd,
             executor_cmd,
+            coder_cmd,
             pre_run_script,
             post_success_script,
             post_fail_script,


### PR DESCRIPTION
## Summary
Replaces the hardcoded `coder.sh` script path in batch mode with a configurable `coder_cmd` option, following the established pattern used for `evaluator_cmd`, `advisor_cmd`, and `executor_cmd`.

## Changes
- **Added `coder_cmd` field** to `BatchProjectConfig` struct
- **Updated batch command** to use configured path with fallback to default `.newton/scripts/coder.sh`
- **Enhanced init template** with commented examples for all script path configurations
- **Maintains backward compatibility** by defaulting to the original hardcoded path when not configured

## Technical Details
The implementation uses the existing `resolve_tool_command` function to:
- Check for user-configured `coder_cmd` in config file
- Support both absolute and relative paths (relative to project/workspace root)
- Fall back to default `.newton/scripts/coder.sh` if not specified

## Test Plan
- [x] Pre-commit checks passed (formatting, clippy, unit tests)
- [x] Pre-push checks passed (full test suite, documentation build)
- [x] All 64 unit tests passing
- [x] Code follows existing patterns for tool command configuration