### PR TITLE
feat(workflow): implement 017-b state, checkpoints, and artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1010,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1506,6 +1518,8 @@ dependencies = [
  "crossterm 0.28.1",
  "dirs-next",
  "futures",
+ "hex",
+ "humantime",
  "insta",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1522,6 +1536,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2444,6 +2459,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ serde_yaml = "0.9"
 rhai = "1.11"
 petgraph = "0.7"
 async-trait = "0.1"
+sha2 = "0.10"
+hex = "0.4.3"
+humantime = "2.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -116,6 +119,14 @@ path = "tests/workflow_graph/test_parse_and_validate.rs"
 [[test]]
 name = "test_workflow_scheduler"
 path = "tests/workflow_graph/test_scheduler.rs"
+
+[[test]]
+name = "test_workflow_checkpoints"
+path = "tests/workflow_graph/test_checkpoints.rs"
+
+[[test]]
+name = "test_workflow_artifacts"
+path = "tests/workflow_graph/test_artifacts.rs"
 
 [[test]]
 name = "test_profile_mode"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 use std::str::FromStr;
+use uuid::Uuid;
 
 #[derive(Args, Clone)]
 pub struct RunArgs {
@@ -110,6 +111,12 @@ pub enum WorkflowCommand {
     Validate(WorkflowValidateArgs),
     #[command(about = "Render workflow graph as DOT")]
     Dot(WorkflowDotArgs),
+    #[command(about = "Resume a previously-started workflow execution")]
+    Resume(WorkflowResumeArgs),
+    #[command(about = "Inspect workflow checkpoints")]
+    Checkpoints(WorkflowCheckpointsArgs),
+    #[command(about = "Manage workflow artifacts")]
+    Artifacts(WorkflowArtifactsArgs),
 }
 
 #[derive(Args, Clone)]
@@ -143,6 +150,62 @@ pub struct WorkflowDotArgs {
 
     #[arg(long, value_name = "FILE")]
     pub out: Option<PathBuf>,
+}
+
+#[derive(Args, Clone)]
+pub struct WorkflowResumeArgs {
+    #[arg(long, value_name = "UUID")]
+    pub execution_id: Uuid,
+
+    #[arg(long, value_name = "PATH")]
+    pub workspace: Option<PathBuf>,
+
+    #[arg(long)]
+    pub allow_workflow_change: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct WorkflowCheckpointsArgs {
+    #[command(subcommand)]
+    pub command: WorkflowCheckpointCommand,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum WorkflowCheckpointCommand {
+    #[command(about = "List workflow checkpoints")]
+    List {
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+
+        #[arg(long)]
+        format_json: bool,
+    },
+    #[command(about = "Clean historical checkpoints")]
+    Clean {
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+
+        #[arg(long, value_name = "DURATION")]
+        older_than: String,
+    },
+}
+
+#[derive(Args, Clone)]
+pub struct WorkflowArtifactsArgs {
+    #[command(subcommand)]
+    pub command: WorkflowArtifactCommand,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum WorkflowArtifactCommand {
+    #[command(about = "Clean artifact store files")]
+    Clean {
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+
+        #[arg(long, value_name = "DURATION")]
+        older_than: String,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/core/workflow_graph/artifacts.rs
+++ b/src/core/workflow_graph/artifacts.rs
@@ -1,0 +1,263 @@
+#![allow(clippy::result_large_err)] // Artifact store returns AppError to preserve structured diagnostic context; boxing would discard run-time state.
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use crate::core::workflow_graph::checkpoint;
+use crate::core::workflow_graph::schema::ArtifactStorageSettings;
+use crate::core::workflow_graph::state::{compute_sha256_hex, validate_task_id, OutputRef};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+pub struct ArtifactStore {
+    workspace_root: PathBuf,
+    artifact_root: PathBuf,
+    settings: ArtifactStorageSettings,
+}
+
+impl ArtifactStore {
+    pub fn new(workspace_root: PathBuf, settings: &ArtifactStorageSettings) -> Self {
+        let artifact_root = if settings.base_path.is_absolute() {
+            settings.base_path.clone()
+        } else {
+            workspace_root.join(&settings.base_path)
+        };
+        ArtifactStore {
+            workspace_root,
+            artifact_root,
+            settings: settings.clone(),
+        }
+    }
+
+    pub fn route_output(
+        &mut self,
+        execution_id: &Uuid,
+        task_id: &str,
+        run_seq: usize,
+        output: serde_json::Value,
+    ) -> Result<OutputRef, AppError> {
+        let serialized = serde_json::to_vec(&output)
+            .map_err(|err| internal_serialization_error("output", err))?;
+        let size = serialized.len() as u64;
+        if size <= self.settings.max_inline_bytes as u64 {
+            return Ok(OutputRef::Inline(output));
+        }
+        if size > self.settings.max_artifact_bytes as u64 {
+            return Err(AppError::new(
+                ErrorCategory::ArtifactError,
+                "operator output exceeds max_artifact_bytes limit",
+            )
+            .with_code("WFG-ART-002"));
+        }
+        self.ensure_capacity(size)?;
+        validate_task_id(task_id)?;
+        let artifact_path = self
+            .artifact_root
+            .join("workflows")
+            .join(execution_id.to_string())
+            .join("task")
+            .join(task_id)
+            .join(run_seq.to_string())
+            .join("output.json");
+        if !artifact_path.starts_with(&self.artifact_root) {
+            return Err(AppError::new(
+                ErrorCategory::ArtifactError,
+                "artifact path escapes base path",
+            )
+            .with_code("WFG-ART-001"));
+        }
+        let parent = artifact_path.parent().ok_or_else(|| {
+            AppError::new(
+                ErrorCategory::ArtifactError,
+                "invalid artifact path for output",
+            )
+            .with_code("WFG-ART-001")
+        })?;
+        fs::create_dir_all(parent).map_err(|err| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "failed to create artifact path {}: {}",
+                    parent.display(),
+                    err
+                ),
+            )
+        })?;
+        atomic_write(&artifact_path, &serialized)?;
+        let sha256 = compute_sha256_hex(&serialized);
+        let rel_path = artifact_path
+            .strip_prefix(&self.workspace_root)
+            .map_err(|_| {
+                AppError::new(
+                    ErrorCategory::ArtifactError,
+                    "artifact path is outside workspace",
+                )
+            })?
+            .to_path_buf();
+        Ok(OutputRef::Artifact {
+            path: rel_path,
+            size_bytes: size,
+            sha256,
+        })
+    }
+
+    fn ensure_capacity(&mut self, upcoming: u64) -> Result<(), AppError> {
+        let current = self.current_total_bytes()?;
+        if current + upcoming <= self.settings.max_total_bytes {
+            return Ok(());
+        }
+        let freed = self.cleanup(upcoming)?;
+        if current + upcoming - freed <= self.settings.max_total_bytes {
+            return Ok(());
+        }
+        Err(AppError::new(
+            ErrorCategory::ArtifactError,
+            "artifact store total size quota exceeded; cleanup could not free sufficient space",
+        )
+        .with_code("WFG-ART-003"))
+    }
+
+    fn current_total_bytes(&self) -> Result<u64, AppError> {
+        let files = collect_artifact_files(&self.artifact_root)?;
+        Ok(files.iter().map(|f| f.size).sum())
+    }
+
+    fn cleanup(&mut self, upcoming: u64) -> Result<u64, AppError> {
+        let max_total = self.settings.max_total_bytes;
+        let current = self.current_total_bytes()?;
+        if current + upcoming <= max_total {
+            return Ok(0);
+        }
+        let target = current + upcoming - max_total;
+        let mut files = collect_artifact_files(&self.artifact_root)?;
+        let retention = Duration::from_secs(self.settings.retention_hours * 3600);
+        let live = checkpoint::collect_live_artifact_paths(&self.workspace_root, retention)?;
+        files.sort_by_key(|f| f.modified);
+        let mut freed = 0;
+        for file in files {
+            let canonical = file
+                .path
+                .canonicalize()
+                .unwrap_or_else(|_| file.path.clone());
+            if live.contains(&canonical) {
+                continue;
+            }
+            if fs::remove_file(&file.path).is_ok() {
+                freed += file.size;
+            }
+            if freed >= target {
+                break;
+            }
+        }
+        Ok(freed)
+    }
+
+    pub fn clean_artifacts(workspace_root: &Path, older_than: Duration) -> Result<(), AppError> {
+        let settings = ArtifactStorageSettings::default();
+        let store = ArtifactStore::new(workspace_root.to_path_buf(), &settings);
+        let live = checkpoint::collect_live_artifact_paths(workspace_root, older_than)?;
+        let files = collect_artifact_files(&store.artifact_root)?;
+        for file in files {
+            if live.contains(
+                &file
+                    .path
+                    .canonicalize()
+                    .unwrap_or_else(|_| file.path.clone()),
+            ) {
+                continue;
+            }
+            if SystemTime::now()
+                .duration_since(file.modified)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                >= older_than
+            {
+                let _ = fs::remove_file(&file.path);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!("failed to create {}: {}", parent.display(), err),
+            )
+        })?;
+    }
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, data).map_err(|err| {
+        AppError::new(
+            ErrorCategory::IoError,
+            format!("failed to write {}: {}", tmp.display(), err),
+        )
+    })?;
+    fs::rename(&tmp, path).map_err(|err| {
+        AppError::new(
+            ErrorCategory::IoError,
+            format!(
+                "failed to rename {} -> {}: {}",
+                tmp.display(),
+                path.display(),
+                err
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+struct ArtifactFile {
+    path: PathBuf,
+    size: u64,
+    modified: SystemTime,
+}
+
+fn collect_artifact_files(base: &Path) -> Result<Vec<ArtifactFile>, AppError> {
+    let mut files = Vec::new();
+    if !base.exists() {
+        return Ok(files);
+    }
+    fn recurse(dir: &Path, files: &mut Vec<ArtifactFile>) -> Result<(), AppError> {
+        for entry in fs::read_dir(dir).map_err(|err| {
+            AppError::new(
+                ErrorCategory::IoError,
+                format!(
+                    "failed to read artifact directory {}: {}",
+                    dir.display(),
+                    err
+                ),
+            )
+        })? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                recurse(&path, files)?;
+                continue;
+            }
+            let metadata = entry.metadata().map_err(|err| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!("failed to stat artifact {}: {}", path.display(), err),
+                )
+            })?;
+            files.push(ArtifactFile {
+                path,
+                size: metadata.len(),
+                modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            });
+        }
+        Ok(())
+    }
+    recurse(base, &mut files)?;
+    Ok(files)
+}
+
+fn internal_serialization_error(target: &str, err: serde_json::Error) -> AppError {
+    AppError::new(
+        ErrorCategory::SerializationError,
+        format!("failed to serialize {}: {}", target, err),
+    )
+}

--- a/src/core/workflow_graph/checkpoint.rs
+++ b/src/core/workflow_graph/checkpoint.rs
@@ -1,0 +1,316 @@
+#![allow(clippy::result_large_err)] // Checkpoint module returns AppError to preserve structured diagnostic context; boxing would discard run-time state.
+
+use crate::core::error::AppError;
+use crate::core::workflow_graph::state::{
+    OutputRef, WorkflowCheckpoint, WorkflowExecution, WorkflowExecutionStatus,
+};
+use chrono::{DateTime, Utc};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+/// Paths under `.newton/state/workflows/<execution_id>`.
+pub struct WorkflowStatePaths {
+    pub execution_dir: PathBuf,
+    pub execution_file: PathBuf,
+    pub checkpoint_file: PathBuf,
+    pub checkpoints_dir: PathBuf,
+}
+
+impl WorkflowStatePaths {
+    pub fn new(workspace_root: &Path, execution_id: &Uuid) -> Self {
+        let base = workspace_root.join(".newton/state/workflows");
+        let execution_dir = base.join(execution_id.to_string());
+        let execution_file = execution_dir.join("execution.json");
+        let checkpoint_file = execution_dir.join("checkpoint.json");
+        let checkpoints_dir = execution_dir.join("checkpoints");
+        Self {
+            execution_dir,
+            execution_file,
+            checkpoint_file,
+            checkpoints_dir,
+        }
+    }
+
+    pub fn workspace_root(workspace_root: &Path) -> PathBuf {
+        workspace_root.join(".newton/state/workflows")
+    }
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            AppError::new(
+                crate::core::types::ErrorCategory::IoError,
+                format!("failed to create directory {}: {}", parent.display(), err),
+            )
+        })?;
+    }
+    let tmp_path = path.with_extension("tmp");
+    fs::write(&tmp_path, data).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!("failed to write {}: {}", tmp_path.display(), err),
+        )
+    })?;
+    fs::rename(&tmp_path, path).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!(
+                "failed to rename {} -> {}: {}",
+                tmp_path.display(),
+                path.display(),
+                err
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+pub fn save_execution(
+    workspace_root: &Path,
+    execution_id: &Uuid,
+    execution: &WorkflowExecution,
+) -> Result<(), AppError> {
+    let paths = WorkflowStatePaths::new(workspace_root, execution_id);
+    let content = serde_json::to_vec_pretty(execution).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::SerializationError,
+            format!("failed to serialize execution.json: {}", err),
+        )
+    })?;
+    atomic_write(&paths.execution_file, &content)
+}
+
+pub fn save_checkpoint(
+    workspace_root: &Path,
+    execution_id: &Uuid,
+    checkpoint: &WorkflowCheckpoint,
+    keep_history: bool,
+) -> Result<(), AppError> {
+    let paths = WorkflowStatePaths::new(workspace_root, execution_id);
+    let content = serde_json::to_vec_pretty(checkpoint).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::SerializationError,
+            format!("failed to serialize checkpoint.json: {}", err),
+        )
+    })?;
+    atomic_write(&paths.checkpoint_file, &content)?;
+    if keep_history {
+        if !paths.checkpoints_dir.exists() {
+            fs::create_dir_all(&paths.checkpoints_dir).map_err(|err| {
+                AppError::new(
+                    crate::core::types::ErrorCategory::IoError,
+                    format!(
+                        "failed to create checkpoints dir {}: {}",
+                        paths.checkpoints_dir.display(),
+                        err
+                    ),
+                )
+            })?;
+        }
+        let timestamp = checkpoint
+            .created_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+            .replace(':', "-");
+        let historic = paths
+            .checkpoints_dir
+            .join(format!("checkpoint-{}.json", timestamp));
+        atomic_write(&historic, &content)?;
+    }
+    Ok(())
+}
+
+pub fn load_execution(
+    workspace_root: &Path,
+    execution_id: &Uuid,
+) -> Result<WorkflowExecution, AppError> {
+    let paths = WorkflowStatePaths::new(workspace_root, execution_id);
+    let bytes = fs::read(&paths.execution_file).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!("failed to read {}: {}", paths.execution_file.display(), err),
+        )
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::SerializationError,
+            format!("failed to deserialize execution.json: {}", err),
+        )
+    })
+}
+
+pub fn load_checkpoint(
+    workspace_root: &Path,
+    execution_id: &Uuid,
+) -> Result<WorkflowCheckpoint, AppError> {
+    let paths = WorkflowStatePaths::new(workspace_root, execution_id);
+    let bytes = fs::read(&paths.checkpoint_file).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!(
+                "failed to read {}: {}",
+                paths.checkpoint_file.display(),
+                err
+            ),
+        )
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::SerializationError,
+            format!("failed to deserialize checkpoint.json: {}", err),
+        )
+    })
+}
+
+pub struct CheckpointSummary {
+    pub execution_id: Uuid,
+    pub status: WorkflowExecutionStatus,
+    pub started_at: DateTime<Utc>,
+    pub checkpoint_age: Duration,
+    pub checkpoint_size: u64,
+}
+
+pub fn list_checkpoints(workspace_root: &Path) -> Result<Vec<CheckpointSummary>, AppError> {
+    let mut entries = Vec::new();
+    let base = WorkflowStatePaths::workspace_root(workspace_root);
+    if !base.exists() {
+        return Ok(entries);
+    }
+    for entry in fs::read_dir(&base)
+        .map_err(|err| {
+            AppError::new(
+                crate::core::types::ErrorCategory::IoError,
+                format!("failed to list workflows state: {}", err),
+            )
+        })?
+        .flatten()
+    {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        if let Ok(uuid) = Uuid::parse_str(&entry.file_name().to_string_lossy()) {
+            if let (Ok(execution), Ok(metadata)) = (
+                load_execution(workspace_root, &uuid),
+                fs::metadata(
+                    WorkflowStatePaths::new(workspace_root, &uuid)
+                        .checkpoint_file
+                        .clone(),
+                ),
+            ) {
+                if let Ok(modified) = metadata.modified() {
+                    let now = SystemTime::now();
+                    let age = now
+                        .duration_since(modified)
+                        .unwrap_or_else(|_| Duration::from_secs(0));
+                    entries.push(CheckpointSummary {
+                        execution_id: uuid,
+                        status: execution.status,
+                        started_at: execution.started_at,
+                        checkpoint_age: age,
+                        checkpoint_size: metadata.len(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(entries)
+}
+
+pub fn clean_checkpoints(workspace_root: &Path, older_than: Duration) -> Result<(), AppError> {
+    let base = WorkflowStatePaths::workspace_root(workspace_root);
+    if !base.exists() {
+        return Ok(());
+    }
+    let now = SystemTime::now();
+    for entry in fs::read_dir(&base)
+        .map_err(|err| {
+            AppError::new(
+                crate::core::types::ErrorCategory::IoError,
+                format!("failed to list workflows state: {}", err),
+            )
+        })?
+        .flatten()
+    {
+        let checkpoints_dir = entry.path().join("checkpoints");
+        if !checkpoints_dir.is_dir() {
+            continue;
+        }
+        for item in fs::read_dir(&checkpoints_dir)
+            .map_err(|err| {
+                AppError::new(
+                    crate::core::types::ErrorCategory::IoError,
+                    format!("failed to scan checkpoints dir: {}", err),
+                )
+            })?
+            .flatten()
+        {
+            if let Ok(metadata) = item.metadata() {
+                if let Ok(modified) = metadata.modified() {
+                    if now
+                        .duration_since(modified)
+                        .unwrap_or_else(|_| Duration::from_secs(0))
+                        >= older_than
+                    {
+                        let _ = fs::remove_file(item.path());
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn collect_live_artifact_paths(
+    workspace_root: &Path,
+    retention: Duration,
+) -> Result<HashSet<PathBuf>, AppError> {
+    let mut live = HashSet::new();
+    let base = WorkflowStatePaths::workspace_root(workspace_root);
+    if !base.exists() {
+        return Ok(live);
+    }
+    let now = SystemTime::now();
+    for entry in fs::read_dir(&base)
+        .map_err(|err| {
+            AppError::new(
+                crate::core::types::ErrorCategory::IoError,
+                format!("failed to list workflows state: {}", err),
+            )
+        })?
+        .flatten()
+    {
+        let file_name = entry.file_name().to_string_lossy().to_string();
+        if let Ok(exec_id) = Uuid::parse_str(&file_name) {
+            let paths = WorkflowStatePaths::new(workspace_root, &exec_id);
+            let checkpoint_meta = match fs::metadata(&paths.checkpoint_file) {
+                Ok(meta) => meta,
+                Err(_) => continue,
+            };
+            let checkpoint_age = now
+                .duration_since(checkpoint_meta.modified().unwrap_or(SystemTime::UNIX_EPOCH))
+                .unwrap_or_else(|_| Duration::from_secs(0));
+            let execution_status = load_execution(workspace_root, &exec_id).map(|exec| exec.status);
+            let status_protect = matches!(
+                execution_status,
+                Ok(WorkflowExecutionStatus::Running | WorkflowExecutionStatus::Cancelled)
+            ) || checkpoint_age <= retention;
+            if !status_protect {
+                continue;
+            }
+            if let Ok(checkpoint) = load_checkpoint(workspace_root, &exec_id) {
+                for record in checkpoint.completed.values() {
+                    if let OutputRef::Artifact { path, .. } = &record.output_ref {
+                        let absolute = workspace_root.join(path);
+                        if let Ok(canonical) = absolute.canonicalize() {
+                            live.insert(canonical);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(live)
+}

--- a/src/core/workflow_graph/mod.rs
+++ b/src/core/workflow_graph/mod.rs
@@ -1,8 +1,11 @@
 //! Workflow graph execution support for Newton.
 
+pub mod artifacts;
+pub mod checkpoint;
 pub mod dot;
 pub mod executor;
 pub mod expression;
 pub mod operator;
 pub mod operators;
 pub mod schema;
+pub mod state;

--- a/src/core/workflow_graph/state.rs
+++ b/src/core/workflow_graph/state.rs
@@ -1,0 +1,306 @@
+#![allow(clippy::result_large_err)] // State module returns AppError to preserve structured diagnostic context; boxing would discard run-time state.
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use crate::core::workflow_graph::schema::WorkflowSettings;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Version embedded in persisted workflow execution files.
+pub const WORKFLOW_EXECUTION_FORMAT_VERSION: &str = "1";
+/// Version embedded in persisted workflow checkpoint files.
+pub const WORKFLOW_CHECKPOINT_FORMAT_VERSION: &str = "1";
+
+pub type GraphSettings = WorkflowSettings;
+/// Workflow execution metadata persisted under `.newton/state/workflows`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowExecution {
+    pub format_version: String,
+    pub execution_id: Uuid,
+    pub workflow_file: String,
+    pub workflow_version: String,
+    pub workflow_hash: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub status: WorkflowExecutionStatus,
+    pub settings_effective: GraphSettings,
+    #[serde(default)]
+    pub task_runs: Vec<WorkflowTaskRunSummary>,
+}
+
+/// Execution status enumeration for workflow graphs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkflowExecutionStatus {
+    #[default]
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl WorkflowExecutionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WorkflowExecutionStatus::Running => "Running",
+            WorkflowExecutionStatus::Completed => "Completed",
+            WorkflowExecutionStatus::Failed => "Failed",
+            WorkflowExecutionStatus::Cancelled => "Cancelled",
+        }
+    }
+}
+
+/// Workflow task status for persisted records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkflowTaskStatus {
+    Success,
+    Failed,
+    Skipped,
+}
+
+/// Lightweight per-task summary appended to `execution.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowTaskRunSummary {
+    pub task_id: String,
+    pub run_seq: usize,
+    pub status: WorkflowTaskStatus,
+    pub duration_ms: u64,
+    pub error_code: Option<String>,
+}
+
+/// Detailed run record stored in checkpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowTaskRunRecord {
+    pub task_id: String,
+    pub run_seq: usize,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+    pub status: WorkflowTaskStatus,
+    pub output_ref: OutputRef,
+    pub error: Option<AppErrorSummary>,
+}
+
+/// Simplified summary of errors persisted to disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppErrorSummary {
+    pub code: String,
+    pub category: String,
+    pub message: String,
+}
+
+/// Representation of operator output in checkpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum OutputRef {
+    Inline(Value),
+    Artifact {
+        path: PathBuf,
+        size_bytes: u64,
+        sha256: String,
+    },
+}
+
+impl OutputRef {
+    pub fn materialize(&self, workspace_root: &Path) -> Result<Value, AppError> {
+        match self {
+            OutputRef::Inline(value) => Ok(value.clone()),
+            OutputRef::Artifact { path, .. } => {
+                let absolute = workspace_root.join(path);
+                let bytes = fs::read(&absolute).map_err(|err| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!("failed to read artifact {}: {}", absolute.display(), err),
+                    )
+                })?;
+                serde_json::from_slice(&bytes).map_err(|err| {
+                    AppError::new(
+                        ErrorCategory::SerializationError,
+                        format!(
+                            "failed to deserialize artifact {}: {}",
+                            absolute.display(),
+                            err
+                        ),
+                    )
+                })
+            }
+        }
+    }
+}
+
+/// Workflow checkpoint persisted to `checkpoint.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowCheckpoint {
+    pub format_version: String,
+    pub execution_id: Uuid,
+    pub workflow_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub ready_queue: Vec<String>,
+    pub context: Value,
+    pub task_iterations: HashMap<String, usize>,
+    pub total_iterations: usize,
+    pub completed: HashMap<String, WorkflowTaskRunRecord>,
+}
+
+impl WorkflowCheckpoint {
+    pub fn new(
+        execution_id: Uuid,
+        workflow_hash: String,
+        context: Value,
+        ready_queue: Vec<String>,
+        task_iterations: HashMap<String, usize>,
+        total_iterations: usize,
+        completed: HashMap<String, WorkflowTaskRunRecord>,
+    ) -> Self {
+        WorkflowCheckpoint {
+            format_version: WORKFLOW_CHECKPOINT_FORMAT_VERSION.to_string(),
+            execution_id,
+            workflow_hash,
+            created_at: Utc::now(),
+            ready_queue,
+            context,
+            task_iterations,
+            total_iterations,
+            completed,
+        }
+    }
+}
+
+impl WorkflowTaskStatus {
+    pub fn from_execution(status: crate::core::workflow_graph::executor::TaskStatus) -> Self {
+        match status {
+            crate::core::workflow_graph::executor::TaskStatus::Success => {
+                WorkflowTaskStatus::Success
+            }
+            crate::core::workflow_graph::executor::TaskStatus::Failed => WorkflowTaskStatus::Failed,
+            crate::core::workflow_graph::executor::TaskStatus::Skipped => {
+                WorkflowTaskStatus::Skipped
+            }
+        }
+    }
+}
+
+impl From<WorkflowTaskRunRecord> for WorkflowTaskRunSummary {
+    fn from(record: WorkflowTaskRunRecord) -> Self {
+        WorkflowTaskRunSummary {
+            task_id: record.task_id,
+            run_seq: record.run_seq,
+            status: record.status,
+            duration_ms: record
+                .completed_at
+                .signed_duration_since(record.started_at)
+                .num_milliseconds() as u64,
+            error_code: record.error.as_ref().map(|err| err.code.clone()),
+        }
+    }
+}
+
+impl WorkflowTaskStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WorkflowTaskStatus::Success => "success",
+            WorkflowTaskStatus::Failed => "failed",
+            WorkflowTaskStatus::Skipped => "skipped",
+        }
+    }
+}
+
+/// Redact sensitive keys in the given JSON value.
+pub fn redact_value(value: &mut Value, redact_keys: &[String]) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if should_redact(key, redact_keys) {
+                    *child = Value::String("[REDACTED]".to_string());
+                    continue;
+                }
+                redact_value(child, redact_keys);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_value(item, redact_keys);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn should_redact(key: &str, redact_keys: &[String]) -> bool {
+    let key_lower = key.to_lowercase();
+    for pattern in redact_keys {
+        if key_lower.contains(&pattern.to_lowercase()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Create a redacted summary of an AppError.
+pub fn summarize_error(error: &AppError, redact_keys: &[String]) -> AppErrorSummary {
+    let mut message = error.message.clone();
+    for pattern in redact_keys {
+        if error
+            .context
+            .get("context")
+            .map(|ctx| ctx.to_lowercase().contains(&pattern.to_lowercase()))
+            .unwrap_or(false)
+        {
+            message = "[REDACTED]".to_string();
+            break;
+        }
+    }
+    AppErrorSummary {
+        code: error.code.clone(),
+        category: format!("{:?}", error.category),
+        message,
+    }
+}
+
+/// Compute the SHA-256 hash encoded as lowercase hex.
+pub fn compute_sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// Determine if a task_id is valid for filesystem paths.
+pub fn validate_task_id(task_id: &str) -> Result<(), AppError> {
+    if task_id.contains('/') || task_id.contains('\\') || task_id.contains("..") {
+        return Err(AppError::new(
+            ErrorCategory::ValidationError,
+            "task_id contains invalid characters for filesystem use",
+        )
+        .with_code("WFG-ART-001"));
+    }
+    if !task_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(AppError::new(
+            ErrorCategory::ValidationError,
+            "task_id contains invalid characters for filesystem use",
+        )
+        .with_code("WFG-ART-001"));
+    }
+    Ok(())
+}
+
+/// Build the canonical absolute workflow file path.
+pub fn canonicalize_workflow_path(path: &Path) -> Result<PathBuf, AppError> {
+    path.canonicalize().map_err(|err| {
+        AppError::new(
+            ErrorCategory::IoError,
+            format!(
+                "failed to canonicalize workflow path {}: {}",
+                path.display(),
+                err
+            ),
+        )
+    })
+}

--- a/tests/workflow_graph/test_artifacts.rs
+++ b/tests/workflow_graph/test_artifacts.rs
@@ -1,0 +1,95 @@
+use newton::core::workflow_graph::artifacts::ArtifactStore;
+use newton::core::workflow_graph::schema::{ArtifactCleanupPolicy, ArtifactStorageSettings};
+use newton::core::workflow_graph::state::compute_sha256_hex;
+use newton::core::workflow_graph::state::OutputRef;
+use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+fn default_settings() -> ArtifactStorageSettings {
+    ArtifactStorageSettings {
+        base_path: PathBuf::from(".newton/artifacts"),
+        max_inline_bytes: 1 << 10,
+        max_artifact_bytes: 1 << 20,
+        max_total_bytes: 1 << 22,
+        retention_hours: 168,
+        cleanup_policy: ArtifactCleanupPolicy::Lru,
+    }
+}
+
+#[test]
+fn inline_outputs_stay_inline() {
+    let workspace = tempdir().expect("workspace");
+    let mut settings = default_settings();
+    settings.max_inline_bytes = 1024;
+    let mut store = ArtifactStore::new(workspace.path().to_path_buf(), &settings);
+    let execution_id = Uuid::new_v4();
+    let output = json!({"value": "small"});
+    match store
+        .route_output(&execution_id, "task_one", 1, output.clone())
+        .expect("success")
+    {
+        OutputRef::Inline(value) => assert_eq!(value, output),
+        other => panic!("expected inline, got {:?}", other),
+    }
+}
+
+#[test]
+fn large_outputs_route_to_artifacts() {
+    let workspace = tempdir().expect("workspace");
+    let mut settings = default_settings();
+    settings.max_inline_bytes = 1;
+    let mut store = ArtifactStore::new(workspace.path().to_path_buf(), &settings);
+    let execution_id = Uuid::new_v4();
+    let payload = json!({"value": "{}", "repeat": 200});
+    if let OutputRef::Artifact {
+        path,
+        size_bytes,
+        sha256,
+    } = store
+        .route_output(&execution_id, "task_big", 1, payload.clone())
+        .expect("artifact")
+    {
+        assert!(size_bytes > settings.max_inline_bytes as u64);
+        let artifact_path = workspace.path().join(&path);
+        let bytes = fs::read(&artifact_path).expect("artifact file");
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+        assert_eq!(parsed, payload);
+        assert_eq!(sha256, compute_sha256_hex(&bytes));
+    } else {
+        panic!("expected artifact output");
+    }
+}
+
+#[test]
+fn output_exceeding_artifact_limit_errors() {
+    let workspace = tempdir().expect("workspace");
+    let mut settings = default_settings();
+    settings.max_inline_bytes = 1;
+    settings.max_artifact_bytes = 4;
+    let mut store = ArtifactStore::new(workspace.path().to_path_buf(), &settings);
+    let execution_id = Uuid::new_v4();
+    let payload = json!({"value": "{}", "repeat": 200});
+    let err = store
+        .route_output(&execution_id, "task_big", 1, payload)
+        .expect_err("too large")
+        .code;
+    assert_eq!(err, "WFG-ART-002");
+}
+
+#[test]
+fn invalid_task_id_rejected() {
+    let workspace = tempdir().expect("workspace");
+    let mut settings = default_settings();
+    settings.max_inline_bytes = 1;
+    let mut store = ArtifactStore::new(workspace.path().to_path_buf(), &settings);
+    let execution_id = Uuid::new_v4();
+    let payload = json!({"value": "ok"});
+    let err = store
+        .route_output(&execution_id, "../escape", 1, payload)
+        .expect_err("invalid task id")
+        .code;
+    assert_eq!(err, "WFG-ART-001");
+}

--- a/tests/workflow_graph/test_checkpoints.rs
+++ b/tests/workflow_graph/test_checkpoints.rs
@@ -1,0 +1,194 @@
+use newton::core::workflow_graph::{
+    executor::{self, ExecutionOverrides},
+    operator::OperatorRegistry,
+    operators, schema,
+};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::{tempdir, NamedTempFile};
+
+const RESUME_WORKFLOW: &str = r#"
+version: 2.0
+mode: workflow_graph
+workflow:
+  context: {}
+  settings:
+    entry_task: first
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 5
+    max_workflow_iterations: 10
+  tasks:
+    - id: first
+      operator: NoOpOperator
+      params: {}
+      transitions:
+        - to: second
+          when:
+            $expr: "true"
+    - id: second
+      operator: NoOpOperator
+      params: {}
+      transitions:
+        - to: done
+          when:
+            $expr: "true"
+    - id: done
+      operator: NoOpOperator
+      params: {}
+"#;
+
+fn build_registry(workspace: PathBuf) -> OperatorRegistry {
+    let mut builder = OperatorRegistry::builder();
+    operators::register_builtins(&mut builder, workspace);
+    builder.build()
+}
+
+fn write_workflow(yaml: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("temp file");
+    write!(file, "{}", yaml).unwrap();
+    file
+}
+
+fn read_json(path: &Path) -> Value {
+    let bytes = fs::read(path).expect("read file");
+    serde_json::from_slice(&bytes).expect("parse json")
+}
+
+fn write_json(path: &Path, value: &Value) {
+    let bytes = serde_json::to_vec_pretty(value).expect("serialize json");
+    fs::write(path, bytes).expect("write file");
+}
+
+#[tokio::test]
+async fn resume_skips_completed_tasks() {
+    let workspace = tempdir().expect("workspace");
+    let workflow_file = write_workflow(RESUME_WORKFLOW);
+    let document = schema::load_workflow(workflow_file.path()).expect("valid workflow");
+    let registry = build_registry(workspace.path().to_path_buf());
+    let overrides = ExecutionOverrides {
+        parallel_limit: None,
+        max_time_seconds: None,
+    };
+
+    let summary = executor::execute_workflow(
+        document,
+        workflow_file.path().to_path_buf(),
+        registry.clone(),
+        workspace.path().to_path_buf(),
+        overrides,
+    )
+    .await
+    .expect("first run succeeded");
+
+    let state_dir = workspace
+        .path()
+        .join(".newton")
+        .join("state")
+        .join("workflows")
+        .join(summary.execution_id.to_string());
+    let execution_path = state_dir.join("execution.json");
+    let checkpoint_path = state_dir.join("checkpoint.json");
+
+    let mut execution_value = read_json(&execution_path);
+    if let Some(array) = execution_value
+        .get_mut("task_runs")
+        .and_then(Value::as_array_mut)
+    {
+        let filtered: Vec<Value> = array
+            .iter()
+            .filter(|entry| entry["task_id"] == "first")
+            .cloned()
+            .collect();
+        *array = filtered;
+    }
+    execution_value["status"] = Value::String("Running".to_string());
+    execution_value["completed_at"] = Value::Null;
+    write_json(&execution_path, &execution_value);
+
+    let mut checkpoint_value = read_json(&checkpoint_path);
+    if let Some(map) = checkpoint_value.as_object_mut() {
+        map.insert("ready_queue".to_string(), json!(["second"]));
+        map.insert("task_iterations".to_string(), json!({"first": 1}));
+        map.insert("total_iterations".to_string(), json!(1));
+        if let Some(completed) = map.get_mut("completed").and_then(Value::as_object_mut) {
+            completed.retain(|key, _| key == "first");
+        }
+    }
+    write_json(&checkpoint_path, &checkpoint_value);
+
+    let resume_registry = build_registry(workspace.path().to_path_buf());
+    let resume_summary = executor::resume_workflow(
+        resume_registry,
+        workspace.path().to_path_buf(),
+        summary.execution_id,
+        false,
+    )
+    .await
+    .expect("resume succeeded");
+
+    assert!(resume_summary.total_iterations >= 3);
+    let execution_value = read_json(&execution_path);
+    let task_runs = execution_value["task_runs"]
+        .as_array()
+        .expect("task runs present");
+    let ids: HashSet<_> = task_runs
+        .iter()
+        .map(|entry| entry["task_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids.len(), 3);
+    assert!(ids.contains("first"));
+    assert!(ids.contains("second"));
+    assert!(ids.contains("done"));
+    assert_eq!(
+        execution_value["status"],
+        Value::String("Completed".to_string())
+    );
+
+    let checkpoint_value = read_json(&checkpoint_path);
+    let completed = checkpoint_value["completed"]
+        .as_object()
+        .expect("completed map");
+    assert_eq!(completed.len(), 3);
+}
+
+#[tokio::test]
+async fn resume_hash_mismatch_blocks_resume() {
+    let workspace = tempdir().expect("workspace");
+    let workflow_file = write_workflow(RESUME_WORKFLOW);
+    let document = schema::load_workflow(workflow_file.path()).expect("valid workflow");
+    let registry = build_registry(workspace.path().to_path_buf());
+    let overrides = ExecutionOverrides {
+        parallel_limit: None,
+        max_time_seconds: None,
+    };
+
+    let summary = executor::execute_workflow(
+        document,
+        workflow_file.path().to_path_buf(),
+        registry.clone(),
+        workspace.path().to_path_buf(),
+        overrides,
+    )
+    .await
+    .expect("first run succeeded");
+
+    let mut contents = fs::read_to_string(workflow_file.path()).expect("read workflow");
+    contents.push('\n');
+    fs::write(workflow_file.path(), contents).expect("rewrite workflow");
+
+    let resume_registry = build_registry(workspace.path().to_path_buf());
+    let err = executor::resume_workflow(
+        resume_registry,
+        workspace.path().to_path_buf(),
+        summary.execution_id,
+        false,
+    )
+    .await
+    .expect_err("hash mismatch should fail");
+    assert_eq!(err.code, "WFG-CKPT-001");
+}

--- a/tests/workflow_graph/test_scheduler.rs
+++ b/tests/workflow_graph/test_scheduler.rs
@@ -155,9 +155,15 @@ async fn transitions_deduplicate_targets_per_tick() {
         max_time_seconds: Some(60),
     };
 
-    let summary = executor::execute_workflow(document, registry, workspace, overrides)
-        .await
-        .expect("execution succeeded");
+    let summary = executor::execute_workflow(
+        document,
+        file.path().to_path_buf(),
+        registry,
+        workspace,
+        overrides,
+    )
+    .await
+    .expect("execution succeeded");
     let done = summary
         .completed_tasks
         .get("done")
@@ -177,7 +183,14 @@ async fn loop_exhausts_iteration_limit() {
         max_time_seconds: Some(60),
     };
 
-    let result = executor::execute_workflow(document, registry, workspace, overrides).await;
+    let result = executor::execute_workflow(
+        document,
+        file.path().to_path_buf(),
+        registry,
+        workspace,
+        overrides,
+    )
+    .await;
     let err = result.expect_err("should hit iteration limit");
     assert_eq!(err.code, "WFG-ITER-002");
 }
@@ -194,9 +207,15 @@ async fn higher_priority_transition_wins() {
         max_time_seconds: Some(60),
     };
 
-    let summary = executor::execute_workflow(document, registry, workspace, overrides)
-        .await
-        .expect("execution succeeded");
+    let summary = executor::execute_workflow(
+        document,
+        file.path().to_path_buf(),
+        registry,
+        workspace,
+        overrides,
+    )
+    .await
+    .expect("execution succeeded");
     // priority=1 beats priority=10; high_prio_target runs, low_prio_target does not.
     assert!(summary.completed_tasks.contains_key("high_prio_target"));
     assert!(!summary.completed_tasks.contains_key("low_prio_target"));
@@ -214,7 +233,14 @@ async fn workflow_exhausts_global_iteration_limit() {
         max_time_seconds: Some(60),
     };
 
-    let result = executor::execute_workflow(document, registry, workspace, overrides).await;
+    let result = executor::execute_workflow(
+        document,
+        file.path().to_path_buf(),
+        registry,
+        workspace,
+        overrides,
+    )
+    .await;
     let err = result.expect_err("should hit global iteration limit");
     assert_eq!(err.code, "WFG-ITER-001");
 }


### PR DESCRIPTION
Add crash-safe checkpointing and artifact storage for workflow-graph executions:

- WorkflowExecution + WorkflowCheckpoint entities persisted under .newton/state/workflows/<id>/
- Atomic checkpoint writes (write .tmp then rename) prevent corrupt files on abrupt termination
- Historical checkpoints optional (checkpoint_keep_history, default false)
- Artifact routing: inline when <= max_inline_bytes, else .newton/artifacts/; WFG-ART-001/002/003 error codes
- Path traversal defense on task_id (allow [a-zA-Z0-9_-] only)
- Secret redaction before persist (configurable redact_keys)
- Resume from checkpoint: hash mismatch blocked by WFG-CKPT-001; --allow-workflow-change escape hatch still enforces schema version
- CLI: workflow resume, workflow checkpoints list/clean, workflow artifacts clean
- Dependencies: sha2, hex, humantime added to Cargo.toml
- Tests: B1-B5 scenario coverage (checkpoint save, resume correctness, hash mismatch, artifact routing, path traversal)