### PR TITLE
feat(workflow): add --arg trigger payload overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "newton"
-version = "0.5.33"
+version = "0.5.34"
 dependencies = [
  "aikit-sdk",
  "anyhow",

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -169,6 +169,10 @@ pub struct WorkflowRunArgs {
     #[arg(long, value_name = "PATH")]
     pub trigger_json: Option<PathBuf>,
 
+    /// Trigger payload override in KEY=VALUE form (supports VALUE=@path)
+    #[arg(long, value_name = "KEY=VALUE")]
+    pub arg: Vec<KeyValuePair>,
+
     #[arg(long, value_name = "KEY=VALUE")]
     pub set: Vec<KeyValuePair>,
 
@@ -205,6 +209,10 @@ pub struct WorkflowExplainArgs {
 
     #[arg(long, value_name = "KEY=VALUE")]
     pub set: Vec<KeyValuePair>,
+
+    /// Trigger payload override in KEY=VALUE form (supports VALUE=@path)
+    #[arg(long, value_name = "KEY=VALUE")]
+    pub arg: Vec<KeyValuePair>,
 
     #[arg(long, value_enum, default_value = "text")]
     pub format: OutputFormat,


### PR DESCRIPTION
## Summary
- add repeatable `--arg KEY=VALUE` for `newton workflow run` and `newton workflow explain`
- merge trigger payload as: `--trigger-json` base, then `--arg` overrides in order (last wins)
- support `@path` values to load UTF-8 text from a file for trigger args
- support `@@...` escape for literal values beginning with `@`
- add unit tests for merge order, file loading, literal escape, and error paths

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`