### PR TITLE
feat(cli): improve help text and coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "newton"
-version = "0.5.49"
+version = "0.5.50"
 dependencies = [
  "aikit-sdk",
  "anyhow",

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Newton Test Runner Script
-# Runs tests with cargo-nextest, captures results, and emits report to stdout (text or JSON).
+# Runs fmt check, clippy, then tests with cargo-nextest; captures results and emits report to stdout (text or JSON).
 #
 # Usage: ./run-tests.sh [OPTIONS]
 #
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             echo "Newton Test Runner Script"
             echo ""
-            echo "Runs tests with cargo-nextest, captures results, and emits report to stdout (text or JSON)."
+            echo "Runs fmt check, clippy, then tests with cargo-nextest; captures results and emits report to stdout (text or JSON)."
             echo ""
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -112,6 +112,23 @@ NEWTON_DIR="$(dirname "$SCRIPT_DIR")"
 
 echo -e "${YELLOW}Running tests in: $NEWTON_DIR${NC}" >&2
 cd "$NEWTON_DIR"
+
+# Disable incremental compilation in CI/sandboxed environments where hard-linking
+# the incremental cache can fail across mount points.
+export CARGO_INCREMENTAL=0
+# Keep Cargo artifacts on a single filesystem to avoid cross-device link errors.
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/tmp/newton-target}"
+mkdir -p "$CARGO_TARGET_DIR/tmp"
+export TMPDIR="$CARGO_TARGET_DIR/tmp"
+
+# Run format check (match pre-commit)
+echo -e "${YELLOW}Running cargo fmt --check...${NC}" >&2
+if ! cargo fmt --check 2>&1; then
+    echo -e "${RED}Format check failed. Run 'cargo fmt' to fix.${NC}" >&2
+    exit 1
+fi
+echo -e "${GREEN}Format check passed.${NC}" >&2
+echo "" >&2
 
 # Run clippy linter to check code quality
 echo -e "${YELLOW}Running clippy linter...${NC}" >&2

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -63,9 +63,9 @@ pub struct WebhookArgs {
 
 #[derive(Subcommand, Clone)]
 pub enum WebhookCommand {
-    #[command(about = "Serve a webhook listener")]
+    #[command(about = "Start an HTTP server to receive webhook events and trigger workflows")]
     Serve(WebhookServeArgs),
-    #[command(about = "Show webhook configuration status")]
+    #[command(about = "Display webhook endpoint configuration and server status")]
     Status(WebhookStatusArgs),
 }
 
@@ -246,7 +246,7 @@ pub struct CheckpointsArgs {
 
 #[derive(Subcommand, Clone)]
 pub enum CheckpointCommand {
-    #[command(about = "List workflow checkpoints")]
+    #[command(about = "Display available workflow executions and their checkpoint details")]
     List {
         #[arg(long, value_name = "PATH")]
         workspace: Option<PathBuf>,
@@ -254,7 +254,7 @@ pub enum CheckpointCommand {
         #[arg(long)]
         format_json: bool,
     },
-    #[command(about = "Clean historical checkpoints")]
+    #[command(about = "Remove old checkpoint files to free up disk space")]
     Clean {
         #[arg(long, value_name = "PATH")]
         workspace: Option<PathBuf>,
@@ -272,7 +272,7 @@ pub struct ArtifactsArgs {
 
 #[derive(Subcommand, Clone)]
 pub enum ArtifactCommand {
-    #[command(about = "Clean artifact store files")]
+    #[command(about = "Remove old workflow output files and execution artifacts")]
     Clean {
         #[arg(long, value_name = "PATH")]
         workspace: Option<PathBuf>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -86,42 +86,187 @@ or manually create .newton/configs/ and add a monitor.conf file."
     Monitor(MonitorArgs),
     #[command(
         about = "Validate a workflow graph definition",
-        after_help = "Example:\n    newton validate workflow.yaml"
+        long_about = "Validate checks your workflow YAML file for syntax errors, schema compliance, and logical issues before execution.\n\n\
+This command performs comprehensive validation including:\n  \
+  • YAML syntax and structure validation\n  \
+  • Schema compliance checking\n  \
+  • Task dependency validation\n  \
+  • Resource and configuration verification\n\n\
+Use validate before running workflows to catch errors early and ensure your workflow will execute successfully.",
+        after_help = "EXAMPLES:\n  \
+Validate a workflow file:\n    \
+newton validate workflow.yaml\n\n  \
+Validate with alternative syntax:\n    \
+newton validate --file ./workflows/my-workflow.yaml\n\n\
+RETURN CODES:\n  \
+  0: Workflow is valid and ready to run\n  \
+  1: Validation errors found (details printed to stderr)"
     )]
     Validate(ValidateArgs),
     #[command(
-        about = "Render workflow graph as DOT",
-        after_help = "Example:\n    newton dot workflow.yaml --out graph.dot"
+        about = "Generate a visual diagram of the workflow graph",
+        long_about = "Dot creates a Graphviz DOT file from your workflow definition that can be rendered into visual diagrams.\n\n\
+This command analyzes your workflow's task dependencies and generates a directed graph showing:\n  \
+  • Task execution flow and dependencies\n  \
+  • Parallel execution opportunities\n  \
+  • Critical path through the workflow\n  \
+  • Task relationships and data flow\n\n\
+The output DOT file can be rendered to PNG, SVG, or PDF using Graphviz tools like 'dot' or online viewers.",
+        after_help = "EXAMPLES:\n  \
+Generate DOT file to stdout:\n    \
+newton dot workflow.yaml\n\n  \
+Save DOT file for rendering:\n    \
+newton dot workflow.yaml --out graph.dot\n\n  \
+Create PNG diagram (requires Graphviz):\n    \
+newton dot workflow.yaml --out graph.dot && dot -Tpng graph.dot -o workflow.png\n\n\
+VISUALIZATION:\n  \
+Use online Graphviz viewers or install Graphviz locally:\n  \
+  • Online: https://dreampuf.github.io/GraphvizOnline/\n  \
+  • Install: apt install graphviz (Ubuntu) or brew install graphviz (macOS)"
     )]
     Dot(DotArgs),
     #[command(
-        about = "Validate workflow lint rules",
-        after_help = "Example:\n    newton lint workflow.yaml --format json"
+        about = "Check workflow for best practices and potential issues",
+        long_about = "Lint analyzes your workflow definition against Newton's best practices and coding standards to identify potential issues.\n\n\
+This command performs static analysis checking for:\n  \
+  • Performance anti-patterns\n  \
+  • Resource usage optimization opportunities\n  \
+  • Security considerations\n  \
+  • Maintainability issues\n  \
+  • Common workflow design mistakes\n\n\
+Unlike validate (which checks syntax), lint focuses on quality and best practices. All lint warnings are advisory and won't prevent workflow execution.",
+        after_help = "EXAMPLES:\n  \
+Check workflow with human-readable output:\n    \
+newton lint workflow.yaml\n\n  \
+Generate JSON report for CI/CD integration:\n    \
+newton lint workflow.yaml --format json\n\n  \
+Lint with alternative file specification:\n    \
+newton lint --file ./workflows/production.yaml --format json\n\n\
+OUTPUT FORMATS:\n  \
+  • text: Human-readable summary (default)\n  \
+  • json: Machine-readable structured data for tooling integration"
     )]
     Lint(LintArgs),
     #[command(
-        about = "Explain workflow graph settings/transitions",
-        after_help = "Example:\n    newton explain workflow.yaml --format text\n    newton explain workflow.yaml --format prose"
+        about = "Generate human-readable explanations of workflow behavior",
+        long_about = "Explain creates detailed documentation about what your workflow does and how it will execute.\n\n\
+This command analyzes your workflow definition and produces explanations covering:\n  \
+  • Step-by-step execution flow\n  \
+  • Task dependencies and timing\n  \
+  • Configuration settings and their effects\n  \
+  • Resource requirements and constraints\n  \
+  • Expected inputs and outputs\n\n\
+Use this command to understand complex workflows, document your automation, or verify that your workflow behaves as intended.",
+        after_help = "EXAMPLES:\n  \
+Generate structured explanation:\n    \
+newton explain workflow.yaml --format text\n\n  \
+Create natural language description:\n    \
+newton explain workflow.yaml --format prose\n\n  \
+Explain with custom trigger data:\n    \
+newton explain workflow.yaml --arg env=production --format prose\n\n  \
+Generate JSON explanation for documentation tools:\n    \
+newton explain workflow.yaml --format json\n\n\
+OUTPUT FORMATS:\n  \
+  • text: Structured technical breakdown\n  \
+  • prose: Natural language description\n  \
+  • json: Machine-readable analysis for documentation generation"
     )]
     Explain(ExplainArgs),
     #[command(
-        about = "Resume a previously-started workflow execution",
-        after_help = "Example:\n    newton resume --execution-id 12345678-1234-1234-1234-123456789abc"
+        about = "Continue a workflow that was interrupted or stopped",
+        long_about = "Resume restarts a workflow execution from its last saved checkpoint, allowing you to continue from where it left off.\n\n\
+This command is useful when:\n  \
+  • A workflow was interrupted by system shutdown or network issues\n  \
+  • You need to modify execution parameters and continue\n  \
+  • A long-running workflow needs to be restarted after maintenance\n  \
+  • You want to debug a failed workflow by resuming from a specific point\n\n\
+Newton automatically creates checkpoints during execution, so you can safely resume most workflows without losing progress.",
+        after_help = "EXAMPLES:\n  \
+Resume a specific workflow execution:\n    \
+newton resume --execution-id 12345678-1234-1234-1234-123456789abc\n\n  \
+Resume with custom workspace:\n    \
+newton resume --execution-id abcdef01-2345-6789-abcd-ef0123456789 --workspace ./project\n\n  \
+Resume and allow workflow definition changes:\n    \
+newton resume --execution-id 12345678-1234-1234-1234-123456789abc --allow-workflow-change\n\n\
+FINDING EXECUTION IDs:\n  \
+List available executions to resume:\n    \
+newton checkpoints list --workspace ./workspace\n\n\
+SAFETY:\n  \
+By default, resume requires the workflow definition to be unchanged since the checkpoint.\n  \
+Use --allow-workflow-change to override this safety check if you've modified the workflow."
     )]
     Resume(ResumeArgs),
     #[command(
-        about = "Inspect workflow checkpoints",
-        after_help = "Example:\n    newton checkpoints list --workspace ./workspace"
+        about = "Manage and inspect workflow execution checkpoints",
+        long_about = "Checkpoints provides tools to manage the saved states that allow workflow resumption after interruption.\n\n\
+Newton automatically creates checkpoints during workflow execution to preserve progress and enable recovery. This command helps you:\n  \
+  • View available executions that can be resumed\n  \
+  • Clean up old checkpoint data to save disk space\n  \
+  • Inspect checkpoint details for debugging\n  \
+  • Monitor checkpoint storage usage\n\n\
+Checkpoints include execution state, task progress, and all necessary context to safely resume workflows.",
+        after_help = "EXAMPLES:\n  \
+List all available checkpoints:\n    \
+newton checkpoints list --workspace ./workspace\n\n  \
+Get checkpoint details in JSON format:\n    \
+newton checkpoints list --workspace ./workspace --format-json\n\n  \
+Clean old checkpoints (older than 7 days):\n    \
+newton checkpoints clean --workspace ./workspace --older-than 7d\n\n  \
+Clean checkpoints with custom retention:\n    \
+newton checkpoints clean --workspace ./workspace --older-than 30d\n\n\
+CHECKPOINT STORAGE:\n  \
+Checkpoints are stored in .newton/checkpoints/ within your workspace.\n  \
+Large workflows may generate substantial checkpoint data over time."
     )]
     Checkpoints(CheckpointsArgs),
     #[command(
-        about = "Manage workflow artifacts",
-        after_help = "Example:\n    newton artifacts clean --workspace ./workspace --older-than 7d"
+        about = "Manage workflow output files and execution artifacts",
+        long_about = "Artifacts provides tools to manage the files, logs, and output data generated during workflow execution.\n\n\
+Newton stores workflow outputs, logs, and temporary files as artifacts for debugging and analysis. This command helps you:\n  \
+  • Clean up old artifacts to reclaim disk space\n  \
+  • Manage artifact retention policies\n  \
+  • Monitor artifact storage usage\n  \
+  • Archive important execution results\n\n\
+Artifacts include task outputs, execution logs, intermediate files, and any data generated by your workflow tasks.",
+        after_help = "EXAMPLES:\n  \
+Clean artifacts older than 7 days:\n    \
+newton artifacts clean --workspace ./workspace --older-than 7d\n\n  \
+Clean with custom retention period:\n    \
+newton artifacts clean --workspace ./workspace --older-than 30d\n\n  \
+Clean artifacts in specific workspace:\n    \
+newton artifacts clean --workspace /path/to/project --older-than 1w\n\n\
+RETENTION FORMATS:\n  \
+Supported time formats for --older-than:\n  \
+  • Days: 7d, 30d\n  \
+  • Weeks: 1w, 2w\n  \
+  • Hours: 24h, 48h\n\n\
+ARTIFACT STORAGE:\n  \
+Artifacts are stored in .newton/artifacts/ within your workspace.\n  \
+Regular cleanup helps maintain good performance and disk usage."
     )]
     Artifacts(ArtifactsArgs),
     #[command(
-        about = "Manage workflow webhook listener",
-        after_help = "Example:\n    newton webhook serve workflow.yaml --workspace ./workspace"
+        about = "Run webhooks to trigger workflows from external events",
+        long_about = "Webhook provides HTTP endpoints that can trigger workflow executions in response to external events.\n\n\
+This command enables integration with:\n  \
+  • Git hosting services (GitHub, GitLab, Bitbucket)\n  \
+  • CI/CD platforms and build systems\n  \
+  • Monitoring and alerting systems\n  \
+  • Custom applications and services\n\n\
+Webhooks allow you to automate workflow execution based on external triggers, creating reactive automation pipelines.",
+        after_help = "EXAMPLES:\n  \
+Start webhook server for a workflow:\n    \
+newton webhook serve workflow.yaml --workspace ./workspace\n\n  \
+Check webhook configuration status:\n    \
+newton webhook status workflow.yaml --workspace ./workspace\n\n  \
+Serve webhook with alternative file syntax:\n    \
+newton webhook serve --file ./workflows/deploy.yaml --workspace ./project\n\n\
+INTEGRATION:\n  \
+Configure your external services to send POST requests to the webhook URL.\n  \
+The webhook server will parse the incoming payload and trigger the workflow with the event data.\n\n\
+SECURITY:\n  \
+Webhook endpoints include built-in security features like request validation and rate limiting.\n  \
+Configure authentication tokens and HTTPS for production deployments."
     )]
     Webhook(WebhookArgs),
 }

--- a/tests/test_cli_help.rs
+++ b/tests/test_cli_help.rs
@@ -1,5 +1,120 @@
 use std::process::Command;
 
+// Command lists for testing
+static ALL_MAIN_COMMANDS: &[&[&str]] = &[
+    &["run"],
+    &["init"],
+    &["batch"],
+    &["monitor"],
+    &["validate"],
+    &["dot"],
+    &["lint"],
+    &["explain"],
+    &["resume"],
+    &["checkpoints"],
+    &["artifacts"],
+    &["webhook"],
+];
+
+static COMPLEX_COMMANDS: &[&[&str]] = &[
+    &["run"],
+    &["monitor"],
+    &["validate"],
+    &["dot"],
+    &["lint"],
+    &["explain"],
+    &["resume"],
+    &["checkpoints"],
+    &["artifacts"],
+    &["webhook"],
+];
+
+/// Generic helper to run tests on multiple commands
+fn test_commands_with<F>(commands: &[&[&str]], test_fn: F)
+where
+    F: Fn(&[&str]),
+{
+    for command in commands {
+        test_fn(command);
+    }
+}
+
+/// Helper function to run a command and get help output
+fn get_help_output(args: &[&str]) -> String {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("newton"))
+        .args(args)
+        .arg("--help")
+        .output()
+        .expect("should run successfully");
+
+    std::str::from_utf8(&output.stdout).unwrap().to_string()
+}
+
+/// Test that help text is descriptive and user-friendly (not just technical terms)
+fn assert_help_is_descriptive(command_args: &[&str], min_length: usize) {
+    let stdout = get_help_output(command_args);
+
+    // Should contain descriptive language
+    let descriptive_indicators = [
+        "help",
+        "allows",
+        "provides",
+        "creates",
+        "generates",
+        "manages",
+        "enables",
+        "analyzes",
+        "checks",
+        "displays",
+        "useful",
+        "when",
+    ];
+
+    let has_descriptive_language = descriptive_indicators
+        .iter()
+        .any(|&indicator| stdout.to_lowercase().contains(indicator));
+
+    assert!(
+        has_descriptive_language,
+        "Help text for {:?} should contain descriptive language",
+        command_args
+    );
+
+    // Help should be reasonably long (more descriptive than minimal)
+    assert!(
+        stdout.len() > min_length,
+        "Help text for {:?} should be at least {} characters, got {}",
+        command_args,
+        min_length,
+        stdout.len()
+    );
+}
+
+/// Test that complex commands include examples
+fn assert_has_examples(command_args: &[&str]) {
+    let stdout = get_help_output(command_args);
+    assert!(
+        stdout.contains("EXAMPLES") || stdout.contains("Example"),
+        "Help text for {:?} should contain examples section",
+        command_args
+    );
+}
+
+/// Test that help follows consistent formatting standards
+fn assert_consistent_formatting(command_args: &[&str]) {
+    let stdout = get_help_output(command_args);
+
+    // Should have consistent section headers (UPPERCASE)
+    let has_proper_sections =
+        stdout.contains("EXAMPLES") || stdout.contains("USAGE") || stdout.contains("OPTIONS");
+
+    assert!(
+        has_proper_sections,
+        "Help text for {:?} should have properly formatted section headers",
+        command_args
+    );
+}
+
 #[test]
 fn test_monitor_help_contains_configuration_section() {
     let output = Command::new(assert_cmd::cargo::cargo_bin!("newton"))
@@ -125,4 +240,320 @@ fn test_webhook_help_documents_positional_workflow_example() {
 
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     assert!(stdout.contains("newton webhook serve workflow.yaml --workspace ./workspace"));
+}
+
+// Tests for improved help text descriptiveness and quality
+
+#[test]
+fn test_all_main_commands_have_descriptive_help() {
+    test_commands_with(ALL_MAIN_COMMANDS, |command| {
+        assert_help_is_descriptive(command, 200); // At least 200 chars of help
+    });
+}
+
+#[test]
+fn test_complex_commands_include_examples() {
+    test_commands_with(COMPLEX_COMMANDS, |command| {
+        assert_has_examples(command);
+    });
+}
+
+#[test]
+fn test_help_formatting_consistency() {
+    test_commands_with(ALL_MAIN_COMMANDS, |command| {
+        assert_consistent_formatting(command);
+    });
+}
+
+// Specific tests for improved commands
+
+#[test]
+fn test_validate_help_explains_file_checking() {
+    let stdout = get_help_output(&["validate"]);
+    assert!(stdout.contains("checks your workflow YAML file"));
+}
+
+#[test]
+fn test_validate_help_mentions_syntax_errors() {
+    let stdout = get_help_output(&["validate"]);
+    assert!(stdout.contains("syntax errors"));
+}
+
+#[test]
+fn test_validate_help_explains_pre_execution_purpose() {
+    let stdout = get_help_output(&["validate"]);
+    assert!(stdout.contains("before execution"));
+}
+
+#[test]
+fn test_validate_help_documents_return_codes() {
+    let stdout = get_help_output(&["validate"]);
+    assert!(stdout.contains("RETURN CODES"));
+}
+
+#[test]
+fn test_dot_help_mentions_visual_diagram() {
+    let stdout = get_help_output(&["dot"]);
+    assert!(stdout.contains("visual diagram"));
+}
+
+#[test]
+fn test_dot_help_references_graphviz() {
+    let stdout = get_help_output(&["dot"]);
+    assert!(stdout.contains("Graphviz"));
+}
+
+#[test]
+fn test_dot_help_explains_task_dependencies() {
+    let stdout = get_help_output(&["dot"]);
+    assert!(stdout.contains("task dependencies"));
+}
+
+#[test]
+fn test_dot_help_has_visualization_section() {
+    let stdout = get_help_output(&["dot"]);
+    assert!(stdout.contains("VISUALIZATION"));
+}
+
+#[test]
+fn test_lint_help_mentions_best_practices() {
+    let stdout = get_help_output(&["lint"]);
+    assert!(stdout.contains("best practices"));
+}
+
+#[test]
+fn test_lint_help_distinguishes_from_validate() {
+    let stdout = get_help_output(&["lint"]);
+    assert!(stdout.contains("Unlike validate"));
+}
+
+#[test]
+fn test_lint_help_emphasizes_quality() {
+    let stdout = get_help_output(&["lint"]);
+    assert!(stdout.contains("quality"));
+}
+
+#[test]
+fn test_lint_help_documents_output_formats() {
+    let stdout = get_help_output(&["lint"]);
+    assert!(stdout.contains("OUTPUT FORMATS"));
+}
+
+#[test]
+fn test_explain_help_mentions_detailed_documentation() {
+    let stdout = get_help_output(&["explain"]);
+    assert!(stdout.contains("detailed documentation"));
+}
+
+#[test]
+fn test_explain_help_describes_step_by_step() {
+    let stdout = get_help_output(&["explain"]);
+    assert!(stdout.contains("Step-by-step"));
+}
+
+#[test]
+fn test_explain_help_documents_output_formats() {
+    let stdout = get_help_output(&["explain"]);
+    assert!(stdout.contains("OUTPUT FORMATS"));
+}
+
+#[test]
+fn test_explain_help_mentions_prose_format() {
+    let stdout = get_help_output(&["explain"]);
+    assert!(stdout.contains("prose"));
+}
+
+#[test]
+fn test_resume_help_mentions_interrupted_workflows() {
+    let stdout = get_help_output(&["resume"]);
+    assert!(stdout.contains("interrupted"));
+}
+
+#[test]
+fn test_resume_help_explains_checkpoint_concept() {
+    let stdout = get_help_output(&["resume"]);
+    assert!(stdout.contains("checkpoint"));
+}
+
+#[test]
+fn test_resume_help_has_finding_execution_section() {
+    let stdout = get_help_output(&["resume"]);
+    assert!(stdout.contains("FINDING EXECUTION"));
+}
+
+#[test]
+fn test_resume_help_documents_safety_considerations() {
+    let stdout = get_help_output(&["resume"]);
+    assert!(stdout.contains("SAFETY"));
+}
+
+#[test]
+fn test_resume_help_documents_workflow_change_option() {
+    let stdout = get_help_output(&["resume"]);
+    assert!(stdout.contains("--allow-workflow-change"));
+}
+
+#[test]
+fn test_checkpoints_help_explains_saved_states() {
+    let stdout = get_help_output(&["checkpoints"]);
+    assert!(stdout.contains("saved states"));
+}
+
+#[test]
+fn test_checkpoints_help_mentions_resumption() {
+    let stdout = get_help_output(&["checkpoints"]);
+    assert!(stdout.contains("resumption"));
+}
+
+#[test]
+fn test_checkpoints_help_explains_automatic_creation() {
+    let stdout = get_help_output(&["checkpoints"]);
+    assert!(stdout.contains("automatically creates"));
+}
+
+#[test]
+fn test_checkpoints_help_documents_storage_section() {
+    let stdout = get_help_output(&["checkpoints"]);
+    assert!(stdout.contains("CHECKPOINT STORAGE"));
+}
+
+#[test]
+fn test_artifacts_help_mentions_output_files() {
+    let stdout = get_help_output(&["artifacts"]);
+    assert!(stdout.contains("output files"));
+}
+
+#[test]
+fn test_artifacts_help_explains_retention_concept() {
+    let stdout = get_help_output(&["artifacts"]);
+    assert!(stdout.contains("retention"));
+}
+
+#[test]
+fn test_artifacts_help_mentions_disk_space() {
+    let stdout = get_help_output(&["artifacts"]);
+    assert!(stdout.contains("disk space"));
+}
+
+#[test]
+fn test_artifacts_help_documents_retention_formats() {
+    let stdout = get_help_output(&["artifacts"]);
+    assert!(stdout.contains("RETENTION FORMATS"));
+}
+
+#[test]
+fn test_artifacts_help_documents_storage_section() {
+    let stdout = get_help_output(&["artifacts"]);
+    assert!(stdout.contains("ARTIFACT STORAGE"));
+}
+
+#[test]
+fn test_webhook_help_mentions_external_events() {
+    let stdout = get_help_output(&["webhook"]);
+    assert!(stdout.contains("external events"));
+}
+
+#[test]
+fn test_webhook_help_explains_integration_concept() {
+    let stdout = get_help_output(&["webhook"]);
+    assert!(stdout.contains("integration"));
+}
+
+#[test]
+fn test_webhook_help_mentions_github_integration() {
+    let stdout = get_help_output(&["webhook"]);
+    assert!(stdout.contains("GitHub"));
+}
+
+#[test]
+fn test_webhook_help_has_integration_section() {
+    let stdout = get_help_output(&["webhook"]);
+    assert!(stdout.contains("INTEGRATION"));
+}
+
+#[test]
+fn test_webhook_help_documents_security_considerations() {
+    let stdout = get_help_output(&["webhook"]);
+    assert!(stdout.contains("SECURITY"));
+}
+
+// Test subcommand help improvements
+
+#[test]
+fn test_webhook_serve_help_is_descriptive() {
+    let stdout = get_help_output(&["webhook", "serve"]);
+    assert!(stdout.contains("Start an HTTP server"));
+    assert!(stdout.contains("webhook events"));
+}
+
+#[test]
+fn test_webhook_status_help_is_descriptive() {
+    let stdout = get_help_output(&["webhook", "status"]);
+    assert!(stdout.contains("Display webhook endpoint"));
+    assert!(stdout.contains("configuration"));
+}
+
+#[test]
+fn test_checkpoints_list_help_is_descriptive() {
+    let stdout = get_help_output(&["checkpoints", "list"]);
+    assert!(stdout.contains("Display available"));
+    assert!(stdout.contains("checkpoint details"));
+}
+
+#[test]
+fn test_checkpoints_clean_help_is_descriptive() {
+    let stdout = get_help_output(&["checkpoints", "clean"]);
+    assert!(stdout.contains("Remove old checkpoint"));
+    assert!(stdout.contains("disk space"));
+}
+
+#[test]
+fn test_artifacts_clean_help_is_descriptive() {
+    let stdout = get_help_output(&["artifacts", "clean"]);
+    assert!(stdout.contains("Remove old workflow"));
+    assert!(stdout.contains("execution artifacts"));
+}
+
+// Test that help text avoids overly technical jargon
+
+#[test]
+fn test_explain_help_avoids_technical_jargon() {
+    let stdout = get_help_output(&["explain"]);
+
+    // Should NOT contain the old technical phrase
+    assert!(!stdout.contains("Explain workflow graph settings/transitions"));
+
+    // Should contain user-friendly language instead
+    assert!(stdout.contains("detailed documentation"));
+    assert!(stdout.contains("what your workflow does"));
+}
+
+#[test]
+fn test_help_text_quality_meets_spec_requirements() {
+    // Test that improved help text is at least 2x longer than minimal descriptions
+    let commands_to_check = [
+        (&["validate"][..], "Validate checks your workflow"),
+        (&["dot"][..], "visual diagram"),
+        (&["lint"][..], "best practices"),
+        (&["explain"][..], "detailed documentation"),
+        (&["resume"][..], "interrupted"),
+    ];
+
+    for (command, expected_content) in &commands_to_check {
+        let stdout = get_help_output(command);
+        assert!(
+            stdout.contains(expected_content),
+            "Help for {:?} should contain: {}",
+            command,
+            expected_content
+        );
+
+        // Verify help is substantially longer than minimal descriptions
+        assert!(
+            stdout.len() > 500,
+            "Help for {:?} should be substantially detailed (>500 chars), got {}",
+            command,
+            stdout.len()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- expand user-facing help text for core CLI commands (validate, dot, lint, explain, resume, checkpoints, artifacts, webhook)
- improve subcommand descriptions for webhook/checkpoints/artifacts in CLI args
- add broad CLI help coverage tests for descriptiveness, examples, consistency, and command-specific expectations
- update scripts/run-tests.sh to run cargo fmt --check and harden cargo env defaults for sandbox/CI filesystem compatibility

## Testing
- ./scripts/run-tests.sh
- pre-commit checks (fmt, clippy, unit tests)
- pre-push checks (full test suite + docs build)