### PR TITLE
fix(resume): use current workflow document when allow_workflow_change is set

### DIFF
--- a/src/core/workflow_graph/executor.rs
+++ b/src/core/workflow_graph/executor.rs
@@ -1058,9 +1058,9 @@ pub async fn resume_workflow(
         max_workflow_iterations: graph_settings.max_workflow_iterations,
     };
 
-    let runtime_graph = if checkpoint_data.version >= 2 {
+    let runtime_graph = if checkpoint_data.version >= 2 && !allow_workflow_change {
         if let Some(runtime_tasks) = checkpoint_data.runtime_tasks {
-            // Version 2+: Build runtime graph from checkpoint's runtime_tasks
+            // Version 2+: Build runtime graph from checkpoint's runtime_tasks (unchanged workflow)
             let tasks_map: HashMap<String, WorkflowTask> = runtime_tasks
                 .into_iter()
                 .map(|task| (task.id.clone(), task))
@@ -1088,7 +1088,7 @@ pub async fn resume_workflow(
             )
         }
     } else {
-        // Version 1: Build runtime graph from document (current behavior)
+        // Version 1, or allow_workflow_change: use current workflow document (e.g. updated max_iterations)
         GraphHandle::new(
             document
                 .workflow


### PR DESCRIPTION
Resume with --allow-workflow-change now builds the runtime graph from the current workflow file instead of the checkpoint's runtime_tasks, so updated task settings (e.g. max_iterations) take effect and the run can continue past iteration caps.