### PR TITLE
feat(api): add backend serve and monitor compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ NEWTON-0021 - Code coverage SHOULD be maintained or improved
 NEWTON-0022 - Release builds MUST compile successfully on all target platforms
 NEWTON-0023 - You MUST assume git is installed on the user machine and MUST NOT check for git presence
 NEWTON-0024 - You SHOULD NOT adopt an extremely defensive coding style with excessive validation
+NEWTON-0025 - Each command and subcommand MUST have a proper descriptive help message (about/long_about as needed) including at least one example (e.g. in after_help)
 
 ## Active Technologies
 - Rust 1.93.0 Stable + clap 4.5 (CLI parsing), tokio 1.49 (async runtime), anyhow/thiserror 1.0 (error handling), tracing 0.1 (logging), serde 1.0.228/serde_json 1.0 (serialization), chrono 0.4 (time), uuid 1.0 (execution IDs) (002-rust-newton-code)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -204,8 +227,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -569,6 +594,20 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -946,6 +985,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1575,22 +1620,25 @@ dependencies = [
 
 [[package]]
 name = "newton"
-version = "0.5.55"
+version = "0.5.59"
 dependencies = [
  "aikit-sdk",
  "anyhow",
  "assert_cmd",
+ "async-stream",
  "async-trait",
  "axum",
  "chrono",
  "clap",
  "crossterm 0.28.1",
+ "dashmap",
  "dirs-next",
  "futures",
  "hex",
  "humantime",
  "indexmap",
  "insta",
+ "newton-types",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -1611,8 +1659,9 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tokio-test",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "toml",
  "tower",
  "tower-http",
@@ -1620,10 +1669,20 @@ dependencies = [
  "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.20.1",
  "url",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "newton-types"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3051,7 +3110,19 @@ dependencies = [
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3322,6 +3393,23 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["development-tools", "command-line-utilities"]
 keywords = ["newton", "optimization", "ai", "cli"]
 publish = false
 
+[workspace]
+members = [
+    "crates/types",
+]
+
 [dependencies]
 clap = { version = "4.4", features = ["derive", "cargo"] }
 tokio = { version = "1.49", features = ["full"] }
@@ -48,10 +53,14 @@ indexmap = "2"
 sha2 = "0.10"
 hex = "0.4.3"
 humantime = "2.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["limit"] }
+tower-http = { version = "0.6", features = ["limit", "cors"] }
 subtle = "2"
+dashmap = "6.1"
+async-stream = "0.3"
+tokio-stream = "0.1"
+newton-types = { path = "crates/types" }
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -150,3 +159,6 @@ path = "tests/batch/test_batch_workflow_state_paths.rs"
 [[bin]]
 name = "logging_integration_helper"
 path = "tests/bin/logging_integration_helper.rs"
+[[test]]
+name = "test_api_integration"
+path = "tests/integration/test_api.rs"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "newton-types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.6", features = ["v4", "serde"] }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,0 +1,129 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowInstance {
+    pub instance_id: String,
+    pub workflow_id: String,
+    pub status: WorkflowStatus,
+    pub nodes: Vec<NodeState>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkflowStatus {
+    Running,
+    Succeeded,
+    Failed,
+    Paused,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeState {
+    pub node_id: String,
+    pub status: NodeStatus,
+    pub started_at: Option<DateTime<Utc>>,
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum NodeStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Timeout,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HilEvent {
+    pub event_id: Uuid,
+    pub instance_id: String,
+    pub node_id: Option<String>,
+    pub channel: String,
+    pub event_type: HilEventType,
+    pub question: String,
+    pub choices: Vec<String>,
+    pub timeout_seconds: Option<u64>,
+    pub correlation_id: Option<Uuid>,
+    pub status: HilStatus,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum HilEventType {
+    Question,
+    Authorization,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum HilStatus {
+    Pending,
+    Resolved,
+    TimedOut,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogLine {
+    pub instance_id: String,
+    pub node_id: String,
+    pub level: String,
+    pub message: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorDescriptor {
+    pub operator_type: String,
+    pub description: String,
+    pub params_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum BroadcastEvent {
+    #[serde(rename = "workflowInstanceUpdated")]
+    WorkflowInstanceUpdated { instance_id: String },
+    #[serde(rename = "nodeStateChanged")]
+    NodeStateChanged {
+        instance_id: String,
+        node_id: String,
+    },
+    #[serde(rename = "logMessage")]
+    LogMessage {
+        instance_id: String,
+        node_id: String,
+        message: String,
+    },
+    #[serde(rename = "hilEvent")]
+    HilEvent { instance_id: String, event_id: Uuid },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowDefinition {
+    pub workflow_id: String,
+    pub definition: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HilAction {
+    pub answer: Option<String>,
+    pub response_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiError {
+    pub code: String,
+    pub category: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+}

--- a/src/api/hil.rs
+++ b/src/api/hil.rs
@@ -1,0 +1,112 @@
+use crate::api::state::AppState;
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::{IntoResponse, Json, Response},
+    routing::get,
+    Router,
+};
+use newton_types::{ApiError, HilAction, HilEvent};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/hil/workflows/{id}", get(list_hil_events))
+        .route(
+            "/api/hil/workflows/{id}/{event_id}/action",
+            axum::routing::post(submit_hil_action),
+        )
+        .with_state(state)
+}
+
+async fn list_hil_events(
+    Path(id): Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+) -> Response {
+    let events: Vec<HilEvent> = state
+        .hil_events
+        .iter()
+        .filter(|entry| entry.value().instance_id == id)
+        .map(|entry| entry.value().clone())
+        .collect();
+    (StatusCode::OK, Json(events)).into_response()
+}
+
+async fn submit_hil_action(
+    Path((instance_id, event_id)): Path<(String, Uuid)>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    Json(action): Json<HilAction>,
+) -> Response {
+    match state.hil_events.get_mut(&event_id) {
+        Some(mut hil_event) => {
+            if hil_event.instance_id != instance_id {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ApiError {
+                        code: "API-HIL-001".to_string(),
+                        category: "ValidationError".to_string(),
+                        message: "HIL event not found for this workflow".to_string(),
+                        details: None,
+                    }),
+                )
+                    .into_response();
+            }
+
+            if hil_event.status != newton_types::HilStatus::Pending {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ApiError {
+                        code: "API-HIL-001".to_string(),
+                        category: "ValidationError".to_string(),
+                        message: "HIL event already resolved".to_string(),
+                        details: None,
+                    }),
+                )
+                    .into_response();
+            }
+
+            match action.response_type.as_str() {
+                "text" | "authorization_approved" | "authorization_denied" => {}
+                _ => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ApiError {
+                            code: "API-HIL-002".to_string(),
+                            category: "ValidationError".to_string(),
+                            message: "Invalid response type for HIL event kind".to_string(),
+                            details: None,
+                        }),
+                    )
+                        .into_response()
+                }
+            }
+
+            if action.response_type == "text" && action.answer.is_none() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ApiError {
+                        code: "API-HIL-003".to_string(),
+                        category: "ValidationError".to_string(),
+                        message: "Missing answer field for text response type".to_string(),
+                        details: None,
+                    }),
+                )
+                    .into_response();
+            }
+
+            hil_event.status = newton_types::HilStatus::Resolved;
+            (StatusCode::OK, Json(hil_event.clone())).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-HIL-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "HIL event not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response(),
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,592 @@
+pub mod hil;
+pub mod operators_api;
+pub mod state;
+pub mod streaming_api;
+pub mod workflows;
+
+use crate::api::state::AppState;
+use axum::{
+    extract::Path,
+    extract::Query,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Json, Response, Sse},
+    routing::{get, post, put},
+    Router,
+};
+use newton_types::{
+    ApiError, BroadcastEvent, HilAction, HilEvent, HilStatus, WorkflowDefinition, WorkflowInstance,
+};
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::convert::Infallible;
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+use uuid::Uuid;
+
+pub fn create_router(state: AppState) -> Router {
+    let arc_state = Arc::new(state);
+
+    Router::new()
+        .route("/health", get(health_check))
+        .route("/api/workflows", get(list_workflows))
+        .route("/api/workflows/{id}", get(get_workflow))
+        .route("/api/workflows/{id}", put(update_workflow))
+        .route("/api/hil/workflows/{id}", get(list_hil_events))
+        .route(
+            "/api/hil/workflows/{id}/{event_id}/action",
+            post(submit_hil_action),
+        )
+        .route("/api/channels", get(legacy_list_channels_v1))
+        .route(
+            "/api/channels/{channel}/messages",
+            get(legacy_list_channel_messages),
+        )
+        .route(
+            "/api/v1/messages/{event_id}/response",
+            post(legacy_submit_message_response),
+        )
+        .route("/api/operators", get(list_operators))
+        .route("/api/stream/workflow/{id}/ws", get(workflow_stream))
+        .route("/api/stream/logs/{id}/{node_id}/ws", get(logs_stream))
+        .route("/api/stream/workflow/{id}/sse", get(workflow_sse))
+        .route("/channels", get(legacy_list_channels))
+        .with_state(arc_state)
+        .layer(CorsLayer::permissive())
+}
+
+async fn health_check() -> impl IntoResponse {
+    Json(json!({
+        "status": "healthy",
+        "version": env!("CARGO_PKG_VERSION")
+    }))
+}
+
+async fn list_workflows(State(state): State<Arc<AppState>>) -> Json<Vec<WorkflowInstance>> {
+    let instances: Vec<WorkflowInstance> = state
+        .instances
+        .iter()
+        .map(|entry| entry.value().clone())
+        .collect();
+    Json(instances)
+}
+
+async fn get_workflow(Path(id): Path<String>, State(state): State<Arc<AppState>>) -> Response {
+    match Uuid::parse_str(&id) {
+        Ok(_) => {}
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    code: "API-WORKFLOW-001".to_string(),
+                    category: "ValidationError".to_string(),
+                    message: "Invalid workflow instance ID format".to_string(),
+                    details: None,
+                }),
+            )
+                .into_response()
+        }
+    }
+
+    match state.instances.get(&id) {
+        Some(instance) => (StatusCode::OK, Json(instance.clone())).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-WORKFLOW-002".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Workflow instance not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+async fn update_workflow(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Json(definition): Json<WorkflowDefinition>,
+) -> Response {
+    match Uuid::parse_str(&id) {
+        Ok(_) => {}
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    code: "API-WORKFLOW-001".to_string(),
+                    category: "ValidationError".to_string(),
+                    message: "Invalid workflow instance ID format".to_string(),
+                    details: None,
+                }),
+            )
+                .into_response()
+        }
+    }
+
+    if let Some(mut instance) = state.instances.get_mut(&id) {
+        instance.workflow_id = definition.workflow_id;
+        (StatusCode::OK, Json(instance.clone())).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-WORKFLOW-002".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Workflow instance not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+async fn list_hil_events(Path(id): Path<String>, State(state): State<Arc<AppState>>) -> Response {
+    let events: Vec<HilEvent> = state
+        .hil_events
+        .iter()
+        .filter(|entry| entry.value().instance_id == id)
+        .map(|entry| entry.value().clone())
+        .collect();
+    (StatusCode::OK, Json(events)).into_response()
+}
+
+async fn submit_hil_action(
+    Path((instance_id, event_id)): Path<(String, Uuid)>,
+    State(state): State<Arc<AppState>>,
+    Json(action): Json<HilAction>,
+) -> Response {
+    match state.hil_events.get_mut(&event_id) {
+        Some(mut hil_event) => {
+            if hil_event.instance_id != instance_id {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ApiError {
+                        code: "API-HIL-001".to_string(),
+                        category: "ValidationError".to_string(),
+                        message: "HIL event not found for this workflow".to_string(),
+                        details: None,
+                    }),
+                )
+                    .into_response();
+            }
+
+            if hil_event.status != newton_types::HilStatus::Pending {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ApiError {
+                        code: "API-HIL-001".to_string(),
+                        category: "ValidationError".to_string(),
+                        message: "HIL event already resolved".to_string(),
+                        details: None,
+                    }),
+                )
+                    .into_response();
+            }
+
+            if let Err((status, error)) = apply_hil_action(&mut hil_event, &action) {
+                return (status, Json(error)).into_response();
+            }
+            let _ = state.events_tx.send(BroadcastEvent::HilEvent {
+                instance_id: hil_event.instance_id.clone(),
+                event_id,
+            });
+            (StatusCode::OK, Json(hil_event.clone())).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-HIL-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "HIL event not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+async fn list_operators(State(state): State<Arc<AppState>>) -> Json<Value> {
+    Json(json!(state.operators.as_ref()))
+}
+
+#[derive(Debug, Serialize)]
+struct LegacyChannelInfo {
+    name: String,
+    message_count: usize,
+    oldest_message: Option<String>,
+    newest_message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LegacyMessage {
+    id: Uuid,
+    channel: String,
+    content: Value,
+    timestamp: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyMessagesQuery {
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct LegacySubmitResponse {
+    ok: bool,
+    event_id: Uuid,
+    status: HilStatus,
+}
+
+async fn legacy_list_channels_v1(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let mut channels: Vec<LegacyChannelInfo> = state
+        .instances
+        .iter()
+        .map(|entry| {
+            let workflow_id = entry.value().workflow_id.clone();
+            let mut timestamps: Vec<_> = state
+                .hil_events
+                .iter()
+                .filter(|evt| evt.value().channel == workflow_id)
+                .map(|evt| evt.value().timestamp)
+                .collect();
+            timestamps.sort_unstable();
+
+            LegacyChannelInfo {
+                name: workflow_id,
+                message_count: timestamps.len(),
+                oldest_message: timestamps.first().map(|ts| ts.to_rfc3339()),
+                newest_message: timestamps.last().map(|ts| ts.to_rfc3339()),
+            }
+        })
+        .collect();
+    channels.sort_by(|a, b| a.name.cmp(&b.name));
+    Json(json!({ "channels": channels }))
+}
+
+async fn legacy_list_channel_messages(
+    Path(channel): Path<String>,
+    Query(query): Query<LegacyMessagesQuery>,
+    State(state): State<Arc<AppState>>,
+) -> Json<Vec<LegacyMessage>> {
+    let mut messages: Vec<LegacyMessage> = state
+        .hil_events
+        .iter()
+        .filter(|evt| evt.value().channel == channel)
+        .map(|entry| {
+            let event = entry.value();
+            let content = match event.event_type {
+                newton_types::HilEventType::Question => json!({
+                    "type": "question",
+                    "text": event.question,
+                    "choices": event.choices,
+                    "timeout_seconds": event.timeout_seconds,
+                }),
+                newton_types::HilEventType::Authorization => json!({
+                    "type": "authorization",
+                    "action": event.question,
+                    "choices": event.choices,
+                    "timeout_seconds": event.timeout_seconds,
+                }),
+            };
+
+            LegacyMessage {
+                id: event.event_id,
+                channel: event.channel.clone(),
+                content,
+                timestamp: event.timestamp.to_rfc3339(),
+            }
+        })
+        .collect();
+
+    messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    let limit = query.limit.unwrap_or(50).min(200);
+    if messages.len() > limit {
+        messages.truncate(limit);
+    }
+    Json(messages)
+}
+
+async fn legacy_submit_message_response(
+    Path(event_id): Path<Uuid>,
+    State(state): State<Arc<AppState>>,
+    Json(action): Json<HilAction>,
+) -> Response {
+    match state.hil_events.get_mut(&event_id) {
+        Some(mut hil_event) => {
+            if let Err((status, error)) = apply_hil_action(&mut hil_event, &action) {
+                return (status, Json(error)).into_response();
+            }
+
+            let _ = state.events_tx.send(BroadcastEvent::HilEvent {
+                instance_id: hil_event.instance_id.clone(),
+                event_id,
+            });
+
+            (
+                StatusCode::OK,
+                Json(LegacySubmitResponse {
+                    ok: true,
+                    event_id,
+                    status: hil_event.status.clone(),
+                }),
+            )
+                .into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-HIL-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "HIL event not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+async fn legacy_list_channels(State(state): State<Arc<AppState>>) -> Json<Value> {
+    let channels: Vec<String> = state
+        .instances
+        .iter()
+        .map(|entry| entry.value().workflow_id.clone())
+        .collect();
+    Json(json!({ "channels": channels }))
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct StreamFilters {
+    pub instance_id: Option<String>,
+    pub node_id: Option<String>,
+    #[allow(dead_code)]
+    pub event_type: Option<String>,
+}
+
+async fn workflow_stream(
+    ws: axum::extract::ws::WebSocketUpgrade,
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| handle_workflow_socket(socket, id, state, filters))
+}
+
+async fn handle_workflow_socket(
+    mut socket: axum::extract::ws::WebSocket,
+    instance_id: String,
+    state: Arc<AppState>,
+    filters: StreamFilters,
+) {
+    let mut rx = state.events_tx.subscribe();
+
+    while let Ok(event) = rx.recv().await {
+        if should_send_event(&event, &instance_id, &filters) {
+            if let Ok(json) = serde_json::to_string(&event) {
+                if socket
+                    .send(axum::extract::ws::Message::Text(json.into()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn logs_stream(
+    ws: axum::extract::ws::WebSocketUpgrade,
+    Path((instance_id, node_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&instance_id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| handle_logs_socket(socket, instance_id, node_id, state, filters))
+}
+
+async fn handle_logs_socket(
+    mut socket: axum::extract::ws::WebSocket,
+    instance_id: String,
+    node_id: String,
+    state: Arc<AppState>,
+    filters: StreamFilters,
+) {
+    let mut rx = state.events_tx.subscribe();
+
+    while let Ok(event) = rx.recv().await {
+        if should_send_event(&event, &instance_id, &filters) {
+            if let BroadcastEvent::LogMessage {
+                instance_id: ref evt_inst,
+                node_id: ref evt_node,
+                ..
+            } = event
+            {
+                if evt_inst == &instance_id && evt_node == &node_id {
+                    if let Ok(json) = serde_json::to_string(&event) {
+                        if socket
+                            .send(axum::extract::ws::Message::Text(json.into()))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn workflow_sse(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    let rx = state.events_tx.subscribe();
+    let id_clone = id.clone();
+    let filters_clone = filters.clone();
+
+    let stream = async_stream::stream! {
+        let mut rx = rx;
+        while let Ok(event) = rx.recv().await {
+            if should_send_event(&event, &id_clone, &filters_clone) {
+                if let Ok(json) = serde_json::to_string(&event) {
+                    let sse_event = axum::response::sse::Event::default().data(json);
+                    yield Ok::<_, Infallible>(sse_event);
+                }
+            }
+        }
+    };
+
+    Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(std::time::Duration::from_secs(10))
+                .text("keepalive"),
+        )
+        .into_response()
+}
+
+fn apply_hil_action(
+    hil_event: &mut HilEvent,
+    action: &HilAction,
+) -> Result<(), (StatusCode, ApiError)> {
+    match action.response_type.as_str() {
+        "text" | "authorization_approved" | "authorization_denied" | "timeout" | "cancelled" => {}
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                ApiError {
+                    code: "API-HIL-002".to_string(),
+                    category: "ValidationError".to_string(),
+                    message: "Invalid response type for HIL event kind".to_string(),
+                    details: None,
+                },
+            ))
+        }
+    }
+
+    if action.response_type == "text" && action.answer.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ApiError {
+                code: "API-HIL-003".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Missing answer field for text response type".to_string(),
+                details: None,
+            },
+        ));
+    }
+
+    hil_event.status = match action.response_type.as_str() {
+        "timeout" => HilStatus::TimedOut,
+        "cancelled" => HilStatus::Cancelled,
+        _ => HilStatus::Resolved,
+    };
+    Ok(())
+}
+
+fn should_send_event(event: &BroadcastEvent, instance_id: &str, filters: &StreamFilters) -> bool {
+    if let Some(ref filter_inst) = filters.instance_id {
+        if filter_inst != instance_id {
+            return false;
+        }
+    }
+
+    match event {
+        BroadcastEvent::WorkflowInstanceUpdated {
+            instance_id: ref evt_id,
+        } => evt_id == instance_id,
+        BroadcastEvent::NodeStateChanged {
+            instance_id: ref evt_id,
+            node_id: ref evt_node,
+        } => {
+            if evt_id != instance_id {
+                return false;
+            }
+            if let Some(ref filter_node) = filters.node_id {
+                filter_node == evt_node
+            } else {
+                true
+            }
+        }
+        BroadcastEvent::LogMessage {
+            instance_id: ref evt_id,
+            node_id: ref evt_node,
+            ..
+        } => {
+            if evt_id != instance_id {
+                return false;
+            }
+            if let Some(ref filter_node) = filters.node_id {
+                filter_node == evt_node
+            } else {
+                true
+            }
+        }
+        BroadcastEvent::HilEvent {
+            instance_id: ref evt_id,
+            ..
+        } => evt_id == instance_id,
+    }
+}

--- a/src/api/operators_api.rs
+++ b/src/api/operators_api.rs
@@ -1,0 +1,7 @@
+use crate::api::state::AppState;
+use axum::{extract::State, Json};
+use newton_types::OperatorDescriptor;
+
+pub async fn list_operators(State(state): State<AppState>) -> Json<Vec<OperatorDescriptor>> {
+    Json(state.operators.as_ref().clone())
+}

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1,0 +1,29 @@
+use dashmap::DashMap;
+use newton_types::{BroadcastEvent, HilEvent, LogLine, OperatorDescriptor, WorkflowInstance};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+pub const BROADCAST_CAPACITY: usize = 1024;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub instances: Arc<DashMap<String, WorkflowInstance>>,
+    pub hil_events: Arc<DashMap<Uuid, HilEvent>>,
+    pub operators: Arc<Vec<OperatorDescriptor>>,
+    pub events_tx: broadcast::Sender<BroadcastEvent>,
+    pub logs: Arc<DashMap<(String, String), Vec<LogLine>>>,
+}
+
+impl AppState {
+    pub fn new(operators: Vec<OperatorDescriptor>) -> Self {
+        let (events_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        AppState {
+            instances: Arc::new(DashMap::new()),
+            hil_events: Arc::new(DashMap::new()),
+            operators: Arc::new(operators),
+            events_tx,
+            logs: Arc::new(DashMap::new()),
+        }
+    }
+}

--- a/src/api/streaming_api.rs
+++ b/src/api/streaming_api.rs
@@ -1,0 +1,215 @@
+use crate::api::state::AppState;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Path, Query,
+    },
+    http::StatusCode,
+    response::{IntoResponse, Response, Sse},
+    routing::get,
+    Json, Router,
+};
+use newton_types::ApiError;
+use serde::Deserialize;
+use std::convert::Infallible;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct StreamFilters {
+    pub instance_id: Option<String>,
+    pub node_id: Option<String>,
+    pub event_type: Option<String>,
+}
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/stream/workflow/{id}/ws", get(workflow_stream))
+        .route("/api/stream/logs/{id}/{node_id}/ws", get(logs_stream))
+        .route("/api/stream/workflow/{id}/sse", get(workflow_sse))
+        .with_state(state)
+}
+
+async fn workflow_stream(
+    ws: WebSocketUpgrade,
+    Path(id): Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| handle_workflow_socket(socket, id, state, filters))
+}
+
+async fn handle_workflow_socket(
+    mut socket: WebSocket,
+    instance_id: String,
+    state: Arc<AppState>,
+    filters: StreamFilters,
+) {
+    let mut rx = state.events_tx.subscribe();
+
+    while let Ok(event) = rx.recv().await {
+        if should_send_event(&event, &instance_id, &filters) {
+            if let Ok(json) = serde_json::to_string(&event) {
+                if socket.send(Message::Text(json.into())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn logs_stream(
+    ws: WebSocketUpgrade,
+    Path((instance_id, node_id)): Path<(String, String)>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&instance_id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| handle_logs_socket(socket, instance_id, node_id, state, filters))
+}
+
+async fn handle_logs_socket(
+    mut socket: WebSocket,
+    instance_id: String,
+    node_id: String,
+    state: Arc<AppState>,
+    filters: StreamFilters,
+) {
+    let mut rx = state.events_tx.subscribe();
+
+    while let Ok(event) = rx.recv().await {
+        if should_send_event(&event, &instance_id, &filters) {
+            if let newton_types::BroadcastEvent::LogMessage {
+                instance_id: ref evt_inst,
+                node_id: ref evt_node,
+                ..
+            } = event
+            {
+                if evt_inst == &instance_id && evt_node == &node_id {
+                    if let Ok(json) = serde_json::to_string(&event) {
+                        if socket.send(Message::Text(json.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn workflow_sse(
+    Path(id): Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    Query(filters): Query<StreamFilters>,
+) -> Response {
+    if Uuid::parse_str(&id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                code: "API-STREAM-001".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Invalid workflow instance ID format".to_string(),
+                details: None,
+            }),
+        )
+            .into_response();
+    }
+
+    let rx = state.events_tx.subscribe();
+    let id_clone = id.clone();
+    let filters_clone = filters.clone();
+
+    let stream = async_stream::stream! {
+        let mut rx = rx;
+        while let Ok(event) = rx.recv().await {
+            if should_send_event(&event, &id_clone, &filters_clone) {
+                if let Ok(json) = serde_json::to_string(&event) {
+                    let sse_event = axum::response::sse::Event::default().data(json);
+                    yield Ok::<_, Infallible>(sse_event);
+                }
+            }
+        }
+    };
+
+    Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(std::time::Duration::from_secs(10))
+                .text("keepalive"),
+        )
+        .into_response()
+}
+
+fn should_send_event(
+    event: &newton_types::BroadcastEvent,
+    instance_id: &str,
+    filters: &StreamFilters,
+) -> bool {
+    if let Some(ref filter_inst) = filters.instance_id {
+        if filter_inst != instance_id {
+            return false;
+        }
+    }
+
+    match event {
+        newton_types::BroadcastEvent::WorkflowInstanceUpdated {
+            instance_id: ref evt_id,
+        } => evt_id == instance_id,
+        newton_types::BroadcastEvent::NodeStateChanged {
+            instance_id: ref evt_id,
+            node_id: ref evt_node,
+        } => {
+            if evt_id != instance_id {
+                return false;
+            }
+            if let Some(ref filter_node) = filters.node_id {
+                filter_node == evt_node
+            } else {
+                true
+            }
+        }
+        newton_types::BroadcastEvent::LogMessage {
+            instance_id: ref evt_id,
+            node_id: ref evt_node,
+            ..
+        } => {
+            if evt_id != instance_id {
+                return false;
+            }
+            if let Some(ref filter_node) = filters.node_id {
+                filter_node == evt_node
+            } else {
+                true
+            }
+        }
+        newton_types::BroadcastEvent::HilEvent {
+            instance_id: ref evt_id,
+            ..
+        } => evt_id == instance_id,
+    }
+}

--- a/src/api/workflows.rs
+++ b/src/api/workflows.rs
@@ -1,0 +1,103 @@
+use crate::api::state::AppState;
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::{IntoResponse, Json, Response},
+    routing::get,
+    Router,
+};
+use newton_types::{ApiError, WorkflowDefinition, WorkflowInstance};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/workflows", get(list_workflows))
+        .route("/api/workflows/{id}", get(get_workflow))
+        .route("/api/workflows/{id}", axum::routing::put(update_workflow))
+        .with_state(state)
+}
+
+async fn list_workflows(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+) -> Json<Vec<WorkflowInstance>> {
+    let instances: Vec<WorkflowInstance> = state
+        .instances
+        .iter()
+        .map(|entry| entry.value().clone())
+        .collect();
+    Json(instances)
+}
+
+async fn get_workflow(
+    Path(id): Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+) -> Response {
+    match Uuid::parse_str(&id) {
+        Ok(_) => {}
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    code: "API-WORKFLOW-001".to_string(),
+                    category: "ValidationError".to_string(),
+                    message: "Invalid workflow instance ID format".to_string(),
+                    details: None,
+                }),
+            )
+                .into_response()
+        }
+    }
+
+    match state.instances.get(&id) {
+        Some(instance) => (StatusCode::OK, Json(instance.clone())).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-WORKFLOW-002".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Workflow instance not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+async fn update_workflow(
+    Path(id): Path<String>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    Json(definition): Json<WorkflowDefinition>,
+) -> Response {
+    match Uuid::parse_str(&id) {
+        Ok(_) => {}
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    code: "API-WORKFLOW-001".to_string(),
+                    category: "ValidationError".to_string(),
+                    message: "Invalid workflow instance ID format".to_string(),
+                    details: None,
+                }),
+            )
+                .into_response()
+        }
+    }
+
+    if let Some(mut instance) = state.instances.get_mut(&id) {
+        instance.workflow_id = definition.workflow_id;
+        (StatusCode::OK, Json(instance.clone())).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                code: "API-WORKFLOW-002".to_string(),
+                category: "ValidationError".to_string(),
+                message: "Workflow instance not found".to_string(),
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -363,6 +363,22 @@ pub struct MonitorArgs {
     /// the first alphabetically-sorted .conf file that defines both endpoints.
     #[arg(long, value_name = "URL")]
     pub ws_url: Option<String>,
+
+    /// Also start the HTTP API backend server
+    #[arg(long)]
+    pub backend: bool,
 }
 
+#[derive(Args, Clone, Debug)]
+pub struct ServeArgs {
+    /// Host address to bind the server to (default: 127.0.0.1)
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// Port to listen on (default: 8080)
+    #[arg(long, default_value = "8080")]
+    pub port: u16,
+}
+
+// ErrorArgs removed - command retired
 // ErrorArgs removed - command retired

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,28 +1,25 @@
 #![allow(clippy::result_large_err)] // CLI command handlers return AppError directly to preserve diagnostic context without boxing.
 
+use crate::cli::args::{
+    ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,
+    ExplainArgs, KeyValuePair, LintArgs, MonitorArgs, OutputFormat, ResumeArgs, RunArgs, ServeArgs,
+    ValidateArgs, WebhookArgs, WebhookCommand, WebhookServeArgs, WebhookStatusArgs,
+};
+use crate::core::batch_config::BatchProjectConfig;
 use crate::core::error::AppError;
 use crate::core::types::ErrorCategory;
-use crate::{
-    cli::args::{
-        ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,
-        ExplainArgs, KeyValuePair, LintArgs, MonitorArgs, OutputFormat, ResumeArgs, RunArgs,
-        ValidateArgs, WebhookArgs, WebhookCommand, WebhookServeArgs, WebhookStatusArgs,
-    },
-    core::{
-        batch_config::BatchProjectConfig,
-        workflow_graph::{
-            artifacts, checkpoint, dot as workflow_dot,
-            executor::{self as workflow_executor, ExecutionOverrides},
-            explain,
-            expression::ExpressionEngine,
-            lint::{LintRegistry, LintResult, LintSeverity},
-            operator::OperatorRegistry,
-            operators as workflow_operators, schema as workflow_schema,
-            transform as workflow_transform, webhook,
-        },
-    },
-    monitor, Result,
+use crate::core::workflow_graph::operator::OperatorRegistry;
+use crate::core::workflow_graph::{
+    artifacts, checkpoint, dot as workflow_dot,
+    executor::{self as workflow_executor, ExecutionOverrides},
+    explain,
+    expression::ExpressionEngine,
+    lint::{LintRegistry, LintResult, LintSeverity},
+    operators as workflow_operators, schema as workflow_schema, transform as workflow_transform,
+    webhook,
 };
+use crate::monitor;
+use crate::Result;
 use anyhow::anyhow;
 use humantime::{format_duration, parse_duration};
 use serde::Serialize;
@@ -800,6 +797,66 @@ fn load_trigger_payload(path: &Path) -> StdResult<Value, AppError> {
         ));
     }
     Ok(value)
+}
+
+/// Launch the Newton HTTP API server
+pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
+    use crate::api::{self, state::AppState};
+    use crate::core::workflow_graph::operators;
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+    use tracing::info;
+
+    info!("Starting Newton API server on {}: {}", args.host, args.port);
+
+    let mut builder = OperatorRegistry::builder();
+    operators::register_builtins(
+        &mut builder,
+        std::path::PathBuf::from("."),
+        Default::default(),
+    );
+    let registry = builder.build();
+
+    let operator_names = registry.operator_names();
+    let operator_descriptors: Vec<newton_types::OperatorDescriptor> = operator_names
+        .iter()
+        .map(|name: &String| newton_types::OperatorDescriptor {
+            operator_type: name.clone(),
+            description: format!("{} operator", name),
+            params_schema: serde_json::json!({}),
+        })
+        .collect();
+
+    let state = AppState::new(operator_descriptors);
+    let app = api::create_router(state);
+
+    let addr = format!("{}:{}", args.host, args.port);
+    let socket_addr: SocketAddr = addr.parse().map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::ValidationError,
+            format!("invalid bind address: {}", err),
+        )
+    })?;
+
+    let listener = TcpListener::bind(&socket_addr).await.map_err(|err| {
+        AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!("failed to bind to {}: {}", addr, err),
+        )
+    })?;
+
+    info!("Newton API server listening on {}", socket_addr);
+
+    axum::serve(listener, app.into_make_service())
+        .await
+        .map_err(|err| {
+            AppError::new(
+                crate::core::types::ErrorCategory::IoError,
+                format!("server error: {}", err),
+            )
+        })?;
+
+    Ok(())
 }
 
 /// Launch the interactive Newton monitor TUI that watches ailoop channels.

--- a/src/cli/commands_serve.txt
+++ b/src/cli/commands_serve.txt
@@ -1,0 +1,124 @@
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use newton_types::OperatorDescriptor;
+use crate::api;
+use std::result::Result as StdResult;
+
+pub async fn serve(args: crate::cli::ServeArgs) -> StdResult<(), AppError> {
+    tracing::info!("Starting Newton API server on {}", args.bind);
+    
+    let operators = vec![
+        OperatorDescriptor {
+            operator_type: "agent".to_string(),
+            description: "Run AI agent operations with configurable engines".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "engine": {"type": "string", "default": "claude_code"},
+                    "prompt": {"type": "string"},
+                    "max_iterations": {"type": "number", "default": 10}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "command".to_string(),
+            description: "Execute shell commands".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "working_dir": {"type": "string"},
+                    "timeout_seconds": {"type": "number"}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "human_approval".to_string(),
+            description: "Request human approval for workflow continuation".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string"},
+                    "timeout_seconds": {"type": "number", "default": 300}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "human_decision".to_string(),
+            description: "Request human decision from multiple choices".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string"},
+                    "choices": {"type": "array", "items": {"type": "string"}},
+                    "timeout_seconds": {"type": "number", "default": 300}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "barrier".to_string(),
+            description: "Wait for specified tasks to complete".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "expected": {"type": "array", "items": {"type": "string"}}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "noop".to_string(),
+            description: "No-operation placeholder task".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {}
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "set_context".to_string(),
+            description: "Set values in workflow context".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "values": {"type": "object"}
+                }
+            }),
+        },
+        OperatorDescriptor {
+            operator_type: "assert_completed".to_string(),
+            description: "Assert that specified tasks have completed".to_string(),
+            params_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "task_ids": {"type": "array", "items": {"type": "string"}}
+                }
+            }),
+        },
+    ];
+    
+    let state = api::state::AppState::new(operators);
+    let app = api::create_router(state);
+    
+    let listener = tokio::net::TcpListener::bind(&args.bind).await.map_err(|err| {
+        AppError::new(
+            ErrorCategory::ValidationError,
+            format!("Failed to bind to {}: {}", args.bind, err),
+        )
+    })?;
+    
+    let addr = listener.local_addr().map_err(|err| {
+        AppError::new(
+            ErrorCategory::ValidationError,
+            format!("Failed to get listener address: {}", err),
+        )
+    })?;
+    
+    println!("Newton API server listening on {}", addr);
+    println!("Health check: http://{}/health", addr);
+    println!("API endpoints: http://{}/api", addr);
+    
+    loop {
+        if let Err(err) = axum::serve(&listener, &app).await {
+            tracing::error!("Server error: {}", err);
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,8 +5,8 @@ pub mod init;
 
 pub use args::{
     ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,
-    ExplainArgs, InitArgs, LintArgs, MonitorArgs, ResumeArgs, RunArgs, ValidateArgs, WebhookArgs,
-    WebhookCommand, WebhookServeArgs, WebhookStatusArgs,
+    ExplainArgs, InitArgs, LintArgs, MonitorArgs, ResumeArgs, RunArgs, ServeArgs, ValidateArgs,
+    WebhookArgs, WebhookCommand, WebhookServeArgs, WebhookStatusArgs,
 };
 use clap::{Parser, Subcommand};
 
@@ -51,6 +51,45 @@ pub enum Command {
         after_help = "Example:\n    newton batch project-alpha --workspace ./workspace"
     )]
     Batch(BatchArgs),
+    #[command(
+        about = "Start the Newton HTTP API server",
+        long_about = "Serve starts the HTTP/WebSocket API server that provides real-time access to workflow execution state.
+
+The API server exposes endpoints for:
+    • Workflow instance management and queries
+    • HIL (Human-in-the-Loop) event handling
+    • Real-time streaming via WebSocket and SSE
+    • Operator metadata and schema information
+
+Use this command to run Newton as a backend service for web UIs, monitoring dashboards, or external integrations.
+
+CORS is enabled for local development by default.",
+        after_help = "EXAMPLES:
+  Start API server on default port:
+    newton serve
+
+  Start on custom host and port:
+    newton serve --host 0.0.0.0 --port 9000
+
+  Run in background:
+    newton serve --host 0.0.0.0 --port 8080 &
+
+API ENDPOINTS:
+    GET  /health              Health check endpoint
+    GET  /api/workflows       List all workflow instances
+    GET  /api/workflows/:id   Get workflow instance by ID
+    PUT  /api/workflows/:id   Update workflow definition
+    GET  /api/operators       List registered operators
+    GET  /api/hil/workflows/:id            List HIL events for workflow
+    POST /api/hil/workflows/:id/:eventId/action  Submit HIL action
+    WS   /api/stream/workflow/:id/ws        WebSocket stream for workflow
+    WS   /api/stream/logs/:id/:node_id/ws   WebSocket stream for node logs
+    SSE  /api/stream/workflow/:id/sse      SSE stream for workflow events
+
+LEGACY ENDPOINTS:
+    GET  /api/channels        List workflow channels (legacy compatibility)"
+    )]
+    Serve(ServeArgs),
     #[command(
         about = "Monitor live ailoop channels via a terminal UI",
         long_about = "Monitor listens to every project/branch channel from the workspace using a WebSocket/HTTP mix and lets you answer questions or approve authorizations in a queue.\n\n\
@@ -276,6 +315,9 @@ pub async fn run(args: Args) -> crate::Result<()> {
         Command::Run(run_args) => commands::run(run_args).await,
         Command::Init(init_args) => init::run(init_args).await,
         Command::Batch(batch_args) => commands::batch(batch_args).await,
+        Command::Serve(serve_args) => commands::serve(serve_args)
+            .await
+            .map_err(anyhow::Error::from),
         Command::Monitor(monitor_args) => commands::monitor(monitor_args).await,
         Command::Validate(validate_args) => {
             commands::validate(validate_args).map_err(anyhow::Error::from)

--- a/src/core/workflow_graph/operator.rs
+++ b/src/core/workflow_graph/operator.rs
@@ -117,4 +117,12 @@ impl OperatorRegistry {
     pub fn get(&self, name: &str) -> Option<Arc<dyn Operator>> {
         self.inner.get(name).cloned()
     }
+
+    pub fn list_operators(&self) -> Vec<Arc<dyn Operator>> {
+        self.inner.values().cloned().collect()
+    }
+
+    pub fn operator_names(&self) -> Vec<String> {
+        self.inner.keys().cloned().collect()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Newton CLI crate re-exports for orchestrating AI-driven optimization loops and exposing the shared API surface.
 pub mod ailoop_integration;
+pub mod api;
 pub mod cli;
 pub mod core;
 pub mod logging;

--- a/src/logging/context.rs
+++ b/src/logging/context.rs
@@ -12,6 +12,8 @@ pub enum ExecutionContext {
     Batch,
     /// Remote agent execution that runs on a different host.
     RemoteAgent,
+    /// API server such as `newton serve`.
+    Server,
 }
 
 impl ExecutionContext {
@@ -19,7 +21,10 @@ impl ExecutionContext {
     pub fn disables_console(self) -> bool {
         matches!(
             self,
-            ExecutionContext::Tui | ExecutionContext::Batch | ExecutionContext::RemoteAgent
+            ExecutionContext::Tui
+                | ExecutionContext::Batch
+                | ExecutionContext::RemoteAgent
+                | ExecutionContext::Server
         )
     }
 }
@@ -47,6 +52,7 @@ pub fn detect_context(command: &Command) -> ExecutionContext {
         | Command::Webhook(_)
         | Command::Init(_) => ExecutionContext::LocalDev,
         Command::Monitor(_) => ExecutionContext::Tui,
+        Command::Serve(_) => ExecutionContext::Server,
     }
 }
 

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -211,6 +211,7 @@ fn workspace_root_for_command(command: &Command) -> Result<Option<PathBuf>> {
             let cwd = env::current_dir()?;
             Some(find_workspace_root(&cwd)?)
         }
+        Command::Serve(_) => None,
     };
 
     if let Some(mut path) = candidate {
@@ -441,6 +442,7 @@ mod tests {
         Command::Monitor(MonitorArgs {
             http_url: None,
             ws_url: None,
+            backend: false,
         })
     }
 

--- a/src/monitor/client.rs
+++ b/src/monitor/client.rs
@@ -381,6 +381,7 @@ mod tests {
             http_url,
             ws_url,
             workspace_root: PathBuf::from("."),
+            workflow_service_url: None,
         }
     }
 

--- a/src/monitor/config.rs
+++ b/src/monitor/config.rs
@@ -14,6 +14,8 @@ pub struct MonitorEndpoints {
     pub ws_url: Url,
     /// Underlying workspace root that provided the configuration.
     pub workspace_root: PathBuf,
+    /// Optional HTTP URL for the Newton workflow service (backend API).
+    pub workflow_service_url: Option<Url>,
 }
 
 /// Optional overrides passed through `newton monitor`.
@@ -23,6 +25,8 @@ pub struct MonitorOverrides {
     pub http_url: Option<String>,
     /// Explicit WebSocket URL to use instead of the config file.
     pub ws_url: Option<String>,
+    /// Optional workflow service URL for the Newton backend API.
+    pub workflow_service_url: Option<String>,
 }
 
 /// Load the HTTP/WS URLs using the workspace `.newton/configs/` layout.
@@ -59,7 +63,7 @@ fn validate_configs_dir(workspace_root: &Path) -> Result<PathBuf> {
              Expected location: {}\n\n\
              To fix:\n  \
              - Run 'newton init' in your workspace root, or\n  \
-             - Manually create the directory and add a monitor.conf file, or\n  \
+             - Manually create a directory and add a monitor.conf file, or\n  \
              - Provide both --http-url and --ws-url on the command line",
             configs_dir.display()
         ));
@@ -136,6 +140,7 @@ fn finalize_endpoints(
 struct ConfigPair {
     http_url: Option<String>,
     ws_url: Option<String>,
+    workflow_service_url: Option<String>,
 }
 
 impl ConfigPair {
@@ -143,6 +148,7 @@ impl ConfigPair {
         ConfigPair {
             http_url: overrides.http_url,
             ws_url: overrides.ws_url,
+            workflow_service_url: overrides.workflow_service_url,
         }
     }
 
@@ -152,6 +158,9 @@ impl ConfigPair {
         }
         if self.ws_url.is_none() {
             self.ws_url = other.ws_url;
+        }
+        if self.workflow_service_url.is_none() {
+            self.workflow_service_url = other.workflow_service_url;
         }
     }
 
@@ -193,10 +202,16 @@ impl ConfigPair {
                 .ok_or_else(|| anyhow!("missing WebSocket endpoint"))?,
         )
         .map_err(|e| anyhow!("Invalid WebSocket URL: {}", e))?;
+
+        let workflow_service_url = self
+            .workflow_service_url
+            .and_then(|url| Url::parse(&url).ok());
+
         Ok(MonitorEndpoints {
             http_url,
             ws_url,
             workspace_root,
+            workflow_service_url,
         })
     }
 }
@@ -220,11 +235,23 @@ fn parse_config_entry(path: &Path) -> Result<Option<ConfigPair>> {
             Some(trimmed.to_string())
         }
     });
+    let workflow_service_url = settings.get("workflow_service_url").and_then(|v| {
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
 
-    // Return None only if both are missing; partial configs are valid
+    // Return None only if both core endpoints are missing; partial configs are valid
     if http_url.is_none() && ws_url.is_none() {
         return Ok(None);
     }
 
-    Ok(Some(ConfigPair { http_url, ws_url }))
+    Ok(Some(ConfigPair {
+        http_url,
+        ws_url,
+        workflow_service_url,
+    }))
 }

--- a/src/monitor/event.rs
+++ b/src/monitor/event.rs
@@ -1,4 +1,5 @@
 use crate::monitor::message::MonitorMessage;
+use newton_types::BroadcastEvent;
 use uuid::Uuid;
 
 /// Commands emitted by the UI that require HTTP requests.
@@ -45,6 +46,61 @@ pub enum MonitorEvent {
     ConnectionStatus(ConnectionStatus),
     /// Message received from a channel or from backfill/polling.
     Message(MonitorMessage),
+    /// Workflow event received from the backend API server.
+    Workflow(WorkflowEvent),
+}
+
+/// Workflow-specific events from the backend API.
+#[derive(Debug, Clone)]
+pub enum WorkflowEvent {
+    /// Workflow instance was updated.
+    InstanceUpdated { instance_id: String },
+    /// Node state changed.
+    NodeStateChanged {
+        instance_id: String,
+        node_id: String,
+    },
+    /// Log message received.
+    LogMessage {
+        instance_id: String,
+        node_id: String,
+        message: String,
+    },
+    /// HIL event occurred.
+    HilEvent { instance_id: String, event_id: Uuid },
+}
+
+impl From<BroadcastEvent> for WorkflowEvent {
+    fn from(event: BroadcastEvent) -> Self {
+        match event {
+            BroadcastEvent::WorkflowInstanceUpdated { instance_id } => {
+                WorkflowEvent::InstanceUpdated { instance_id }
+            }
+            BroadcastEvent::NodeStateChanged {
+                instance_id,
+                node_id,
+            } => WorkflowEvent::NodeStateChanged {
+                instance_id,
+                node_id,
+            },
+            BroadcastEvent::LogMessage {
+                instance_id,
+                node_id,
+                message,
+            } => WorkflowEvent::LogMessage {
+                instance_id,
+                node_id,
+                message,
+            },
+            BroadcastEvent::HilEvent {
+                instance_id,
+                event_id,
+            } => WorkflowEvent::HilEvent {
+                instance_id,
+                event_id,
+            },
+        }
+    }
 }
 
 /// Current connection health for display in the UI.

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -22,6 +22,7 @@ pub async fn run(args: MonitorArgs) -> Result<()> {
     let workspace_root = find_workspace_root(&current_dir)?;
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: args.http_url,
         ws_url: args.ws_url,
     };
@@ -40,6 +41,21 @@ pub async fn run(args: MonitorArgs) -> Result<()> {
     let poll_handle = tokio::spawn(polling_loop(client.clone(), event_tx.clone()));
     let command_handle = tokio::spawn(command_loop(client.clone(), command_rx, event_tx.clone()));
 
+    let backend_handle = if args.backend {
+        Some(tokio::spawn(async move {
+            if let Err(err) = crate::cli::commands::serve(crate::cli::args::ServeArgs {
+                host: "127.0.0.1".to_string(),
+                port: 8080,
+            })
+            .await
+            {
+                tracing::error!("Backend server error: {:?}", err);
+            }
+        }))
+    } else {
+        None
+    };
+
     tokio::task::spawn_blocking(move || {
         ui::run_tui(endpoints, workspace_root, event_rx, command_tx)
     })
@@ -48,6 +64,9 @@ pub async fn run(args: MonitorArgs) -> Result<()> {
     ws_handle.abort();
     poll_handle.abort();
     command_handle.abort();
+    if let Some(handle) = backend_handle {
+        handle.abort();
+    }
 
     Ok(())
 }

--- a/src/monitor/state.rs
+++ b/src/monitor/state.rs
@@ -70,6 +70,11 @@ impl MonitorState {
             MonitorEvent::Message(message) => {
                 self.last_seen_message(message);
             }
+            MonitorEvent::Workflow(workflow_event) => {
+                // Workflow events can be handled here in the future
+                // For now, we just log them
+                tracing::debug!("Received workflow event: {:?}", workflow_event);
+            }
         }
     }
 

--- a/tests/bin/logging_integration_helper.rs
+++ b/tests/bin/logging_integration_helper.rs
@@ -95,6 +95,7 @@ impl Config {
             Mode::Monitor => Ok(Command::Monitor(MonitorArgs {
                 http_url: None,
                 ws_url: None,
+                backend: false,
             })),
             Mode::LocalDev => {
                 let workspace = self

--- a/tests/fixtures/operators.json
+++ b/tests/fixtures/operators.json
@@ -1,0 +1,146 @@
+[
+  {
+    "operator_type": "noop",
+    "description": "No-operation operator that does nothing and always succeeds",
+    "params_schema": {}
+  },
+  {
+    "operator_type": "command",
+    "description": "Execute shell commands and capture output",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute"
+        },
+        "capture_output": {
+          "type": "boolean",
+          "description": "Capture stdout and stderr",
+          "default": true
+        }
+      },
+      "required": ["command"]
+    }
+  },
+  {
+    "operator_type": "assert_completed",
+    "description": "Assert that a workflow task has completed successfully",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "description": "Task ID to check"
+        }
+      },
+      "required": ["task_id"]
+    }
+  },
+  {
+    "operator_type": "barrier",
+    "description": "Wait for all upstream tasks to complete before proceeding",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "timeout_seconds": {
+          "type": "number",
+          "description": "Maximum time to wait in seconds",
+          "default": 300
+        }
+      }
+    }
+  },
+  {
+    "operator_type": "set_context",
+    "description": "Set key-value pairs in the workflow context",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "object",
+          "description": "Key-value pairs to set in context"
+        }
+      },
+      "required": ["values"]
+    }
+  },
+  {
+    "operator_type": "read_control_file",
+    "description": "Read and parse control file for workflow directives",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to control file"
+        }
+      },
+      "required": ["path"]
+    }
+  },
+  {
+    "operator_type": "agent",
+    "description": "AI agent operator that uses external AI engines",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "AI engine to use (e.g., claude_code)",
+          "default": "claude_code"
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Prompt to send to the AI engine"
+        }
+      },
+      "required": ["prompt"]
+    }
+  },
+  {
+    "operator_type": "human_approval",
+    "description": "Request human approval before proceeding",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "question": {
+          "type": "string",
+          "description": "Question to ask the human"
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "description": "Time to wait for response in seconds",
+          "default": 300
+        }
+      },
+      "required": ["question"]
+    }
+  },
+  {
+    "operator_type": "human_decision",
+    "description": "Request a decision from a human with multiple options",
+    "params_schema": {
+      "type": "object",
+      "properties": {
+        "question": {
+          "type": "string",
+          "description": "Question to ask the human"
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Available choices for the human"
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "description": "Time to wait for response in seconds",
+          "default": 300
+        }
+      },
+      "required": ["question", "choices"]
+    }
+  }
+]

--- a/tests/integration/test_api.rs
+++ b/tests/integration/test_api.rs
@@ -1,0 +1,735 @@
+use axum::{
+    body::Body,
+    http::{header, method::Method, Request, StatusCode},
+};
+use newton::api::state::AppState;
+use newton_types::{
+    ApiError, BroadcastEvent, HilAction, HilEvent, HilEventType, HilStatus, NodeState, NodeStatus,
+    OperatorDescriptor, WorkflowDefinition, WorkflowInstance, WorkflowStatus,
+};
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_health_endpoint() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "healthy");
+    assert!(json["version"].is_string());
+}
+
+#[tokio::test]
+async fn test_list_workflows_empty() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/api/workflows")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let workflows: Vec<WorkflowInstance> = serde_json::from_slice(&body).unwrap();
+
+    assert!(workflows.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_workflows_with_instances() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let instance = WorkflowInstance {
+        instance_id: instance_id.clone(),
+        workflow_id: "test-workflow".to_string(),
+        status: WorkflowStatus::Running,
+        nodes: vec![],
+        started_at: chrono::Utc::now(),
+        ended_at: None,
+    };
+
+    state.instances.insert(instance_id.clone(), instance);
+
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/api/workflows")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let workflows: Vec<WorkflowInstance> = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(workflows.len(), 1);
+    assert_eq!(workflows[0].instance_id, instance_id);
+    assert_eq!(workflows[0].workflow_id, "test-workflow");
+}
+
+#[tokio::test]
+async fn test_get_workflow_not_found() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let instance_id = Uuid::new_v4();
+    let request = Request::builder()
+        .uri(format!("/api/workflows/{}", instance_id))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let error: ApiError = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(error.code, "API-WORKFLOW-002");
+    assert_eq!(error.category, "ValidationError");
+    assert_eq!(error.message, "Workflow instance not found");
+}
+
+#[tokio::test]
+async fn test_get_workflow_invalid_id() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/api/workflows/invalid-uuid")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let error: ApiError = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(error.code, "API-WORKFLOW-001");
+    assert_eq!(error.category, "ValidationError");
+}
+
+#[tokio::test]
+async fn test_get_workflow_success() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let instance = WorkflowInstance {
+        instance_id: instance_id.clone(),
+        workflow_id: "test-workflow".to_string(),
+        status: WorkflowStatus::Running,
+        nodes: vec![NodeState {
+            node_id: "task-1".to_string(),
+            status: NodeStatus::Succeeded,
+            started_at: Some(chrono::Utc::now()),
+            ended_at: Some(chrono::Utc::now()),
+        }],
+        started_at: chrono::Utc::now(),
+        ended_at: None,
+    };
+
+    state.instances.insert(instance_id.clone(), instance);
+
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri(format!("/api/workflows/{}", instance_id))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let workflow: WorkflowInstance = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(workflow.instance_id, instance_id);
+    assert_eq!(workflow.workflow_id, "test-workflow");
+    assert_eq!(workflow.status, WorkflowStatus::Running);
+    assert_eq!(workflow.nodes.len(), 1);
+}
+
+#[tokio::test]
+async fn test_update_workflow_success() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let instance = WorkflowInstance {
+        instance_id: instance_id.clone(),
+        workflow_id: "old-workflow".to_string(),
+        status: WorkflowStatus::Running,
+        nodes: vec![],
+        started_at: chrono::Utc::now(),
+        ended_at: None,
+    };
+
+    state.instances.insert(instance_id.clone(), instance);
+
+    let app = newton::api::create_router(state);
+
+    let update = WorkflowDefinition {
+        workflow_id: "new-workflow".to_string(),
+        definition: json!({"test": "value"}),
+    };
+
+    let request = Request::builder()
+        .method(Method::PUT)
+        .uri(format!("/api/workflows/{}", instance_id))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&update).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let workflow: WorkflowInstance = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(workflow.workflow_id, "new-workflow");
+}
+
+#[tokio::test]
+async fn test_list_operators() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/api/operators")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let operators: Vec<OperatorDescriptor> = serde_json::from_slice(&body).unwrap();
+
+    assert!(!operators.is_empty());
+    assert!(operators.iter().any(|op| op.operator_type == "noop"));
+}
+
+#[tokio::test]
+async fn test_list_hil_events_empty() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let instance_id = Uuid::new_v4();
+    let request = Request::builder()
+        .uri(format!("/api/hil/workflows/{}", instance_id))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let events: Vec<HilEvent> = serde_json::from_slice(&body).unwrap();
+
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_hil_events_with_events() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let event = HilEvent {
+        event_id,
+        instance_id: instance_id.clone(),
+        node_id: Some("task-1".to_string()),
+        channel: "test-channel".to_string(),
+        event_type: HilEventType::Question,
+        question: "What should we do?".to_string(),
+        choices: vec!["Option A".to_string(), "Option B".to_string()],
+        timeout_seconds: Some(300),
+        correlation_id: None,
+        status: HilStatus::Pending,
+        timestamp: chrono::Utc::now(),
+    };
+
+    state.hil_events.insert(event_id, event);
+
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri(format!("/api/hil/workflows/{}", instance_id))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let events: Vec<HilEvent> = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_id, event_id);
+    assert_eq!(events[0].instance_id, instance_id);
+}
+
+#[tokio::test]
+async fn test_submit_hil_action_success() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let event = HilEvent {
+        event_id,
+        instance_id: instance_id.clone(),
+        node_id: Some("task-1".to_string()),
+        channel: "test-channel".to_string(),
+        event_type: HilEventType::Question,
+        question: "What should we do?".to_string(),
+        choices: vec!["Option A".to_string(), "Option B".to_string()],
+        timeout_seconds: Some(300),
+        correlation_id: None,
+        status: HilStatus::Pending,
+        timestamp: chrono::Utc::now(),
+    };
+
+    state.hil_events.insert(event_id, event);
+
+    let app = newton::api::create_router(state);
+
+    let action = HilAction {
+        answer: Some("Option A".to_string()),
+        response_type: "text".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/hil/workflows/{}/{}/action",
+            instance_id, event_id
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_submit_hil_action_not_found() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let action = HilAction {
+        answer: Some("Option A".to_string()),
+        response_type: "text".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/hil/workflows/{}/{}/action",
+            instance_id, event_id
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_submit_hil_action_already_resolved() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let event = HilEvent {
+        event_id,
+        instance_id: instance_id.clone(),
+        node_id: Some("task-1".to_string()),
+        channel: "test-channel".to_string(),
+        event_type: HilEventType::Question,
+        question: "What should we do?".to_string(),
+        choices: vec!["Option A".to_string(), "Option B".to_string()],
+        timeout_seconds: Some(300),
+        correlation_id: None,
+        status: HilStatus::Resolved,
+        timestamp: chrono::Utc::now(),
+    };
+
+    state.hil_events.insert(event_id, event);
+
+    let app = newton::api::create_router(state);
+
+    let action = HilAction {
+        answer: Some("Option A".to_string()),
+        response_type: "text".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/hil/workflows/{}/{}/action",
+            instance_id, event_id
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_submit_hil_action_invalid_response_type() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let event = HilEvent {
+        event_id,
+        instance_id: instance_id.clone(),
+        node_id: Some("task-1".to_string()),
+        channel: "test-channel".to_string(),
+        event_type: HilEventType::Question,
+        question: "What should we do?".to_string(),
+        choices: vec!["Option A".to_string(), "Option B".to_string()],
+        timeout_seconds: Some(300),
+        correlation_id: None,
+        status: HilStatus::Pending,
+        timestamp: chrono::Utc::now(),
+    };
+
+    state.hil_events.insert(event_id, event);
+
+    let app = newton::api::create_router(state);
+
+    let action = HilAction {
+        answer: Some("Option A".to_string()),
+        response_type: "invalid_type".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/hil/workflows/{}/{}/action",
+            instance_id, event_id
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_submit_hil_action_missing_answer() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+
+    let event = HilEvent {
+        event_id,
+        instance_id: instance_id.clone(),
+        node_id: Some("task-1".to_string()),
+        channel: "test-channel".to_string(),
+        event_type: HilEventType::Question,
+        question: "What should we do?".to_string(),
+        choices: vec!["Option A".to_string(), "Option B".to_string()],
+        timeout_seconds: Some(300),
+        correlation_id: None,
+        status: HilStatus::Pending,
+        timestamp: chrono::Utc::now(),
+    };
+
+    state.hil_events.insert(event_id, event);
+
+    let app = newton::api::create_router(state);
+
+    let action = HilAction {
+        answer: None,
+        response_type: "text".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/hil/workflows/{}/{}/action",
+            instance_id, event_id
+        ))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_workflow_stream_invalid_uuid() {
+    let state = create_test_state();
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/api/stream/workflow/invalid-uuid/ws")
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "upgrade")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_legacy_list_channels() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let instance = WorkflowInstance {
+        instance_id: instance_id.clone(),
+        workflow_id: "test-workflow".to_string(),
+        status: WorkflowStatus::Running,
+        nodes: vec![],
+        started_at: chrono::Utc::now(),
+        ended_at: None,
+    };
+
+    state.instances.insert(instance_id.clone(), instance);
+
+    let app = newton::api::create_router(state);
+
+    let request = Request::builder()
+        .uri("/channels")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(json["channels"].is_array());
+    assert_eq!(json["channels"].as_array().unwrap().len(), 1);
+    assert_eq!(json["channels"][0], "test-workflow");
+}
+
+#[tokio::test]
+async fn test_legacy_api_list_channels() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    state.instances.insert(
+        instance_id.clone(),
+        WorkflowInstance {
+            instance_id: instance_id.clone(),
+            workflow_id: "workflow-a".to_string(),
+            status: WorkflowStatus::Running,
+            nodes: vec![],
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+        },
+    );
+
+    let app = newton::api::create_router(state);
+    let request = Request::builder()
+        .uri("/api/channels")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(json["channels"].is_array());
+    assert_eq!(json["channels"][0]["name"], "workflow-a");
+}
+
+#[tokio::test]
+async fn test_legacy_api_list_channel_messages() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+    state.hil_events.insert(
+        event_id,
+        HilEvent {
+            event_id,
+            instance_id,
+            node_id: Some("task-1".to_string()),
+            channel: "workflow-a".to_string(),
+            event_type: HilEventType::Question,
+            question: "Proceed?".to_string(),
+            choices: vec!["yes".to_string(), "no".to_string()],
+            timeout_seconds: Some(30),
+            correlation_id: None,
+            status: HilStatus::Pending,
+            timestamp: chrono::Utc::now(),
+        },
+    );
+
+    let app = newton::api::create_router(state);
+    let request = Request::builder()
+        .uri("/api/channels/workflow-a/messages?limit=10")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(json.is_array());
+    assert_eq!(json.as_array().unwrap().len(), 1);
+    assert_eq!(json[0]["id"], event_id.to_string());
+    assert_eq!(json[0]["content"]["type"], "question");
+}
+
+#[tokio::test]
+async fn test_legacy_api_submit_message_response() {
+    let state = create_test_state();
+
+    let instance_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4();
+    state.hil_events.insert(
+        event_id,
+        HilEvent {
+            event_id,
+            instance_id,
+            node_id: Some("task-1".to_string()),
+            channel: "workflow-a".to_string(),
+            event_type: HilEventType::Question,
+            question: "Proceed?".to_string(),
+            choices: vec!["yes".to_string(), "no".to_string()],
+            timeout_seconds: Some(30),
+            correlation_id: None,
+            status: HilStatus::Pending,
+            timestamp: chrono::Utc::now(),
+        },
+    );
+
+    let app = newton::api::create_router(state);
+    let action = HilAction {
+        answer: Some("yes".to_string()),
+        response_type: "text".to_string(),
+    };
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/v1/messages/{}/response", event_id))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&action).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["event_id"], event_id.to_string());
+}
+
+#[tokio::test]
+async fn test_event_broadcasting() {
+    let state = create_test_state();
+    let _ = newton::api::create_router(state.clone());
+
+    let instance_id = Uuid::new_v4().to_string();
+
+    let event = BroadcastEvent::WorkflowInstanceUpdated {
+        instance_id: instance_id.clone(),
+    };
+
+    let _ = state.events_tx.send(event);
+}
+
+fn create_test_state() -> AppState {
+    let operators = vec![
+        OperatorDescriptor {
+            operator_type: "noop".to_string(),
+            description: "No-operation operator".to_string(),
+            params_schema: json!({}),
+        },
+        OperatorDescriptor {
+            operator_type: "command".to_string(),
+            description: "Execute shell commands".to_string(),
+            params_schema: json!({"type": "object"}),
+        },
+    ];
+
+    AppState::new(operators)
+}

--- a/tests/monitor_integration_test.rs
+++ b/tests/monitor_integration_test.rs
@@ -20,6 +20,7 @@ fn build_endpoints(server: &MockServer) -> MonitorEndpoints {
         http_url,
         ws_url,
         workspace_root: PathBuf::from("."),
+        workflow_service_url: None,
     }
 }
 

--- a/tests/test_monitor_config.rs
+++ b/tests/test_monitor_config.rs
@@ -17,6 +17,7 @@ fn endpoint_resolution_http_override_ws_from_config() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: Some("http://override.example.com:9081".to_string()),
         ws_url: None,
     };
@@ -44,6 +45,7 @@ fn endpoint_resolution_ws_override_http_from_config() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: Some("ws://override.example.com:9080".to_string()),
     };
@@ -67,6 +69,7 @@ fn endpoint_resolution_missing_http_yields_specific_error() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -100,6 +103,7 @@ fn endpoint_resolution_missing_ws_yields_specific_error() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -129,6 +133,7 @@ fn endpoint_resolution_missing_both_yields_specific_error() {
     fs::write(&monitor_conf, "# Empty config\n").unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -158,6 +163,7 @@ fn url_parse_failure_identifies_http_endpoint() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -187,6 +193,7 @@ fn url_parse_failure_identifies_ws_endpoint() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -226,6 +233,7 @@ fn discovery_order_monitor_conf_takes_precedence() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -260,6 +268,7 @@ fn discovery_order_alphabetical_fallback() {
     .unwrap();
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -276,6 +285,7 @@ fn missing_configs_dir_provides_actionable_error() {
     // Don't create .newton/configs directory
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: None,
         ws_url: None,
     };
@@ -301,6 +311,7 @@ fn cli_overrides_work_without_config_dir() {
     // Don't create .newton/configs directory - CLI overrides should still work
 
     let overrides = MonitorOverrides {
+        workflow_service_url: None,
         http_url: Some("http://override.example.com:8081".to_string()),
         ws_url: Some("ws://override.example.com:8080".to_string()),
     };


### PR DESCRIPTION
## Summary
- add Newton backend API server with in-memory app state and CORS-enabled Axum router
- add workflow/HIL/operator/streaming endpoints plus legacy monitor compatibility routes
- add shared backend types crate and integration tests for API and monitor compatibility

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test