### PR TITLE
chore(deps): bump aikit-sdk to 0.1.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,15 +44,17 @@ dependencies = [
 
 [[package]]
 name = "aikit-sdk"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeb63a7affb101f8a4c353f413a16792910a1810f6ac0c1f83ae921d3b1872d"
+checksum = "15cf14b1fbeacb863cb32495139009455bd52d59d028fdc1dd488b4ba02122c6"
 dependencies = [
  "glob",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "tempfile",
  "toml",
+ "tracing",
  "walkdir",
  "zip",
 ]
@@ -1636,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "newton"
-version = "0.5.71"
+version = "0.5.76"
 dependencies = [
  "aikit-sdk",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 clap = { version = "4.4", features = ["derive", "cargo"] }
 tokio = { version = "1.49", features = ["full"] }
 anyhow = "1.0"
-aikit-sdk = "0.1.49"
+aikit-sdk = "0.1.50"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }

--- a/src/core/workflow_graph/operators/engine/mod.rs
+++ b/src/core/workflow_graph/operators/engine/mod.rs
@@ -191,11 +191,12 @@ impl AikitEngineManager {
             .with_code("WFG-SDK-002"));
         }
 
-        let options = aikit_sdk::RunOptions {
-            model: model.map(str::to_string),
-            yolo: true,
-            stream: false,
-        };
+        let mut options = aikit_sdk::RunOptions::new()
+            .with_yolo(true)
+            .with_stream(false);
+        if let Some(m) = model {
+            options = options.with_model(m);
+        }
 
         let prompt_owned = prompt.to_string();
         let engine_name_owned = engine_name.to_string();
@@ -245,6 +246,23 @@ pub fn map_run_error(err: aikit_sdk::RunError) -> AppError {
             format!("aikit-sdk engine output read failed: {}", io_err),
         )
         .with_code("WFG-SDK-001"),
+        aikit_sdk::RunError::CallbackPanic(_) => AppError::new(
+            ErrorCategory::IoError,
+            "aikit-sdk event callback panicked".to_string(),
+        )
+        .with_code("WFG-SDK-001"),
+        aikit_sdk::RunError::ReaderFailed { stream, source } => AppError::new(
+            ErrorCategory::IoError,
+            format!("aikit-sdk reader failed on {:?}: {}", stream, source),
+        )
+        .with_code("WFG-SDK-001"),
+        aikit_sdk::RunError::TimedOut { timeout, .. } => AppError::new(
+            ErrorCategory::IoError,
+            format!("aikit-sdk agent timed out after {:?}", timeout),
+        )
+        .with_code("WFG-SDK-001"),
+        _ => AppError::new(ErrorCategory::IoError, format!("aikit-sdk error: {}", err))
+            .with_code("WFG-SDK-001"),
     }
 }
 


### PR DESCRIPTION
## Summary
Bump `aikit-sdk` from 0.1.49 to **0.1.50** (crates.io) and refresh `Cargo.lock`.

## SDK API changes (minimal)
`aikit-sdk` 0.1.50 marks `RunOptions` and `RunError` as `#[non_exhaustive]`. Newton now builds options via `RunOptions::new()` / `with_*` and maps new `RunError` variants (`CallbackPanic`, `ReaderFailed`, `TimedOut`) plus a fallback arm.

## Lockfile
The `newton` package entry in `Cargo.lock` is aligned with `Cargo.toml` (0.5.76) after `cargo update -p aikit-sdk`.

## Testing
- `cargo test --all-features --all-targets`
- Pre-commit / pre-push hooks (fmt, clippy, tests, docs)
