### PR TITLE
refactor(init): workflow-first template and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,19 @@
 
 ## What is Newton?
 
-Newton is an iterative optimization framework for agentic AI goals that benefit from structured feedback and controlled execution. The classic loop orchestrates three phases:
+Newton is a **workflow-first** tool for running structured, repeatable automation: you describe steps in YAML (shell commands, agents, human approvals, branching, and checks), and the CLI runs them with clear completion rules, checkpoints, and artifacts. It fits agent-assisted coding, release checklists, and other tasks where you want a defined graph instead of ad hoc scripts.
 
-- **Evaluator**: Assesses the current state/solution and provides quality metrics
-- **Advisor**: Generates improvement recommendations based on evaluation
-- **Executor**: Implements the recommended changes to improve the solution
-
-This evaluation-advice-execution loop continues until goals are met or iteration limits are reached.
-
-Instead of just trying the same thing over and over and hoping it gets better, this kind of loop pauses to check how things are going, think about what could improve, and then make targeted changes. Each round learns from the last, so progress is more guided than random. It also keeps track of what worked best so far, which is helpful when goals involve trade-offs or gradual improvements rather than a simple yes/no result. Overall, it feels less like “try again” and more like “let’s see what happened and do a bit better next time,” which makes it a good fit for a wide range of problems.
+You can still think in terms of **evaluate → advise → act** when designing workflows (measure, decide, apply), but the unit of execution is always the workflow file you run with `newton run` or `newton batch`.
 
 ## Workflow Graph Capabilities
 
 Newton includes a production workflow runner with YAML-defined tasks and deterministic execution semantics:
 
 - Workflow commands: `newton run|lint|validate|dot|explain|resume|checkpoints|artifacts|webhook`
-- Safety checks: lint rules, expression precompile validation, shell opt-in, reachability analysis
+- Safety checks: workflow lint, early validation of expressions, guarded shell usage, reachability checks
 - Deterministic completion: goal gates, terminal tasks, explicit completion policy, stable error codes
 - Runtime durability: checkpoint persistence, resume support, artifact routing/cleanup, execution warnings
-- Authoring ergonomics: transform pipeline with macro expansion, `include_if` filtering, `{{ ... }}` interpolation, and `$expr` evaluation
+- Authoring support: macros, `include_if` filtering, `{{ ... }}` interpolation, and `$expr` evaluation
 
 ### Built-in Workflow Operators
 
@@ -81,19 +75,17 @@ Follow the **Setting up a new project** flow below to go from a blank directory 
 
 1. Create a project directory and `cd` into it.
 2. Run `newton init .` to scaffold the workspace.
-3. Run the loop with an inline goal (no `GOAL.md` needed):
+3. Run a workflow from the template (optional input file as second positional):
    ```bash
-   newton run workflow.yaml input.txt
+   newton run .newton/workflows/develop.yaml --workspace .
    ```
-
-For a project with a persistent goal file or custom evaluator/advisor/executor scripts, follow **Setting up a new project** below.
 
 ### Setting up a new project
 
 1. Create a project directory and `cd` into it.
-2. Run `newton init .` to scaffold `.newton/`, install the template under `.newton/scripts/`, write `.newton/configs/default.conf`, and prompt the template to add `GOAL.md` if it was missing.
-3. Optionally edit `GOAL.md` after initialization so it reflects your real goal.
-4. Run `newton run` in that directory—`run` uses the `.newton/scripts/` toolchain by default, so no additional paths are required.
+2. Run `newton init .` to scaffold `.newton/` (layout, template files such as workflows and helper scripts, and `.newton/configs/default.conf`).
+3. Edit `.newton/configs/default.conf`: set `workflow_file` to the workflow YAML `newton batch` should run (see comment in that file). Add a `<project_id>.conf` copy or symlink if you use batch with a non-default id.
+4. Run a workflow explicitly, for example: `newton run .newton/workflows/develop.yaml --workspace .` (pick the YAML that matches your template).
 
 For an existing repository, run `newton init .` at the repo root instead of creating a new directory.
 
@@ -116,10 +108,6 @@ Usage: newton <COMMAND>
 ```
 
 The help output now includes the same version banner at the top, so you can confirm which release is installed even when scanning command descriptions.
-
-## Repository
-
-This repository includes a Repomix pack (`repomix-output.xml`) for contributors who want AI-assisted analysis or review assistance.
 
 ## Commands Reference
 
@@ -154,10 +142,10 @@ newton run workflow.yaml --max-time-seconds 3600
 
 ### `init [workspace-path]`
 
-Create the `.newton` workspace layout, install the default Newton template via `aikit-sdk`, and write `.newton/configs/default.conf` with `project_root=.`, `coding_agent=opencode`, and the default `zai-coding-plan/glm-4.7` model.
+Create the `.newton` workspace layout, install the default Newton workspace template, and write `.newton/configs/default.conf` with `project_root` (absolute path to the directory you initialized), a default `coding_model` (typically `zai-coding-plan/glm-4.7`), and commented guidance for `workflow_file` (set this when using `newton batch`).
 
 **Options:**
-- `--template-source <SOURCE>`: Optional template locator (default: `gonewton/newton-templates`). Paths that exist on disk are copied directly, otherwise the built-in template is used.
+- `--template-source <SOURCE>`: Optional template locator (default: `gonewton/newton-templates`). If the value is a path on disk, that template is used; otherwise the built-in template shipped with the CLI is used.
 
 **Examples:**
 ```bash
@@ -167,44 +155,17 @@ newton init /path/to/project
 
 ### `batch <project_id>`
 
-Process queued plan files for a project straight from the CLI. `newton batch` discovers the workspace root by walking up from the current directory (or use `--workspace PATH`) until it finds `.newton`. It expects `.newton/configs/<project_id>.conf` to contain at least `project_root`, `coding_agent`, and `coding_model`, and `.newton/plan/<project_id>/todo` to house queued plan files. Each plan is copied into `project_root/.newton/tasks/<task_id>/input/spec.md` and fed to the regular `newton run` flow.
+Process queued plan files for a project. `newton batch` discovers the workspace root by walking up from the current directory (or use `--workspace PATH`) until it finds `.newton`. It reads `.newton/configs/<project_id>.conf`, which **must** include `project_root` and `workflow_file` (path to a workflow YAML, resolved relative to `project_root` or the workspace root). Queued items live under `.newton/plan/<project_id>/todo/`. For each plan, Newton runs that workflow the same way as `newton run` on that YAML.
 
 - `--workspace PATH`: Override workspace discovery.
 - `--once`: Process one todo file then exit.
 - `--sleep SECONDS`: Poll interval when the queue is empty (default 60).
 
-Plan files move from `todo` to `completed` only after a successful run, and the same task ID is reused when a plan is re-queued. Batch also sets `CODING_AGENT`, `CODING_AGENT_MODEL`, `NEWTON_EXECUTOR_CODING_AGENT`, and `NEWTON_EXECUTOR_CODING_AGENT_MODEL` based on the `.conf` so the project honors those overrides.
+Plan files move from `todo` to `completed` when the workflow succeeds, or to `failed` when it errors.
 
+Other keys in `.conf` files are ignored by `newton batch` unless documented for another command.
 
-Batch configs now support additional optional keys for parity with `start.sh`/`loop.sh`:
-
-| Key | Description |
-| --- | --- |
-| `evaluator_cmd`, `advisor_cmd`, `executor_cmd` | Override the tool invocations. When omitted, batch derives defaults that match the workspace layout created by `newton init` (`project_root/.newton/scripts/{evaluator,advisor}.sh` and `workspace_root/.newton/scripts/executor.sh`). |
-| `resume` | `true`/`1` keeps the task and project state directories intact; when false the directories are wiped before the run. |
-| `max_iterations`, `max_time` | Optional limits that mirror the values passed to `newton run`. Without a control file signal, hitting either limit counts as failure. |
-| `verbose` | Passes `--verbose` through to the run so tool stdout/stderr is rendered. |
-| `control_file` | The filename (default `newton_control.json`) stored inside the task state directory; evaluators must write `{"done": true}` to `NEWTON_CONTROL_FILE` in that folder to signal success. |
-
-Batch exposes the following environment variables for pre-run hooks, tool runs, and post hooks: `NEWTON_STATE_DIR`, `NEWTON_WS_ROOT`, `NEWTON_CODER_CMD`, `NEWTON_CONTROL_FILE`, `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`, `CODING_AGENT`, and `CODING_AGENT_MODEL`. Pre-run scripts also see `NEWTON_PROJECT_ROOT`, `NEWTON_PROJECT_ID`, `NEWTON_TASK_ID`, `NEWTON_GOAL_FILE`, and `NEWTON_RESUME`. Post hooks additionally receive `NEWTON_RESULT`, `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`, `NEWTON_STATE_DIR`, and `NEWTON_CONTROL_FILE` so they can reference the same artifacts without re-reading the plan.
-
-The feature branch name is derived from the plan frontmatter (`branch: feature/foo`) when present; otherwise batch uses `feature/<task_id>` with underscores replaced by dashes. This value populates `NEWTON_BRANCH_NAME` everywhere so hooks can operate on the right Git branch without re-parsing the spec.
-
-Success is gatekept by the control file that lives under `NEWTON_STATE_DIR`. Evaluator scripts must write `{"done": true}` to `NEWTON_CONTROL_FILE` when the goal is reached and `{"done": false}` (or remove the file) when more iterations are required. The loop stops only when the control file reports `done: true`; every other termination (limits, errors, or missing file) is treated as failure and sends the plan to `failed/`.
-
-Projects can opt into git hooks by adding a `[hooks]` section to `newton.toml`:
-
-```toml
-[hooks]
-before_run = "git checkout main"
-after_run = "git checkout $NEWTON_RESULT"
-```
-
-Hook commands always run with `sh -c "<value>"` inside the project root. `before_run` executes before the orchestrator and sees `NEWTON_GOAL_FILE`, `NEWTON_PROJECT_ID`, and `NEWTON_TASK_ID` if those variables exist. `after_run` always runs (even on failure) and is passed `NEWTON_RESULT=success|failure` plus `NEWTON_EXECUTION_ID` when available.
-
-Workspace discovery and the `.conf` parser in `core/batch_config` are shared with the upcoming monitor so logic is not duplicated.
-
-### Plan-Based Batch Processing Architecture
+### Plans and the batch queue
 
 Newton uses a plan-based queue system for processing multiple tasks through batch mode:
 
@@ -248,40 +209,39 @@ Each plan creates a task directory at `.newton/tasks/{task_id}/` with:
 
 The task ID is derived from the plan filename (sanitized to remove special characters).
 
-#### Plan Lifecycle
+#### Plan lifecycle
 
 1. Plan file is created in `.newton/plan/{project_id}/todo/`
 2. `newton batch {project_id}` picks it up for processing
 3. Plan content is copied to `.newton/tasks/{task_id}/input/spec.md`
-4. `newton run` executes with the plan as the goal
-5. On success (control file shows `done: true`), plan moves to `completed/`
-6. On failure (limits hit, errors, or `done: false`), plan moves to `failed/`
+4. Newton runs the workflow from `workflow_file` in your `.conf`, passing the spec path and workspace in the trigger payload (same as running that workflow yourself with `newton run`)
+5. If the workflow completes successfully, the plan moves to `completed/`
+6. If the workflow errors, the plan moves to `failed/`
 
-Re-queuing a plan (moving it back to `todo/`) reuses the same task ID, allowing state to be preserved if `resume=true` is set in the configuration.
+Re-queuing a plan (moving it back to `todo/`) reuses the same task ID and task directories under `.newton/tasks/`.
 
 ## Logging
 
-Newton routing now keeps logs deterministic across every command by mapping the CLI command and environment to an execution context. Contexts are:
+Newton sends log output to files and sometimes to the terminal depending on how you invoke the CLI:
 
-- **TUI**: `newton monitor` with no console output (logs persist to file only).
-- **LocalDev**: interactive commands such as `run`, `step`, `status`, `report`, `error`, and `init`; console output defaults to `stderr`.
-- **Batch**: `newton batch` runs in quiet mode, writing only to files unless overridden.
-- **RemoteAgent**: any command run with `NEWTON_REMOTE_AGENT=1` (except `monitor`) – file logging stays enabled and console output remains disabled.
+- **`newton monitor`**: logs go to the log file; the TUI is not mixed with debug log lines by default.
+- **Interactive commands** (for example `newton run`, `newton init`): console output defaults to `stderr` for normal messages.
+- **`newton batch`**: quiet terminal by default; inspect the log file when troubleshooting.
+- **`NEWTON_REMOTE_AGENT=1`**: keeps file logging on and avoids spamming the agent console (does not apply to `monitor`).
 
 All commands write to `<workspace>/.newton/logs/newton.log` when a workspace is detected, or to `$HOME/.newton/logs/newton.log` as a fallback. The directory is created automatically when missing, and paths provided via config are normalized to avoid accidental traversal.
 
 Newton looks for an optional `.newton/config/logging.toml` file and applies the settings only when the file exists. Invalid values (such as a malformed OpenTelemetry endpoint) fail fast with a clear message, while the absence of the config file is not treated as an error.
 
-### Configuration precedence
+### Log configuration
 
-Logging behavior can be customized via:
+You can tune logging with:
 
-1. CLI flags (future-proof – none exist yet for this feature).
-2. Environment variables such as `RUST_LOG`, `NEWTON_REMOTE_AGENT`, and `OTEL_EXPORTER_OTLP_ENDPOINT`.
-3. `.newton/config/logging.toml` using keys like `logging.log_dir`, `logging.default_level`, `logging.enable_file`, `logging.console_output`, and the `logging.opentelemetry.*` table.
-4. Built-in defaults (`info` level, file enabled, console only for local dev, no telemetry).
+1. Optional `.newton/config/logging.toml` (keys such as `logging.log_dir`, `logging.default_level`, `logging.enable_file`, `logging.console_output`, and `logging.opentelemetry.*` when present).
+2. Environment variables, including `RUST_LOG` (verbose Newton messages), `NEWTON_REMOTE_AGENT`, and `OTEL_EXPORTER_OTLP_ENDPOINT` for OpenTelemetry export when configured.
+3. Built-in defaults when no file is present: typically `info`, file logging on, console on for local interactive use, telemetry off unless you enable it.
 
-OpenTelemetry exports only activate when either `logging.opentelemetry.endpoint` or `OTEL_EXPORTER_OTLP_ENDPOINT` provides a valid URL, and the endpoint string is validated before use. The framework always honors `RUST_LOG` as the highest-priority level filter so you can drive verbosity without touching the config file.
+OpenTelemetry export runs only when a valid endpoint is set in config or via `OTEL_EXPORTER_OTLP_ENDPOINT`. `RUST_LOG` overrides the default level when set.
 
 ### Troubleshooting TUI/logging conflicts
 
@@ -294,7 +254,7 @@ OpenTelemetry exports only activate when either `logging.opentelemetry.endpoint`
 Stream live ailoop channels for every project/branch in the workspace via a terminal UI that highlights blocking questions and authorizations, keeps a queue of pending prompts, lets you answer/approve/deny directly in the terminal, and provides filtering (`/`), layout toggle (`V`), queue tab (`Q`), and help (`?`).
 
 **Behavior:**
-`newton monitor` walks up from the current directory to find the workspace root containing `.newton`, then reads `ailoop_server_http_url` and `ailoop_server_ws_url` from the first `.newton/configs/*.conf` file that exposes both keys (alphabetically) or from `.newton/configs/monitor.conf` when present. It connects to the configured HTTP and WebSocket endpoints, backfills up to 50 messages per channel, subscribes to channels, and renders a ratatui interface with tiles/list stream views, a 30% queue panel, a filter status line, and optional queue-only mode.
+`newton monitor` walks up from the current directory to find the workspace root containing `.newton`, then reads `ailoop_server_http_url` and `ailoop_server_ws_url` from the first `.newton/configs/*.conf` file that defines both keys (alphabetically) or from `.newton/configs/monitor.conf` when present. It connects to those HTTP and WebSocket endpoints, loads recent messages per channel, and opens a full-screen terminal UI with stream views, a queue for pending prompts, filtering, and keyboard shortcuts (see `?` in the UI for help).
 
 **Options:**
 - `--http-url <URL>`: Override the HTTP base URL for this session.
@@ -309,14 +269,7 @@ newton monitor
 
 `newton monitor` works with [ailoop](https://github.com/goailoop/ailoop), a human-in-the-loop messaging server for AI agents. To use newton monitor:
 
-1. **Install ailoop:**
-   ```bash
-   # Using Homebrew
-   brew install ailoop
-
-   # Or using cargo
-   cargo install ailoop-cli
-   ```
+1. **Install ailoop** (for example with Homebrew: `brew install ailoop`, or follow the [ailoop installation docs](https://github.com/goailoop/ailoop)).
 
 2. **Start the ailoop server:**
    ```bash
@@ -356,28 +309,9 @@ Then simply run:
 newton monitor
 ```
 
-### `init <workspace-path>`
+### `init <workspace-path>` (same as `init [workspace-path]`)
 
-Bootstrap a workspace from an installed Newton template. See **Quick Start → Setting up a new project** for the minimal flow that gets a fresh directory to `newton run`. `newton init` renders `.newton/scripts`, `.newton/state`, and `newton.toml`, seeds `GOAL.md`, and keeps everything in sync with the template variables (`project_name`, `coding_agent`, `coding_agent_model`, `test_command`, `language`). The command requires `aikit` to be available on `PATH` and at least one template directory under `.newton/templates/` (templates can be installed via `aikit` packages or checked in alongside your projects).
-
-**Options:**
-- `--template <NAME>`: Choose a template (default: `basic`). The template name must match a subdirectory under `.newton/templates/`.
-- `--name <NAME>`: Override the project name written to `newton.toml` and used in the GOAL stub.
-- `--coding-agent <AGENT>`: Specify the coding agent that will be listed in `newton.toml`.
-- `--model <MODEL>`: Override the coding agent model in the generated config.
-- `--interactive`: Prompt for missing values instead of assuming defaults.
-- `--force`: Proceed even if `.newton/` already exists (existing files are overwritten).
-
-**Behavior:**
-- Validates that `aikit` is installed (`aikit --version` must succeed); otherwise prints an install hint (`https://aikit.readthedocs.io`) and exits with an error.
-- Clears `.newton/state/context.md`, writes fresh `promise.txt`/`executor_prompt.md`/`iteration.txt`, and renders the selected template into `.newton/`.
-- Writes `newton.toml` only when it does not already exist, defaults the `project.template` to the template name, and populates `executor.coding_agent`/`coding_agent_model` plus the recommended `test_command`.
-- Creates `GOAL.md` with a placeholder goal if it is missing.
-
-**Example:**
-```bash
-newton init . --template basic --interactive
-```
+See **Commands Reference → `init [workspace-path]`** above. The command installs the bundled or selected template, creates the usual `.newton/` directories, and writes `configs/default.conf`.
 
 ## Advanced Usage
 
@@ -396,58 +330,9 @@ newton run workflow.yaml --parallel-limit 4
 newton run workflow.yaml --max-time-seconds 3600 --parallel-limit 2
 ```
 
-### Git Integration
+### Git and plans
 
-Newton includes built-in git integration for batch processing workflows:
-
-#### Automatic Branch Management
-
-Each plan can specify a git branch in its frontmatter:
-
-```markdown
----
-branch: feature/add-authentication
----
-
-# Task Description
-...
-```
-
-**Branch name resolution:**
-1. Plan file frontmatter (`branch:` field) - highest priority
-2. Auto-generated from task ID (`feature/{task_id}`) with underscores converted to dashes
-3. Environment variables (`NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`)
-
-The resolved branch name is exposed via `NEWTON_BRANCH_NAME` environment variable to all tools and hooks.
-
-#### Git Hooks in newton.toml
-
-Configure git operations in your project's `newton.toml`:
-
-```toml
-[hooks]
-before_run = "git checkout -b $NEWTON_BRANCH_NAME"
-after_run = "git add . && git commit -m 'Automated changes' || true"
-```
-
-**Hook environment variables:**
-- `before_run`: Receives `NEWTON_GOAL_FILE`, `NEWTON_PROJECT_ID`, `NEWTON_TASK_ID`, `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`
-- `after_run`: Receives all of the above plus `NEWTON_RESULT` (success|failure) and `NEWTON_EXECUTION_ID`
-
-Hooks run with `sh -c "<command>"` from the project root directory.
-
-#### Git Operations in Scripts
-
-Batch mode automatically detects and exposes:
-- Current git branch
-- Base branch (typically `main` or `master`)
-- Both values are available in `NEWTON_BRANCH_NAME` and `NEWTON_BASE_BRANCH`
-
-Your custom scripts can use these for:
-- Creating feature branches
-- Committing changes during optimization
-- Creating pull requests after successful completion
-- Rolling back on failure
+Plan files are Markdown and may include YAML frontmatter (for example a `branch` field) for **your** workflows and scripts to read. Newton batch copies the plan into `.newton/tasks/<task_id>/input/spec.md` and runs the configured workflow; any git checkout, commit, or PR steps belong in workflow tasks or helper scripts you invoke from the workflow.
 
 ## Configuration
 
@@ -458,12 +343,9 @@ Newton expects the following workspace structure:
 ```
 workspace/
 ├── .newton/                # Newton workspace directory
-│   ├── scripts/            # Tool scripts
-│   │   ├── evaluator.sh
-│   │   ├── advisor.sh
-│   │   ├── executor.sh
-│   │   └── coder.sh        # Optional coder script
-│   ├── configs/            # Batch configuration files
+│   ├── workflows/          # Workflow YAML (after init from default template)
+│   ├── scripts/            # Optional helper shell scripts from template
+│   ├── configs/            # Batch configuration files (*.conf)
 │   │   └── default.conf
 │   ├── plan/               # Batch processing plans
 │   │   └── {project_id}/
@@ -479,264 +361,30 @@ workspace/
 │   ├── state/              # Execution state
 │   ├── logs/               # Execution logs
 │   └── artifacts/          # Generated artifacts
-└── GOAL.md                 # Optimization objectives (optional)
+└── (project files)
 ```
 
-### Toolchain Configuration
+### Workflows and shell tasks
 
-Each tool script receives environment variables:
+What your commands and agents see at runtime is defined by your workflow YAML (for example `CommandOperator` and `AgentOperator` tasks) and any wrapper scripts you call from there. Use `.newton/tasks/<task_id>/` under the project for per-plan inputs and state when using batch.
 
-**Common Environment Variables:**
-- `NEWTON_WORKSPACE_PATH`: Absolute path to workspace root
-- `NEWTON_ITERATION`: Current iteration number
-- `NEWTON_STATE_DIR`: Path to state directory
-- `NEWTON_ARTIFACTS_DIR`: Path to artifacts directory
+### Batch configuration file (`.newton/configs/*.conf`)
 
-**Evaluator Environment Variables:**
-- `NEWTON_SCORE_FILE`: Path where score must be written
-- `NEWTON_EVALUATOR_DIR`: Path for evaluator output files
-
-**Advisor Environment Variables:**
-- `NEWTON_ADVISOR_DIR`: Path for advisor recommendations
-
-**Executor Environment Variables:**
-- `NEWTON_EXECUTOR_DIR`: Path for executor logs
-- `NEWTON_SOLUTION_FILE`: Path to current solution file
-
-### Batch Configuration File (.newton/configs/*.conf)
-
-Newton uses simple key=value configuration files for batch processing:
+Use simple `key=value` lines. For `newton batch`, set:
 
 ```conf
-# Required settings
+# Required for batch
 project_root=/path/to/project
-coding_agent=claude
-coding_model=claude-sonnet-4-5
+workflow_file=.newton/workflows/develop.yaml
 
-# Optional tool commands
-evaluator_cmd=.newton/scripts/evaluator.sh
-advisor_cmd=.newton/scripts/advisor.sh
-executor_cmd=.newton/scripts/executor.sh
-coder_cmd=.newton/scripts/coder.sh
-
-# Hook scripts
-
-# Execution control
-resume=true
-max_iterations=10
-max_time=3600
-verbose=true
-control_file=newton_control.json
+# Optional: kept in default.conf after init for templates and tooling; ignored by batch
+coding_model=zai-coding-plan/glm-4.7
 ```
 
-**Configuration Keys:**
-- `project_root`: Root directory of your project (required)
-- `coding_agent`: AI agent to use, e.g., "claude", "openai" (required)
-- `coding_model`: Specific model identifier (required)
-- `evaluator_cmd`, `advisor_cmd`, `executor_cmd`, `coder_cmd`: Custom tool commands (optional, defaults to `.newton/scripts/*.sh`)
-- `resume`: Whether to resume from previous state - `true`/`1` or `false`/`0` (optional, default: false)
-- `max_iterations`: Maximum optimization iterations per task (optional)
-- `max_time`: Maximum execution time in seconds (optional)
-- `verbose`: Enable verbose logging - `true`/`1` or `false`/`0` (optional, default: false)
-- `control_file`: Filename for control file stored in task state directory (optional, default: `newton_control.json`)
+- **`project_root`**: Your project directory; must already contain a `.newton` folder (required for batch).
+- **`workflow_file`**: Workflow YAML to run for each queued plan. Relative paths are resolved against `project_root` first, then the workspace root (required for batch).
 
-### Control Files for Success Determination
-
-Control files provide a mechanism for evaluator scripts to signal task completion in batch processing workflows.
-
-#### How Control Files Work
-
-The control file is a JSON file stored in the task's state directory (`NEWTON_STATE_DIR`) that the evaluator writes to indicate whether the optimization goal has been met:
-
-```json
-{
-  "done": true
-}
-```
-
-**File location:** `{task_state_dir}/{control_file_name}`
-- Path is available via `NEWTON_CONTROL_FILE` environment variable
-- Default filename is `newton_control.json` (configurable via `control_file` config key)
-
-#### Success Criteria
-
-The batch orchestrator determines task success based on the control file:
-
-- **Success:** Control file exists with `"done": true`
-- **Failure:** Any of the following:
-  - Control file missing
-  - Control file has `"done": false`
-  - Iteration or time limits reached without `"done": true`
-  - Errors during execution
-
-#### Evaluator Script Example
-
-```bash
-#!/bin/bash
-# evaluator.sh
-
-# Run tests
-if npm test; then
-  # Tests passed - signal completion
-  echo '{"done": true}' > "$NEWTON_CONTROL_FILE"
-  echo "All tests passed!" > "$NEWTON_EVALUATOR_DIR/status.md"
-else
-  # Tests failed - need more iterations
-  echo '{"done": false}' > "$NEWTON_CONTROL_FILE"
-  echo "Tests failed, needs improvement" > "$NEWTON_EVALUATOR_DIR/status.md"
-fi
-```
-
-#### Extended Control File Format
-
-You can include additional metadata in the control file:
-
-```json
-{
-  "done": true,
-  "message": "All acceptance criteria met",
-  "score": 95,
-  "tests_passed": 42,
-  "tests_failed": 0
-}
-```
-
-The orchestrator only checks the `done` field; additional fields are for logging and debugging purposes.
-
-### Hook Scripts
-
-Hook scripts allow you to run custom commands at different stages of the batch processing lifecycle.
-
-#### Configuring Hooks
-
-Add hook script paths to your `.newton/configs/{project_id}.conf`:
-
-```conf
-# Pre-run hook: executes before newton run starts
-
-# Post-success hook: executes after successful task completion
-
-# Post-failure hook: executes after task failure
-```
-
-All hooks run with `sh -c "<script_path>"` from the project root directory.
-
-#### Hook Types
-
-- Executes once before `newton run` starts
-- Use for: environment setup, dependency installation, test database initialization
-- Environment variables available:
-  - `NEWTON_PROJECT_ROOT`, `NEWTON_PROJECT_ID`, `NEWTON_TASK_ID`
-  - `NEWTON_GOAL_FILE`, `NEWTON_RESUME`
-  - All batch environment variables
-
-- Executes after successful task completion (control file shows `done: true`)
-- Exit code determines final plan state:
-  - `0` - Plan moves to `completed/`
-  - Non-zero - Plan moves to `failed/` (overrides success)
-- Use for: deployment, creating pull requests, notifications, cleanup
-- Environment variables available:
-  - All batch environment variables
-  - `NEWTON_RESULT=success`
-  - `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`
-  - `NEWTON_STATE_DIR`, `NEWTON_CONTROL_FILE`
-
-- Executes after task failure
-- Exit code is ignored (plan always moves to `failed/`)
-- Use for: rollback, error notifications, cleanup, logging
-- Environment variables available:
-  - All batch environment variables
-  - `NEWTON_RESULT=failure`
-  - `NEWTON_BRANCH_NAME`, `NEWTON_BASE_BRANCH`
-  - `NEWTON_STATE_DIR`, `NEWTON_CONTROL_FILE`
-
-#### Example Hook Scripts
-
-**Pre-run hook (setup environment):**
-```bash
-#!/bin/bash
-# .newton/scripts/pre-run.sh
-
-echo "Setting up environment for task $NEWTON_TASK_ID"
-
-# Install dependencies
-npm install
-
-# Create feature branch if it doesn't exist
-if ! git rev-parse --verify "$NEWTON_BRANCH_NAME" >/dev/null 2>&1; then
-  git checkout -b "$NEWTON_BRANCH_NAME"
-else
-  git checkout "$NEWTON_BRANCH_NAME"
-fi
-```
-
-**Post-success hook (create PR):**
-```bash
-#!/bin/bash
-# .newton/scripts/post-success.sh
-
-echo "Task completed successfully: $NEWTON_TASK_ID"
-
-# Commit changes
-git add .
-git commit -m "feat: $NEWTON_TASK_ID" || true
-
-# Push to remote
-git push origin "$NEWTON_BRANCH_NAME"
-
-# Create pull request
-gh pr create --title "$NEWTON_TASK_ID" --body "Automated implementation" --base "$NEWTON_BASE_BRANCH"
-```
-
-**Post-failure hook (cleanup and notify):**
-```bash
-#!/bin/bash
-# .newton/scripts/post-failure.sh
-
-echo "Task failed: $NEWTON_TASK_ID"
-
-# Send notification
-curl -X POST https://hooks.slack.com/... \
-  -H 'Content-Type: application/json' \
-  -d "{\"text\":\"Task $NEWTON_TASK_ID failed\"}"
-
-# Cleanup partial changes
-git reset --hard HEAD
-```
-
-### Environment Variables Available to Tools
-
-Tools can access Newton's environment variables:
-
-#### Basic Environment Variables
-
-| Variable | Purpose | Example |
-|----------|---------|---------|
-| `NEWTON_WORKSPACE_PATH` | Workspace root directory | `/path/to/workspace` |
-| `NEWTON_ITERATION` | Current iteration number | `5` |
-| `NEWTON_SCORE_FILE` | Evaluator output file | `/path/to/workspace/.newton/score.txt` |
-| `NEWTON_STATE_DIR` | State directory | `/path/to/workspace/.newton/state` |
-| `NEWTON_ARTIFACTS_DIR` | Artifacts directory | `/path/to/workspace/.newton/artifacts` |
-
-#### Batch Processing Environment Variables
-
-| Variable | Purpose | Example |
-|----------|---------|---------|
-| `NEWTON_PROJECT_ROOT` | Project root directory | `/path/to/project` |
-| `NEWTON_PROJECT_ID` | Current project identifier | `myproject` |
-| `NEWTON_TASK_ID` | Current task identifier | `feature-123-abc` |
-| `NEWTON_RESUME` | Whether resuming from previous state | `1` or `0` |
-| `NEWTON_RESULT` | Result status (in post hooks) | `success` or `failure` |
-| `NEWTON_CONTROL_FILE` | Path to control file | `/path/.newton/tasks/abc/state/newton_control.json` |
-| `NEWTON_WS_ROOT` | Workspace root path | `/path/to/workspace` |
-| `NEWTON_CODER_CMD` | Coder tool command | `.newton/scripts/coder.sh` |
-| `NEWTON_BRANCH_NAME` | Git branch name for task | `feature/add-auth` |
-| `NEWTON_BASE_BRANCH` | Git base branch | `main` |
-| `NEWTON_GOAL_FILE` | Path to goal file | `/path/.newton/state/goal.txt` |
-| `CODING_AGENT` | AI agent identifier | `claude` |
-| `CODING_AGENT_MODEL` | AI model identifier | `claude-sonnet-4-5` |
-| `NEWTON_EXECUTOR_CODING_AGENT` | Executor's coding agent | `claude` |
-| `NEWTON_EXECUTOR_CODING_AGENT_MODEL` | Executor's model | `claude-sonnet-4-5` |
+Any other keys in that file are ignored by `newton batch` unless documented for a different command.
 
 ### Resource Limits
 
@@ -747,87 +395,9 @@ Configure execution limits for workflow runs:
 --parallel-limit N      Maximum number of tasks to run concurrently
 ```
 
-## Output and Artifacts
+## Output, logs, and artifacts
 
-### Generated Artifacts
-
-Newton generates several artifacts during execution:
-
-**Evaluator Outputs:**
-- `evaluator_status.md`: Evaluation results and metrics
-- `evaluation_score.txt`: Numeric quality score
-
-**Advisor Outputs:**
-- `advisor_recommendations.md`: Improvement suggestions
-- `recommendations.json`: Machine-readable recommendations
-
-**Executor Outputs:**
-- `executor_log.md`: Detailed execution logs
-- `changes_applied.md`: List of changes made
-- `solution_state.json`: Current solution state
-
-### Execution History
-
-All execution state is persisted in the `.newton/` directory:
-
-```
-.newton/
-├── state/
-│   ├── execution.json      # Execution metadata
-│   ├── current_solution.json
-│   └── iteration_history.json
-├── artifacts/
-│   ├── evaluator_status.md
-│   ├── advisor_recommendations.md
-│   └── executor_log.md
-└── logs/
-    └── execution.log
-```
-
-### Report Formats
-
-Reports can be generated in multiple formats:
-
-**Text Format** (human-readable):
-```bash
-newton report <execution-id>
-```
-
-**JSON Format** (machine-readable):
-```bash
-newton report <execution-id> --format json
-```
-
-**JSON Output Structure:**
-```json
-{
-  "execution_id": "abc-123",
-  "status": "completed",
-  "iteration": 10,
-  "start_time": "2024-01-15T10:00:00Z",
-  "end_time": "2024-01-15T10:05:30Z",
-  "total_duration": 330,
-  "final_score": 85.7,
-  "goals_met": true,
-  "metrics": {
-    "evaluation_count": 10,
-    "advisor_recommendations": 25,
-    "changes_applied": 18
-  }
-}
-```
-
-### Statistics and Performance Metrics
-
-Reports include detailed statistics:
-
-- Execution duration by phase
-- Tool execution times
-- Evaluation score progression
-- Number of recommendations generated
-- Changes applied per iteration
-- Resource usage metrics
-- Success/failure rates
+Each workflow run writes checkpoints, task output, and artifacts under your workspace, typically under `.newton/state/` and `.newton/artifacts/` (exact layout depends on the workflow and operators you use). Use `newton run ... --verbose` to print task stdout/stderr to the terminal after each task. Log files are described in **Logging** above.
 
 ## Troubleshooting
 
@@ -841,11 +411,11 @@ Reports include detailed statistics:
    lsof -i :8080 -i :8081
    ```
 
-2. **Check connection in monitor logs:**
+2. **Verbose Newton logging:**
    ```bash
    RUST_LOG=newton=debug,info newton monitor --http-url http://127.0.0.1:8081 --ws-url ws://127.0.0.1:8080
    ```
-   Look for "Subscription message sent successfully" and "Parsed message" logs.
+   Then inspect `<workspace>/.newton/logs/newton.log` for connection or parse errors.
 
 3. **Test ailoop server directly:**
    ```bash

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Follow the **Setting up a new project** flow below to go from a blank directory 
 
 1. Create a project directory and `cd` into it.
 2. Run `newton init .` to scaffold the workspace.
-3. Run a workflow from the template (optional input file as second positional):
+3. Run a workflow (path comes from your template or your own YAML; optional input file as second positional):
    ```bash
-   newton run .newton/workflows/develop.yaml --workspace .
+   newton run path/to/workflow.yaml --workspace .
    ```
 
 ### Setting up a new project
@@ -85,7 +85,7 @@ Follow the **Setting up a new project** flow below to go from a blank directory 
 1. Create a project directory and `cd` into it.
 2. Run `newton init .` to scaffold `.newton/` (layout, template files such as workflows and helper scripts, and `.newton/configs/default.conf`).
 3. Edit `.newton/configs/default.conf`: set `workflow_file` to the workflow YAML `newton batch` should run (see comment in that file). Add a `<project_id>.conf` copy or symlink if you use batch with a non-default id.
-4. Run a workflow explicitly, for example: `newton run .newton/workflows/develop.yaml --workspace .` (pick the YAML that matches your template).
+4. Run a workflow explicitly, for example: `newton run path/to/workflow.yaml --workspace .` (use the paths described in your template README).
 
 For an existing repository, run `newton init .` at the repo root instead of creating a new directory.
 
@@ -375,7 +375,7 @@ Use simple `key=value` lines. For `newton batch`, set:
 ```conf
 # Required for batch
 project_root=/path/to/project
-workflow_file=.newton/workflows/develop.yaml
+workflow_file=path/to/workflow.yaml
 
 # Optional: kept in default.conf after init for templates and tooling; ignored by batch
 coding_model=zai-coding-plan/glm-4.7

--- a/resources/newton-template/newton/README.md
+++ b/resources/newton-template/newton/README.md
@@ -1,27 +1,22 @@
-# Newton Workspace Template
+# Newton workspace template
 
-This template provides a complete Newton workspace with scripts for evaluator, advisor, post-success, and post-failure hooks.
+This template scaffolds a Newton workspace with **workflow YAML** definitions and small **shell helpers** under `.newton/`.
 
-## Scripts
+## Layout
 
-The following scripts are installed in `.newton/scripts/`:
+- **`.newton/workflows/`**  
+  - `develop.yaml`, `planner.yaml`, `documenter.yaml` (example workflow graphs you can run or customize).
 
-- `advisor.sh`: Advisor script for Newton's planning phase
-- `evaluator.sh`: Evaluator script for validating plan progress
-- `post-success.sh`: Script to run after a successful `newton run` in batch mode
-- `post-failure.sh`: Script to run after a failed `newton run` in batch mode
+- **`.newton/scripts/`**  
+  - `newton-project-root.sh` – shared helpers (config dir, `project_root` resolution).  
+  - `develop.sh`, `planner.sh`, `documenter.sh` – convenience entrypoints that invoke `newton run` with the matching workflow (see script headers for usage).
 
-## Usage
+## After `newton init`
 
-After installing this template with `aikit install`, you can customize these scripts to fit your project's workflow.
+1. Edit `.newton/configs/default.conf`: set `workflow_file` to the workflow you want `newton batch` to use (path relative to `project_root` or your workspace), for example:
+   - `workflow_file=.newton/workflows/develop.yaml`
+2. Run a workflow directly:
+   - `newton run .newton/workflows/develop.yaml --workspace .`
+3. Use the helper scripts from your workspace root if you prefer (they expect a matching `<project_id>.conf` under `.newton/configs/`).
 
-## Post-Success Behavior
-
-The `post-success.sh` script is called after a successful `newton run` in batch mode:
-- Exit code 0: Plan is moved to `completed/`
-- Non-zero exit code: Plan is moved to `failed/`
-
-## Post-Failure Behavior
-
-The `post-failure.sh` script is called after a failed `newton run` in batch mode:
-- After this script runs, the plan is moved to `failed/`
+Customize workflows and scripts to match your repositories and automation.

--- a/resources/newton-template/newton/scripts/advisor.sh
+++ b/resources/newton-template/newton/scripts/advisor.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# Newton Advisor Script
-# Called during the planning phase to provide guidance
-
-echo "Newton advisor: Providing planning guidance..."
-exit 0

--- a/resources/newton-template/newton/scripts/develop.sh
+++ b/resources/newton-template/newton/scripts/develop.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# develop workflow (see workflow_path in project .conf): AgentOperator models are set in that YAML.
+# Convention: engine claude_code -> model sonnet; engine opencode -> model zai-coding-plan/glm-5.
+# Newton applies settings.model_stylesheet only when a task omits params.model (default there is sonnet).
+set -e
+. ".newton/scripts/newton-project-root.sh"
+
+usage() {
+  echo "Usage: develop <project_id>                 # pick next Ready board item and run workflow" >&2
+  echo "       develop <project_id> resume <uuid>    # resume a workflow from checkpoint" >&2
+}
+
+project_id="${1:?Usage: develop <project_id> [resume <execution-id>]}"
+project_root="$(resolve_project_root "$project_id")"
+
+config_file="$NEWTON_CONFIG_DIR/${project_id}.conf"
+# shellcheck disable=SC1090
+. "$config_file"
+
+[[ -n "${workflow_path:-}" ]]     || { echo "workflow_path is not set in $config_file" >&2; exit 1; }
+[[ -n "${gh_project_owner:-}" ]]  || { echo "gh_project_owner is not set in $config_file" >&2; exit 1; }
+[[ -n "${gh_project_number:-}" ]] || { echo "gh_project_number is not set in $config_file" >&2; exit 1; }
+
+if [[ "${2:-}" == "resume" ]]; then
+  execution_id="${3:?Usage: develop <project_id> resume <execution-id>}"
+  export GH_PROJECT_OWNER="$gh_project_owner"
+  export GH_PROJECT_NUMBER="$gh_project_number"
+  export RUST_LOG=debug
+  exec newton resume --execution-id "$execution_id" \
+    --workspace "$project_root" \
+    --allow-workflow-change
+fi
+
+if [[ -n "${2:-}" ]]; then
+  usage
+  exit 1
+fi
+
+item_json=$(gh project item-list "$gh_project_number" \
+  --owner "$gh_project_owner" \
+  --query "status:Ready" \
+  --format json \
+  --limit 1 | jq '.items[0] // empty')
+
+[[ -n "$item_json" ]] || { echo "No items with status Ready on the board" >&2; exit 1; }
+
+item_title=$(echo "$item_json" | jq -r '.title')
+item_id=$(echo "$item_json" | jq -r '.id')
+item_body=$(echo "$item_json" | jq -r '.content.body')
+
+spec_path="/tmp/${item_title}.md"
+echo "$item_body" > "$spec_path"
+
+echo "Picked: $item_title (ID: $item_id)"
+echo "Spec:   $spec_path"
+
+export GH_PROJECT_OWNER="$gh_project_owner"
+export GH_PROJECT_NUMBER="$gh_project_number"
+export RUST_LOG=debug
+exec newton run "$workflow_path" \
+  --workspace "$project_root" \
+  --arg "prompt=$spec_path" \
+  --arg "board_item_id=$item_id" \
+  --verbose

--- a/resources/newton-template/newton/scripts/documenter.sh
+++ b/resources/newton-template/newton/scripts/documenter.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+. ".newton/scripts/newton-project-root.sh"
+
+# Usage: documenter <project_id> [trigger_json_path]
+# Runs newton documenter workflow against project_root from configs.
+# Default trigger file: $project_root/.newton/documenter-trigger.json (if present).
+# Trigger JSON keys: base_ref, allowlist (newline-separated paths), prompt, commit_docs, require_plan_approval.
+
+project_id="${1:?Usage: documenter <project_id> [trigger_json_path]}"
+shift || true
+project_root="$(resolve_project_root "$project_id")"
+
+config_file="$NEWTON_CONFIG_DIR/${project_id}.conf"
+# shellcheck disable=SC1090
+. "$config_file"
+
+WORKFLOW="/home/sysuser/ws001/.newton/workflows/documenter.yaml"
+
+trigger_json="${1:-}"
+if [[ -z "$trigger_json" ]]; then
+  default_trigger="$project_root/.newton/documenter-trigger.json"
+  if [[ -f "$default_trigger" ]]; then
+    trigger_json="$default_trigger"
+  fi
+fi
+
+args=(newton run "$WORKFLOW" --workspace "$project_root" --verbose --server http://127.0.0.1:8080)
+if [[ -n "$trigger_json" ]]; then
+  args+=(--trigger-json "$trigger_json")
+fi
+
+# --server must match newton serve bind (default 127.0.0.1:8080).
+exec "${args[@]}"

--- a/resources/newton-template/newton/scripts/documenter.sh
+++ b/resources/newton-template/newton/scripts/documenter.sh
@@ -15,7 +15,7 @@ config_file="$NEWTON_CONFIG_DIR/${project_id}.conf"
 # shellcheck disable=SC1090
 . "$config_file"
 
-WORKFLOW="/home/sysuser/ws001/.newton/workflows/documenter.yaml"
+WORKFLOW=".newton/workflows/documenter.yaml"
 
 trigger_json="${1:-}"
 if [[ -z "$trigger_json" ]]; then

--- a/resources/newton-template/newton/scripts/evaluator.sh
+++ b/resources/newton-template/newton/scripts/evaluator.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# Newton Evaluator Script
-# Called to validate plan progress and determine next steps
-
-echo "Newton evaluator: Evaluating plan progress..."
-exit 0

--- a/resources/newton-template/newton/scripts/newton-project-root.sh
+++ b/resources/newton-template/newton/scripts/newton-project-root.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+NEWTON_CONFIG_DIR="${NEWTON_CONFIG_DIR:-.newton/configs}"
+
+resolve_project_root() {
+  local project_id="$1"
+  local config_file="$NEWTON_CONFIG_DIR/${project_id}.conf"
+
+  if [[ -z "$project_id" ]]; then
+    echo "project_id is required" >&2
+    return 1
+  fi
+
+  if [[ ! -f "$config_file" ]]; then
+    echo "Config not found for project_id '$project_id' at $config_file" >&2
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  . "$config_file"
+
+  if [[ -z "$project_root" ]]; then
+    echo "project_root is not set in $config_file" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$project_root"
+}
+

--- a/resources/newton-template/newton/scripts/planner.sh
+++ b/resources/newton-template/newton/scripts/planner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+. ".newton/scripts/newton-project-root.sh"
+
+project_id="${1:?Usage: planner <project_id>}"
+project_root="$(resolve_project_root "$project_id")"
+
+config_file="$NEWTON_CONFIG_DIR/${project_id}.conf"
+# shellcheck disable=SC1090
+. "$config_file"
+
+[[ -n "${gh_project_owner:-}" ]]  || { echo "gh_project_owner is not set in $config_file" >&2; exit 1; }
+[[ -n "${gh_project_number:-}" ]] || { echo "gh_project_number is not set in $config_file" >&2; exit 1; }
+
+WORKFLOW=".newton/workflows/planner.yaml"
+
+item_json=$(gh project item-list "$gh_project_number" \
+  --owner "$gh_project_owner" \
+  --query "status:Draft" \
+  --format json \
+  --limit 1 | jq '.items[0] // empty')
+
+[[ -n "$item_json" ]] || { echo "No items with status Draft on the board" >&2; exit 1; }
+
+item_title=$(echo "$item_json"        | jq -r '.title')
+item_id=$(echo "$item_json"          | jq -r '.id')
+item_content_id=$(echo "$item_json"  | jq -r '.content.id')
+item_issue_number=$(echo "$item_json" | jq -r '.content.number // empty')
+item_body=$(echo "$item_json"        | jq -r '.content.body')
+
+spec_path="/tmp/${item_title}.md"
+echo "$item_body" > "$spec_path"
+
+echo "Picked: $item_title (ID: $item_id)"
+echo "Spec:   $spec_path"
+
+export GH_PROJECT_OWNER="$gh_project_owner"
+export GH_PROJECT_NUMBER="$gh_project_number"
+# --server must match newton serve bind (default 127.0.0.1:8080).
+exec newton run "$WORKFLOW" \
+  --workspace "$project_root" \
+  --arg "prompt=$spec_path" \
+  --arg "output_path=$spec_path" \
+  --arg "board_item_id=$item_id" \
+  --arg "board_content_id=$item_content_id" \
+  --arg "board_issue_number=${item_issue_number}" \
+  --arg "board_item_title=$item_title" \
+  --verbose \
+  --server http://127.0.0.1:8080

--- a/resources/newton-template/newton/scripts/post-failure.sh
+++ b/resources/newton-template/newton/scripts/post-failure.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Newton Post-Failure Script
-# Called after a failed 'newton run' in batch mode
-# After this script runs, the plan is moved to `failed`
-
-echo "Newton post-failure: Plan failed"
-exit 0

--- a/resources/newton-template/newton/scripts/post-success.sh
+++ b/resources/newton-template/newton/scripts/post-success.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Newton Post-Success Script
-# Called after a successful 'newton run' in batch mode
-# Exit code 0 -> plan moved to completed
-# Non-zero -> plan moved to failed
-
-echo "Newton post-success: Plan completed successfully"
-exit 0

--- a/resources/newton-template/newton/workflows/develop.yaml
+++ b/resources/newton-template/newton/workflows/develop.yaml
@@ -1,0 +1,503 @@
+version: "2.0"
+mode: workflow_graph
+
+metadata:
+  name: "develop-workflow"
+  description: "Run a implementation workflow for a given spec"
+
+triggers:
+  type: manual
+  schema_version: "1.0"
+  payload:
+    prompt: ""
+
+workflow:
+  settings:
+    entry_task: ensure_clean_main
+    max_time_seconds: 604800
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 15000
+    max_workflow_iterations: 25000
+
+    default_engine: opencode
+    # Fallback when a task omits params.model. Use sonnet so claude_code never inherits a GLM id.
+    model_stylesheet:
+      model: zai-coding-plan/glm-5
+
+    command_operator:
+      allow_shell: true
+
+  context:
+    preamble: |-
+      Implement the following spec in the target source code target.
+      After you have applied the changes and ./scripts/run-tests.sh completes with no errors, print exactly <status>COMPLETED</status> in your final output.
+    codescene_preamble: |-
+      Fix code health issues reported by CodeScene. Work in the target source code base; run ./scripts/run-tests.sh to verify. Do not require a COMPLETED marker.
+    precommit_fix_preamble: |-
+      The pre-commit hook rejected a commit. The full hook output is below.
+      Fix all reported issues in the codebase. Run ./scripts/run-tests.sh to verify.
+      Do not attempt to commit; only fix the code.
+    validation_preamble: |-
+      You are a reviewer. You will be given the spec path, the spec content (or path if passed as reference), and the diff vs main.
+      Determine whether the provided diff fully implements the given spec.
+      Reply with exactly one of <status>VALID</status> or <status>INVALID</status>.
+      If INVALID, include a single block <feedback>...</feedback> with clear, actionable feedback.
+
+  tasks:
+    - id: ensure_clean_main
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: |
+          set -e
+          git fetch origin
+          git checkout main
+          git pull --rebase origin main
+          git diff --quiet || { echo "Precondition failed: unstaged changes"; exit 1; }
+          git diff --cached --quiet || { echo "Precondition failed: staged changes"; exit 1; }
+        capture_stdout: false
+      transitions:
+        - to: resolve_board_ids
+
+    - id: resolve_board_ids
+      operator: GhOperator
+      params:
+        operation: project_resolve_board
+        owner:
+          $expr: 'env("GH_PROJECT_OWNER")'
+        project_number:
+          $expr: 'env("GH_PROJECT_NUMBER")'
+      transitions:
+        - to: move_to_in_progress
+
+    - id: move_to_in_progress
+      operator: GhOperator
+      params:
+        operation: project_item_set_status
+        item_id:
+          $expr: 'triggers.board_item_id'
+        board:
+          $expr: 'tasks.resolve_board_ids.output'
+        status: "In progress"
+        on_error: warn
+      transitions:
+        - to: create_branch
+
+    - id: create_branch
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: |
+          BRANCH_NAME=$(basename "$PROMPT_PATH" | sed 's/\.[^.]*$//')
+          git checkout -b "feature/$BRANCH_NAME"
+        env:
+          PROMPT_PATH:
+            $expr: 'triggers.prompt'
+        capture_stdout: false
+      transitions:
+        - to: load_spec
+
+    - id: load_spec
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          SPEC_PATH:
+            $expr: 'triggers.prompt'
+        cmd: |
+          set -e
+          cat "$SPEC_PATH"
+        capture_stdout: true
+        capture_stderr: true
+      transitions:
+        - to: implement_spec
+
+    - id: implement_spec
+      operator: "AgentOperator"
+      max_iterations: 3
+      params:
+        engine: claude
+        model: sonnet
+        prompt:
+          $expr: 'context.preamble + "\n\nSpec path: " + triggers.prompt + "\n\nSpec content:\n" + tasks.load_spec.output.stdout'
+        signals:
+          complete: '<status>COMPLETED</status>'
+      transitions:
+        - to: run_tests
+          priority: 0
+          when: { "$expr": 'tasks.implement_spec.output.signal == "complete"' }
+        - to: retry_implementation
+          priority: 10
+
+    - id: run_tests
+      max_iterations: 60
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: |
+          OUTPUT=$(./scripts/run-tests.sh 2>&1)
+          EXIT=$?
+          echo "$OUTPUT"
+          [ $EXIT -eq 0 ] && echo "TEST_STATUS: passed" || echo "TEST_STATUS: failed"
+        capture_stdout: true
+        capture_stderr: true
+      transitions:
+        - to: snapshot_commit
+          priority: 0
+          when: { "$expr": "contains(tasks.run_tests.output.stdout, \"TEST_STATUS: passed\")" }
+        - to: fix_test_failures
+          priority: 10
+
+    - id: fix_test_failures
+      operator: AgentOperator
+      max_iterations: 3
+      params:
+        engine: opencode
+        model: zai-coding-plan/glm-5
+        prompt:
+          $expr: 'context.preamble + "\n\nSpec path: " + triggers.prompt + "\n\nSpec content:\n" + tasks.load_spec.output.stdout + "\n\nTests failed. Fix the issues and re-run ./scripts/run-tests.sh:\n" + tasks.run_tests.output.stdout'
+      transitions:
+        - to: run_tests
+
+    - id: snapshot_commit
+      max_iterations: 90
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          SPEC_PATH:
+            $expr: 'triggers.prompt'
+        cmd: |
+          SPEC_BASENAME=$(basename "$SPEC_PATH" | sed 's/\.[^.]*$//')
+          git add -A
+          git diff --cached --name-only | { grep -E '^test_results\.' || true; } | xargs -r git reset --
+          if git diff --cached --quiet; then
+            echo "COMMIT_STATUS: skipped"
+            exit 0
+          fi
+          OUTPUT=$(git commit -m "chore(develop): $SPEC_BASENAME" 2>&1)
+          EXIT=$?
+          echo "$OUTPUT"
+          [ $EXIT -eq 0 ] && echo "COMMIT_STATUS: success" || echo "COMMIT_STATUS: failed"
+        capture_stdout: true
+        capture_stderr: true
+      transitions:
+        - to: get_diff
+          priority: 0
+          when: { "$expr": "contains(tasks.snapshot_commit.output.stdout, \"COMMIT_STATUS: success\") || contains(tasks.snapshot_commit.output.stdout, \"COMMIT_STATUS: skipped\")" }
+        - to: fix_snapshot_precommit
+          priority: 10
+
+    - id: fix_snapshot_precommit
+      operator: AgentOperator
+      max_iterations: 3
+      params:
+        engine: opencode
+        model: zai-coding-plan/glm-5
+        prompt:
+          $expr: 'context.precommit_fix_preamble + "\n\nPre-commit hook output:\n" + tasks.snapshot_commit.output.stdout'
+      transitions:
+        - to: snapshot_commit
+
+    - id: get_diff
+      max_iterations: 60
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'git diff main...HEAD'
+        capture_stdout: true
+      transitions:
+        - to: validate_against_spec
+
+    - id: validate_against_spec
+      max_iterations: 60
+      operator: AgentOperator
+      params:
+        engine: claude
+        model: sonnet
+        prompt:
+          $expr: 'context.validation_preamble + "\n\nSpec path: " + triggers.prompt + "\n\nSpec content:\n" + tasks.load_spec.output.stdout + "\n\nDiff vs main:\n" + tasks.get_diff.output.stdout'
+        signals:
+          valid: '<status>VALID</status>'
+          invalid: '<status>INVALID</status>'
+      transitions:
+        - to: analyze_code_health
+          priority: 0
+          when: { "$expr": 'tasks.validate_against_spec.output.signal == "valid"' }
+        - to: load_validation_feedback
+          priority: 10
+
+    - id: load_validation_feedback
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          VALIDATION_STDOUT_ARTIFACT:
+            $expr: 'tasks.validate_against_spec.output.stdout_artifact'
+        cmd: 'cat "$VALIDATION_STDOUT_ARTIFACT"'
+      transitions:
+        - to: implement_feedback
+
+    - id: implement_feedback
+      operator: AgentOperator
+      max_iterations: 60
+      params:
+        engine: claude
+        model: sonnet
+        prompt:
+          $expr: 'context.preamble + "\n\nSpec path: " + triggers.prompt + "\n\nSpec content:\n" + tasks.load_spec.output.stdout + "\n\nValidation feedback (address and re-run tests):\n" + tasks.load_validation_feedback.output.stdout'
+        signals:
+          complete: '<status>COMPLETED</status>'
+      transitions:
+        - to: run_tests
+
+    - id: analyze_code_health
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'cs delta --output-format json'
+        capture_stdout: true
+      transitions:
+        - to: fix_code_health
+          priority: 0
+          when: { "$expr": "contains(tasks.analyze_code_health.output.stdout, \"{\")" }
+        - to: git_stage
+          priority: 10
+
+    - id: fix_code_health
+      operator: "AgentOperator"
+      params:
+        engine: opencode
+        model: zai-coding-plan/glm-5
+        prompt:
+          $expr: 'context.codescene_preamble + "\n\nCodeScene delta report (JSON):\n" + tasks.analyze_code_health.output.stdout'
+      transitions:
+        - to: git_stage
+
+    - id: git_stage
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: |
+          set -e
+          git add -A
+          git diff --cached --name-only | { grep -E '^test_results\.' || true; } | xargs -r git reset --
+          if git diff --cached --quiet; then
+            if git diff --quiet main...HEAD; then
+              echo "NO_CHANGES"
+            else
+              echo "COMMITTED_ONLY"
+            fi
+            exit 0
+          fi
+          echo "HAS_CHANGES"
+        capture_stdout: true
+      transitions:
+        - to: no_changes_done
+          priority: 0
+          when: { "$expr": "contains(tasks.git_stage.output.stdout, \"NO_CHANGES\")" }
+        - to: git_push
+          priority: 5
+          when: { "$expr": "contains(tasks.git_stage.output.stdout, \"COMMITTED_ONLY\")" }
+        - to: git_commit
+          priority: 10
+          when: { "$expr": "contains(tasks.git_stage.output.stdout, \"HAS_CHANGES\")" }
+
+    - id: no_changes_done
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "No changes to commit; skipping PR."'
+        capture_stdout: false
+      terminal: success
+
+    - id: git_commit
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          PROMPT_PATH:
+            $expr: 'triggers.prompt'
+        cmd: |
+          MSG="feat: implement $(basename "$PROMPT_PATH" .md 2>/dev/null || echo "spec")"
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            echo "COMMIT_STATUS: skipped"
+            exit 0
+          fi
+          OUTPUT=$(git commit -m "$MSG" 2>&1)
+          EXIT=$?
+          echo "$OUTPUT"
+          [ $EXIT -eq 0 ] && echo "COMMIT_STATUS: success" || echo "COMMIT_STATUS: failed"
+        capture_stdout: true
+        capture_stderr: true
+      transitions:
+        - to: git_push
+          priority: 0
+          when: { "$expr": "contains(tasks.git_commit.output.stdout, \"COMMIT_STATUS: success\") || contains(tasks.git_commit.output.stdout, \"COMMIT_STATUS: skipped\")" }
+        - to: fix_final_precommit
+          priority: 10
+
+    - id: fix_final_precommit
+      operator: AgentOperator
+      max_iterations: 3
+      params:
+        engine: opencode
+        model: zai-coding-plan/glm-5
+        prompt:
+          $expr: 'context.precommit_fix_preamble + "\n\nPre-commit hook output:\n" + tasks.git_commit.output.stdout'
+      transitions:
+        - to: git_commit
+
+    - id: git_push
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: |
+          for i in 1 2 3; do
+            git push -u origin HEAD && exit 0
+            sleep 5
+          done
+          echo "git push failed after 3 attempts"; exit 1
+        capture_stdout: true
+        capture_stderr: true
+      transitions:
+        - to: gh_create_pr
+
+    - id: gh_create_pr
+      operator: GhOperator
+      params:
+        operation: pr_create
+        base: main
+        title:
+          $expr: '"feat: implement " + file_stem(triggers.prompt)'
+        body: "Implements spec. Merge with squash."
+        retry_count: 3
+        retry_delay_ms: 5000
+      transitions:
+        - to: move_to_in_review
+
+    - id: move_to_in_review
+      operator: GhOperator
+      params:
+        operation: project_item_set_status
+        item_id:
+          $expr: 'triggers.board_item_id'
+        board:
+          $expr: 'tasks.resolve_board_ids.output'
+        status: "In review"
+        on_error: warn
+      transitions:
+        - to: poll_pr
+
+    - id: poll_pr
+      operator: GhOperator
+      max_iterations: 15000
+      timeout_ms: 120000
+      params:
+        operation: pr_view
+        pr:
+          $expr: 'tasks.gh_create_pr.output.pr_number'
+      transitions:
+        - to: merge_git_cleanup
+          priority: 0
+          when: { "$expr": 'tasks.poll_pr.output.state == "MERGED"' }
+        - to: move_to_ready_on_close
+          priority: 1
+          when: { "$expr": 'tasks.poll_pr.output.state == "CLOSED"' }
+        - to: sleep_merge_wait
+          priority: 5
+          when: { "$expr": 'tasks.poll_pr.output.state == "OPEN"' }
+        - to: sleep_merge_unknown
+          priority: 10
+          when: { "$expr": 'tasks.poll_pr.output.state != "OPEN" && tasks.poll_pr.output.state != "MERGED" && tasks.poll_pr.output.state != "CLOSED"' }
+
+    - id: sleep_merge_wait
+      operator: CommandOperator
+      max_iterations: 15000
+      params:
+        shell: true
+        cmd: "sleep 60"
+        capture_stdout: false
+      transitions:
+        - to: poll_pr
+
+    - id: sleep_merge_unknown
+      operator: CommandOperator
+      max_iterations: 15000
+      params:
+        shell: true
+        cmd: 'echo "Unexpected PR state; waiting 30s"; sleep 30'
+        capture_stdout: false
+      transitions:
+        - to: poll_pr
+
+    - id: move_to_ready_on_close
+      operator: GhOperator
+      params:
+        operation: project_item_set_status
+        item_id:
+          $expr: 'triggers.board_item_id'
+        board:
+          $expr: 'tasks.resolve_board_ids.output'
+        status: "Ready"
+        on_error: warn
+      transitions:
+        - to: fail_pr_closed
+
+    - id: fail_pr_closed
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "PR closed without merge" >&2; exit 1'
+        capture_stdout: false
+      terminal: failure
+
+    - id: merge_git_cleanup
+      operator: CommandOperator
+      timeout_ms: 600000
+      params:
+        shell: true
+        cmd: |
+          set -e
+          BRANCH=$(git branch --show-current)
+          git checkout main
+          git pull --rebase origin main
+          git branch -d "$BRANCH" 2>/dev/null || true
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+        capture_stdout: false
+      transitions:
+        - to: move_to_done
+
+    - id: move_to_done
+      operator: GhOperator
+      params:
+        operation: project_item_set_status
+        item_id:
+          $expr: 'triggers.board_item_id'
+        board:
+          $expr: 'tasks.resolve_board_ids.output'
+        status: "Done"
+        on_error: warn
+      transitions:
+        - to: success
+
+    - id: success
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "Job is completed based on opencode output" | tee /dev/tty'
+        capture_stdout: false
+      terminal: success
+
+    - id: retry_implementation
+      operator: CommandOperator
+      max_iterations: 3
+      params:
+        shell: true
+        cmd: 'echo "Job failed (status != COMPLETED), retrying implement_spec task..."'
+        capture_stdout: false
+      transitions:
+        - to: implement_spec

--- a/resources/newton-template/newton/workflows/documenter.yaml
+++ b/resources/newton-template/newton/workflows/documenter.yaml
@@ -1,0 +1,337 @@
+version: "2.0"
+mode: workflow_graph
+
+metadata:
+  name: "documenter-workflow"
+  description: "Triage and update documentation from git diff vs base ref; allowlist-enforced"
+
+triggers:
+  type: manual
+  schema_version: "1.0"
+  payload:
+    base_ref: ""
+    allowlist: ""
+    prompt: ""
+    commit_docs: false
+    require_plan_approval: false
+
+workflow:
+  settings:
+    entry_task: normalize_documenter_config
+    max_time_seconds: 604800
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 15000
+    max_workflow_iterations: 25000
+
+    default_engine: opencode
+    model_stylesheet:
+      model: zai-coding-plan/glm-5
+
+    command_operator:
+      allow_shell: true
+
+    human:
+      default_timeout_seconds: 86400
+      audit_path: .newton/state/workflows
+
+  context:
+    documenter_triage_preamble: |-
+      You are a technical writer and release engineer.
+      Inputs: (1) doc allowlist: only these repo-relative paths may be edited later; (2) changed paths; (3) unified diff vs base; (4) optional spec text.
+      For every allowlisted path (expand directory entries to concrete files in the table when needed), decide if this branch's changes require a doc update.
+      Tie decisions to observable facts in the diff (flags, commands, APIs, config).
+      Do not edit any file in this step. Output only:
+      - Exactly one status line matching one of the signal patterns below (as its own line).
+      - A machine-readable block:
+      <doc_plan>
+      | path | action | rationale |
+      | ... | UPDATE or NO_CHANGE or DEFER | ... |
+      </doc_plan>
+      Use UPDATE only when the diff clearly implies the doc is stale or wrong. NO_CHANGE when unrelated. DEFER when unclear without more context.
+    documenter_apply_preamble: |-
+      You are a technical writer. Implement documentation updates only for rows marked UPDATE in the provided <doc_plan>.
+      Edit only files that fall under the allowlist. Do not modify application source unless that path is explicitly on the allowlist.
+      Ground statements in the provided diff and spec. When done, print exactly <status>DOC_APPLY_DONE</status> on its own line in your final output.
+    documenter_precommit_fix_preamble: |-
+      Pre-commit rejected the documentation commit. Fix only issues under the doc allowlist. Do not commit; only fix files.
+      After fixes, the workflow will retry the commit.
+
+  tasks:
+    - id: normalize_documenter_config
+      operator: SetContextOperator
+      params:
+        patch:
+          documenter:
+            base_ref:
+              $expr: 'if triggers.base_ref != () && triggers.base_ref != "" { triggers.base_ref } else { "main" }'
+            allowlist:
+              $expr: 'if triggers.allowlist != () { triggers.allowlist } else { "" }'
+      transitions:
+        - to: ensure_allowlist_nonempty
+
+    - id: ensure_allowlist_nonempty
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          ALLOWLIST:
+            $expr: 'context.documenter.allowlist'
+        cmd: |
+          set -e
+          if [ -z "$ALLOWLIST" ]; then
+            echo "documenter: allowlist is empty; set allowlist in trigger JSON (newline-separated paths)"
+            exit 1
+          fi
+          echo "ALLOWLIST_OK"
+      transitions:
+        - to: precondition_git
+
+    - id: precondition_git
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: false
+        cmd: |
+          set -e
+          git fetch origin
+      transitions:
+        - to: collect_changed_paths
+
+    - id: collect_changed_paths
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          BASE_REF:
+            $expr: 'context.documenter.base_ref'
+        cmd: |
+          set -e
+          git diff --name-only "${BASE_REF}...HEAD"
+      transitions:
+        - to: collect_diff
+
+    - id: collect_diff
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          BASE_REF:
+            $expr: 'context.documenter.base_ref'
+        cmd: |
+          set -e
+          git diff "${BASE_REF}...HEAD"
+      transitions:
+        - to: load_spec
+
+    - id: load_spec
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          SPEC_PATH:
+            $expr: 'if triggers.prompt != () { triggers.prompt } else { "" }'
+        cmd: |
+          set -e
+          if [ -n "$SPEC_PATH" ] && [ -f "$SPEC_PATH" ]; then
+            cat "$SPEC_PATH"
+          else
+            echo ""
+          fi
+      transitions:
+        - to: agent_doc_triage
+
+    - id: agent_doc_triage
+      operator: AgentOperator
+      max_iterations: 5
+      params:
+        engine: opencode
+        prompt:
+          $expr: 'context.documenter_triage_preamble + "\n\n## Allowlist (only these paths may be edited later)\n" + context.documenter.allowlist + "\n\n## Changed paths (name-only)\n" + tasks.collect_changed_paths.output.stdout + "\n\n## Unified diff\n" + tasks.collect_diff.output.stdout + "\n\n## Optional spec\n" + tasks.load_spec.output.stdout + "\n\n## Signals\n" + "If no allowlisted doc needs changes, output a line containing exactly: <status>DOC_STATUS_NO_UPDATES</status>\n" + "If at least one allowlisted doc needs changes, output a line containing exactly: <status>DOC_STATUS_UPDATES_NEEDED</status>\n"'
+        signals:
+          no_updates: '<status>DOC_STATUS_NO_UPDATES</status>'
+          updates_needed: '<status>DOC_STATUS_UPDATES_NEEDED</status>'
+      transitions:
+        - to: terminal_no_edits
+          priority: 0
+          when:
+            $expr: 'tasks.agent_doc_triage.output.signal == "no_updates"'
+        - to: approve_doc_plan
+          priority: 1
+          when:
+            $expr: 'tasks.agent_doc_triage.output.signal == "updates_needed"'
+        - to: agent_doc_apply
+          priority: 10
+          when:
+            $expr: 'tasks.agent_doc_triage.output.signal == "updates_needed"'
+        - to: terminal_triage_exhausted
+          priority: 100
+
+    - id: approve_doc_plan
+      operator: HumanApprovalOperator
+      include_if:
+        $expr: 'triggers.require_plan_approval == true'
+      params:
+        prompt:
+          $expr: '"Approve documentation plan and proceed to apply edits?\n\n" + tasks.agent_doc_triage.output.stdout'
+      transitions:
+        - to: agent_doc_apply
+          priority: 0
+          when:
+            $expr: 'tasks.approve_doc_plan.output.approved == true'
+        - to: terminal_plan_rejected
+          priority: 10
+          when:
+            $expr: 'tasks.approve_doc_plan.output.approved == false'
+
+    - id: agent_doc_apply
+      operator: AgentOperator
+      max_iterations: 5
+      params:
+        engine: opencode
+        prompt:
+          $expr: 'context.documenter_apply_preamble + "\n\n## Allowlist\n" + context.documenter.allowlist + "\n\n## Triage output (follow <doc_plan> for UPDATE rows only)\n" + tasks.agent_doc_triage.output.stdout + "\n\n## Diff (reference)\n" + tasks.collect_diff.output.stdout'
+        signals:
+          done: '<status>DOC_APPLY_DONE</status>'
+      transitions:
+        - to: verify_allowlist
+          priority: 0
+          when:
+            $expr: 'tasks.agent_doc_apply.output.signal == "done"'
+        - to: terminal_apply_incomplete
+          priority: 10
+          when:
+            $expr: 'tasks.agent_doc_apply.output.signal != "done"'
+
+    - id: verify_allowlist
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          ALLOWLIST:
+            $expr: 'context.documenter.allowlist'
+        cmd: |
+          set -e
+          CHANGED=$(git diff --name-only)
+          if [ -z "$CHANGED" ]; then
+            echo "VERIFY_OK"
+            exit 0
+          fi
+          FAIL=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            MATCH=0
+            while IFS= read -r prefix; do
+              [ -z "$prefix" ] && continue
+              if [[ "$f" == "$prefix" ]] || [[ "$f" == "$prefix/"* ]]; then
+                MATCH=1
+                break
+              fi
+            done <<< "$ALLOWLIST"
+            if [ "$MATCH" -eq 0 ]; then
+              echo "OUTSIDE_ALLOWLIST: $f"
+              FAIL=1
+            fi
+          done <<< "$CHANGED"
+          if [ "$FAIL" -eq 0 ]; then
+            echo "VERIFY_OK"
+          else
+            echo "VERIFY_FAIL"
+          fi
+          exit 0
+      transitions:
+        - to: terminal_verify_failed
+          priority: 0
+          when:
+            $expr: 'contains(tasks.verify_allowlist.output.stdout, "VERIFY_FAIL")'
+        - to: commit_docs
+          priority: 1
+          when:
+            $expr: 'contains(tasks.verify_allowlist.output.stdout, "VERIFY_OK")'
+        - to: terminal_doc_done
+          priority: 10
+          when:
+            $expr: 'contains(tasks.verify_allowlist.output.stdout, "VERIFY_OK")'
+
+    - id: commit_docs
+      operator: CommandOperator
+      include_if:
+        $expr: 'triggers.commit_docs == true'
+      max_iterations: 10
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          ALLOWLIST:
+            $expr: 'context.documenter.allowlist'
+        cmd: |
+          set -e
+          while IFS= read -r prefix; do
+            [ -z "$prefix" ] && continue
+            git add -- "$prefix" 2>/dev/null || true
+          done <<< "$ALLOWLIST"
+          if git diff --cached --quiet; then
+            echo "COMMIT_STATUS: skipped"
+            exit 0
+          fi
+          OUTPUT=$(git commit -m "docs: sync documentation with branch changes" 2>&1) || true
+          EXIT=$?
+          echo "$OUTPUT"
+          if [ $EXIT -eq 0 ]; then
+            echo "COMMIT_STATUS: success"
+          else
+            echo "COMMIT_STATUS: failed"
+          fi
+          exit 0
+      transitions:
+        - to: terminal_doc_done
+          priority: 0
+          when:
+            $expr: 'contains(tasks.commit_docs.output.stdout, "COMMIT_STATUS: success") || contains(tasks.commit_docs.output.stdout, "COMMIT_STATUS: skipped")'
+        - to: fix_doc_commit_precommit
+          priority: 10
+
+    - id: fix_doc_commit_precommit
+      operator: AgentOperator
+      max_iterations: 3
+      params:
+        engine: opencode
+        prompt:
+          $expr: 'context.documenter_precommit_fix_preamble + "\n\nCommit output:\n" + tasks.commit_docs.output.stdout'
+      transitions:
+        - to: commit_docs
+
+    - id: terminal_no_edits
+      operator: NoOpOperator
+      params: {}
+      terminal: success
+
+    - id: terminal_doc_done
+      operator: NoOpOperator
+      params: {}
+      terminal: success
+
+    - id: terminal_verify_failed
+      operator: NoOpOperator
+      params: {}
+      terminal: failure
+
+    - id: terminal_plan_rejected
+      operator: NoOpOperator
+      params: {}
+      terminal: failure
+
+    - id: terminal_triage_exhausted
+      operator: NoOpOperator
+      params: {}
+      terminal: failure
+
+    - id: terminal_apply_incomplete
+      operator: NoOpOperator
+      params: {}
+      terminal: failure

--- a/resources/newton-template/newton/workflows/planner.yaml
+++ b/resources/newton-template/newton/workflows/planner.yaml
@@ -1,0 +1,236 @@
+version: "2.0"
+mode: workflow_graph
+
+metadata:
+  name: "planner-workflow"
+  description: "Enrich a user spec with mandatory planning aspects; human-in-the-loop for missing aspects. Optional trigger payload key output_path sets where the final enriched spec is saved (default .newton/plan/enriched.md and .newton/plan/enriched-final.md)."
+
+triggers:
+  type: manual
+  schema_version: "1.0"
+  payload:
+    prompt: ""
+    output_path: ""
+    board_item_id: ""
+    board_content_id: ""
+    board_issue_number: ""
+    board_item_title: ""
+
+workflow:
+  settings:
+    entry_task: resolve_board_ids
+    max_time_seconds: 3600
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 3
+    max_workflow_iterations: 15
+
+    default_engine: claude
+    model_stylesheet:
+      model: claude-sonnet-4-20250514
+
+    command_operator:
+      allow_shell: true
+
+  context:
+    preamble: |-
+      You are enriching a product/spec document so that requirements are clearly and explicitly defined and implementation-ready. The user provided a spec (path or content below).
+
+      CODEBASE GROUNDING (do this first):
+      Before writing the enriched document, you MUST explore the target codebase (read key files, list directories) to ground every section in the actual project structure. File paths in the "Modified files" table MUST correspond to real files. If the spec references entities (commands, endpoints, modules), enumerate them from the source, not from the user's prose.
+
+      You MUST produce an enriched markdown document that MANDATORILY covers these aspects in this order (use the exact section headers):
+
+      TECHNICAL CONTEXT (sections 1-7):
+      1. **Problem statement** - What is broken or missing today. One paragraph grounded in actual codebase state. MUST include an explicit "out of scope" sentence for related work not in this spec.
+      2. **Goals** - Numbered list of concrete outcomes. Each goal MUST be verifiable.
+      3. **Current behavior** - Table: Component | Role | Mutable at runtime? Plus 1-2 sentences on current build and resume flow. Grounded in code inspection.
+      4. **Design** - The core "how". Subsections for each major mechanism (data structures, concurrency model, API surface, integration points). MUST include: storage types and data structure choices with concrete types, concurrency/locking strategy, invariants, identity/naming conventions, collision and error conditions, tick/lifecycle visibility rules. Include YAML or config examples where applicable.
+      5. **Schema and API** - Exact struct/type definitions and method signatures that implementers will create or modify. Use the project's language (Rust, Python, etc.) for code blocks.
+      6. **Error codes** - Table: Code | Category | Trigger. One row per error the implementation introduces.
+      7. **Acceptance criteria** - Numbered, testable conditions. Each criterion MUST be a single verifiable statement (not a vague goal). Produce at least one criterion per goal, one per error code, and one for backward-compatibility regression.
+
+      PLANNING (sections 8-14):
+      8. **Functionality comparison (before vs after)** - What exists today vs what will exist after implementation.
+      9. **Benefit of implementing this functionality** - Why implement this; value and impact.
+      10. **Stages** - Break the work into ordered stages. Each stage MUST define: (a) a concrete deliverable or output, (b) the explicit scope (enumerate items, NEVER use "etc." or ellipsis), and (c) any blocking dependency on a prior stage. If a stage produces a document or artifact that later stages consume, describe its expected content or structure.
+      11. **Breaking changes** - API, config, or behavioral changes that affect existing users or callers.
+      12. **Modified files and summary** - A table: | File/path | Summary of modifications |. Every path MUST be verified against the actual codebase. If existing tests or configs already cover the area, reference them.
+      13. **Dependencies** - External or internal dependencies (libraries, services, teams). For each dependency on a person or team, state whether it is blocking or non-blocking and which stage it gates. If a dependency is marked "recommended" or "optional", state what happens if it is skipped.
+      14. **Proposed folder structure** - If this is a new project, write complete folder structure; otherwise only modified files and paths.
+
+      VERIFICATION AND REFERENCE (sections 15-17):
+      15. **Design decisions** - Table: # | Question | Decision | Rationale. Captures key trade-offs so implementers do not re-debate them.
+      16. **Out of scope (explicit)** - Bulleted list of things explicitly excluded. Prevents scope creep.
+      17. **References** - Pointers to real files, functions, and structs in the codebase that the implementer should start from.
+
+      Requirements quality (apply throughout the spec):
+      - State requirements in normative language where applicable: MUST (mandatory), SHOULD (recommended), MAY (optional). Avoid vague wording; make obligations and options explicit.
+      - For each major capability or command, make applicability explicit (e.g. which commands get which options, or "all read-only commands" with a defined list).
+      - NEVER use "etc.", "and so on", or ellipsis to scope work items. If a stage or requirement applies to a subset of entities, enumerate them explicitly. If the full list is unknown, flag it with [NEED_USER_INPUT].
+      - Include test expectations where relevant (e.g. "Format selection MUST be covered by tests for each updated command").
+      - Ensure success criteria are measurable or verifiable. When a criterion uses a comparative metric (e.g. "2x longer", "50% faster"), it MUST include or reference a concrete baseline value so the criterion can be checked.
+      - If the spec defines options or formats (e.g. output formats, flags), specify per-entity applicability or a clear rule so implementers know exactly where each option applies.
+
+      For each of the 17 aspects: if you can fill it from the spec, codebase inspection, or well-grounded inference, write the section. If you are inventing names, paths, or details that cannot be verified from the spec or codebase, write exactly "[NEED_USER_INPUT: <aspect_name>]" in that section and add the aspect_name to the gaps list. Valid aspect_name values: problem_statement, goals, current_behavior, design, schema_api, error_codes, acceptance_criteria, functionality_comparison, benefit, stages, breaking_changes, modified_files_table, dependencies, folder_structure, design_decisions, out_of_scope, references.
+
+      When presenting multiple options to the user, present a recommended one and the rationale.
+
+  tasks:
+    - id: resolve_board_ids
+      operator: GhOperator
+      params:
+        operation: project_resolve_board
+        owner:
+          $expr: 'env("GH_PROJECT_OWNER")'
+        project_number:
+          $expr: 'env("GH_PROJECT_NUMBER")'
+        required_option_names:
+          - Backlog
+      transitions:
+        - to: enrich_spec
+
+    - id: enrich_spec
+      operator: AgentOperator
+      max_iterations: 2
+      params:
+        engine: claude
+        prompt:
+          $expr: 'context.preamble + "\n\nOutput format:\n- Write the full enriched markdown to the file " + (if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }) + " in the workspace (create directory if needed).\n- Write the list of aspect names that need user input (one per line) to .newton/plan/gaps.txt. If none need input, write a single line \"none\". Use only these aspect names when listing gaps: problem_statement, goals, current_behavior, design, schema_api, error_codes, acceptance_criteria, functionality_comparison, benefit, stages, breaking_changes, modified_files_table, dependencies, folder_structure, design_decisions, out_of_scope, references.\n\n---\nUser spec (path or content):\n\n" + triggers.prompt'
+      transitions:
+        - to: check_gaps
+
+    - id: check_gaps
+      operator: AgentOperator
+      max_iterations: 1
+      params:
+        engine: claude
+        prompt:
+          $expr: '"Read the file " + (if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }) + " in the workspace. Does it contain the exact text \"NEED_USER_INPUT\"? Reply with exactly <status>HAS_GAPS</status> if it does, otherwise <status>NO_GAPS</status>."'
+        signals:
+          has_gaps: "<status>HAS_GAPS</status>"
+          no_gaps: "<status>NO_GAPS</status>"
+      transitions:
+        - to: cat_gaps
+          priority: 0
+          when: { "$expr": 'tasks.check_gaps.output.signal == "has_gaps"' }
+        - to: copy_draft_to_final
+          priority: 10
+
+    - id: cat_gaps
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: "cat .newton/plan/gaps.txt 2>/dev/null || echo 'none'"
+        capture_stdout: true
+      transitions:
+        - to: ask_user
+
+    - id: ask_user
+      operator: HumanDecisionOperator
+      params:
+        prompt:
+          $expr: '"The enriched spec draft is at " + (if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }) + ". The following aspects need your input (add content for them in the draft):\n\n" + tasks.cat_gaps.output.stdout + "\n\nEdit the draft file, then choose Continue. To finalize without adding more, choose Skip."'
+        choices:
+          - "Continue"
+          - "Skip"
+        default_choice: "Continue"
+      transitions:
+        - to: merge_spec
+          priority: 0
+          when: { "$expr": 'tasks.ask_user.output.choice == "Continue"' }
+        - to: copy_draft_to_final
+          priority: 10
+
+    - id: merge_spec
+      operator: AgentOperator
+      max_iterations: 1
+      params:
+        engine: claude
+        prompt:
+          $expr: '"Read " + (if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }) + " in the workspace. Produce a final version that removes any remaining \"[NEED_USER_INPUT: ...]\" placeholders (replace with a short note if needed). Write the result to " + (if triggers.output_path != () && triggers.output_path != "" { triggers.output_path } else { ".newton/plan/enriched-final.md" }) + "."'
+      transitions:
+        - to: cleanup_draft
+
+    - id: copy_draft_to_final
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          DRAFT_PATH:
+            $expr: 'if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }'
+          FINAL_PATH:
+            $expr: 'if triggers.output_path != () && triggers.output_path != "" { triggers.output_path } else { ".newton/plan/enriched-final.md" }'
+        cmd: "mkdir -p \"$(dirname \"$FINAL_PATH\")\" 2>/dev/null; cp \"$DRAFT_PATH\" \"$FINAL_PATH\""
+        capture_stdout: false
+      transitions:
+        - to: cleanup_draft
+
+    - id: cleanup_draft
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          DRAFT_PATH:
+            $expr: 'if triggers.output_path != () && triggers.output_path != "" { triggers.output_path + ".draft.md" } else { ".newton/plan/enriched.md" }'
+        cmd: "rm -f \"$DRAFT_PATH\""
+        capture_stdout: false
+      transitions:
+        - to: finalize
+
+    - id: finalize
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          OUT:
+            $expr: 'if triggers.output_path != () && triggers.output_path != "" { triggers.output_path } else { ".newton/plan/enriched-final.md" }'
+        cmd: "echo Enriched spec written to $OUT"
+        capture_stdout: false
+      transitions:
+        - to: update_board_body
+
+    - id: update_board_body
+      operator: CommandOperator
+      params:
+        shell: true
+        env:
+          ITEM_ID:
+            $expr: 'triggers.board_content_id'
+          ITEM_TITLE:
+            $expr: 'triggers.board_item_title'
+          ISSUE_NUMBER:
+            $expr: 'triggers.board_issue_number'
+          OUT:
+            $expr: 'if triggers.output_path != () && triggers.output_path != "" { triggers.output_path } else { ".newton/plan/enriched-final.md" }'
+        cmd: |
+          set -e
+          if [[ "$ITEM_ID" == DI_* ]]; then
+            gh project item-edit --id "$ITEM_ID" --title "$ITEM_TITLE" --body "$(cat "$OUT")"
+          else
+            gh issue edit "$ISSUE_NUMBER" --body "$(cat "$OUT")"
+          fi
+        capture_stdout: false
+      transitions:
+        - to: move_to_backlog
+
+    - id: move_to_backlog
+      operator: GhOperator
+      params:
+        operation: project_item_set_status
+        item_id:
+          $expr: 'triggers.board_item_id'
+        board:
+          $expr: 'tasks.resolve_board_ids.output'
+        status: "Backlog"
+        on_error: fail
+      transitions:
+        - to: success
+
+    - id: success
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "Planner completed; item moved to Backlog"'
+        capture_stdout: false
+      terminal: success

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -49,14 +49,14 @@ pub async fn run(args: InitArgs) -> Result<()> {
         .unwrap_or_else(|| DEFAULT_TEMPLATE_SOURCE.to_string());
     install_template(&path, &template_source)?;
 
-    // Create minimal executor.sh stub if it doesn't exist
-    ensure_executor_script(&newton_dir)?;
-
     // Write .newton/configs/default.conf
     write_default_config(&newton_dir, &path)?;
 
     println!("Initialized Newton workspace at {}", path.display());
-    println!("Run: newton run");
+    println!(
+        "Next: newton run .newton/workflows/<workflow>.yaml --workspace {}",
+        path.display()
+    );
 
     Ok(())
 }
@@ -106,36 +106,6 @@ fn install_template(project_root: &Path, template_source: &str) -> Result<()> {
     Ok(())
 }
 
-/// Ensures executor.sh exists, creating a minimal stub if the template didn't provide one
-fn ensure_executor_script(newton_dir: &Path) -> Result<()> {
-    let executor_path = newton_dir.join("scripts/executor.sh");
-
-    if !executor_path.exists() {
-        fs::create_dir_all(executor_path.parent().unwrap())?;
-
-        let stub_content = r#"#!/bin/bash
-# Minimal executor stub
-# Replace with your actual executor implementation
-
-echo "Executor stub: implement your coding agent integration here"
-exit 1
-"#;
-
-        fs::write(&executor_path, stub_content)?;
-
-        // Make executable on Unix
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&executor_path)?.permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&executor_path, perms)?;
-        }
-    }
-
-    Ok(())
-}
-
 /// Writes .newton/configs/default.conf with key=value pairs
 fn write_default_config(newton_dir: &Path, project_root: &Path) -> Result<()> {
     let config_path = newton_dir.join("configs/default.conf");
@@ -154,34 +124,14 @@ fn write_default_config(newton_dir: &Path, project_root: &Path) -> Result<()> {
     writeln!(config_file, "project_root={}", project_root.display())?;
     writeln!(config_file, "coding_model={}", coding_model)?;
     writeln!(config_file)?;
-
-    // Script paths (optional - defaults to .newton/scripts/*.sh)
     writeln!(
         config_file,
-        "# Can be absolute paths or relative to project/workspace root"
+        "# Required for newton batch <project_id>: path to a workflow YAML (relative to project_root or workspace)"
     )?;
-    writeln!(config_file, "# evaluator_cmd=.newton/scripts/evaluator.sh")?;
-    writeln!(config_file, "# advisor_cmd=.newton/scripts/advisor.sh")?;
-    writeln!(config_file, "# executor_cmd=.newton/scripts/executor.sh")?;
-    writeln!(config_file, "# coder_cmd=.newton/scripts/coder.sh")?;
-    writeln!(config_file)?;
-
-    // Optionally add script paths if they exist
-    let post_success_script = newton_dir.join("scripts/post-success.sh");
-    if post_success_script.exists() {
-        writeln!(
-            config_file,
-            "post_success_script=.newton/scripts/post-success.sh"
-        )?;
-    }
-
-    let post_fail_script = newton_dir.join("scripts/post-failure.sh");
-    if post_fail_script.exists() {
-        writeln!(
-            config_file,
-            "post_fail_script=.newton/scripts/post-failure.sh"
-        )?;
-    }
+    writeln!(
+        config_file,
+        "# workflow_file=.newton/workflows/develop.yaml"
+    )?;
 
     Ok(())
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -54,7 +54,7 @@ pub async fn run(args: InitArgs) -> Result<()> {
 
     println!("Initialized Newton workspace at {}", path.display());
     println!(
-        "Next: newton run .newton/workflows/<workflow>.yaml --workspace {}",
+        "Set workflow_file in .newton/configs/default.conf to your workflow YAML, then run newton run with that file and --workspace {}",
         path.display()
     );
 
@@ -128,10 +128,7 @@ fn write_default_config(newton_dir: &Path, project_root: &Path) -> Result<()> {
         config_file,
         "# Required for newton batch <project_id>: path to a workflow YAML (relative to project_root or workspace)"
     )?;
-    writeln!(
-        config_file,
-        "# workflow_file=.newton/workflows/develop.yaml"
-    )?;
+    writeln!(config_file, "# workflow_file=path/to/workflow.yaml")?;
 
     Ok(())
 }


### PR DESCRIPTION
Removes executor stub and classic default.conf coupling from `newton init`. Bundled template ships workflow YAML and helper scripts instead of evaluator/advisor/post hooks. README is workflow-first and consumption-oriented. Init output and docs avoid hardcoding specific workflow filenames; template README documents concrete examples.

Also fixes documenter.sh to use a relative workflow path.