### PR TITLE
fix(workflow): harden nested runtime integrity

### DIFF
--- a/src/workflow/executor.rs
+++ b/src/workflow/executor.rs
@@ -741,13 +741,6 @@ impl WorkflowRuntime {
                 Self::print_task_verbose_output(outcome);
             }
 
-            if outcome.failed && !self.config.continue_on_error {
-                return Err(AppError::new(
-                    ErrorCategory::ValidationError,
-                    format!("task {} failed", outcome.task_id),
-                )
-                .with_code("WFG-EXEC-001"));
-            }
             let record = task_execution::build_workflow_task_run_record(
                 outcome,
                 self.runtime_graph
@@ -763,6 +756,23 @@ impl WorkflowRuntime {
             self.workflow_execution
                 .task_runs
                 .push(WorkflowTaskRunSummary::from(record));
+
+            if outcome.failed && !self.config.continue_on_error {
+                if let Some(error) = outcome.error_summary.as_ref() {
+                    if error.code == "WFG-NEST-005" {
+                        return Err(AppError::new(
+                            ErrorCategory::ValidationError,
+                            error.message.clone(),
+                        )
+                        .with_code("WFG-NEST-005"));
+                    }
+                }
+                return Err(AppError::new(
+                    ErrorCategory::ValidationError,
+                    format!("task {} failed", outcome.task_id),
+                )
+                .with_code("WFG-EXEC-001"));
+            }
         }
         let snapshot = guard.snapshot();
         drop(guard);
@@ -929,9 +939,12 @@ impl WorkflowRuntime {
             let barrier_params: BarrierParams =
                 match serde_json::from_value(barrier_task.params.clone()) {
                     Ok(params) => params,
-                    Err(_) => {
-                        // Skip invalid barrier params
-                        continue;
+                    Err(e) => {
+                        return Err(AppError::new(
+                            ErrorCategory::ValidationError,
+                            format!("barrier task '{}' has invalid params: {e}", barrier_task.id),
+                        )
+                        .with_code("WFG-BARRIER-001"));
                     }
                 };
 
@@ -1193,16 +1206,20 @@ fn build_workflow_runtime_with_parent(
                     task_clone.transitions = task
                         .transitions
                         .iter()
-                        .filter(|t| {
+                        .filter_map(|t| {
                             if let Some(ref g) = t.include_if {
-                                context::evaluate_condition(g, engine.as_ref(), &eval_ctx)
-                                    .unwrap_or(true)
+                                match context::evaluate_condition(g, engine.as_ref(), &eval_ctx)
+                                    .map_err(|e| e.with_code("WFG-GRAPH-001"))
+                                {
+                                    Ok(true) => Some(Ok(t.clone())),
+                                    Ok(false) => None,
+                                    Err(e) => Some(Err(e)),
+                                }
                             } else {
-                                true
+                                Some(Ok(t.clone()))
                             }
                         })
-                        .cloned()
-                        .collect();
+                        .collect::<Result<Vec<_>, _>>()?;
                     tasks_map.insert(task.id.clone(), task_clone);
                 }
             }
@@ -1476,6 +1493,17 @@ fn extract_trigger_payload(document: &WorkflowDocument) -> Value {
     )
 }
 
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
 fn shallow_merge_objects(base: &Value, overlay: &Value) -> Result<Value, AppError> {
     let overlay_obj = overlay.as_object().ok_or_else(|| {
         AppError::new(
@@ -1483,7 +1511,16 @@ fn shallow_merge_objects(base: &Value, overlay: &Value) -> Result<Value, AppErro
             "merge value must be an object",
         )
     })?;
-    let mut merged = base.as_object().cloned().unwrap_or_default();
+    let mut merged = base.as_object().cloned().ok_or_else(|| {
+        AppError::new(
+            ErrorCategory::ValidationError,
+            format!(
+                "merge base must be a JSON object, got {}",
+                json_type_name(base)
+            ),
+        )
+        .with_code("WFG-NEST-005")
+    })?;
     for (key, value) in overlay_obj {
         merged.insert(key.clone(), value.clone());
     }
@@ -1529,4 +1566,17 @@ fn hydrate_completed_records(
         );
     }
     Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shallow_merge_objects;
+    use serde_json::json;
+
+    #[test]
+    fn shallow_merge_non_object_base_returns_err() {
+        let err = shallow_merge_objects(&json!("string"), &json!({}))
+            .expect_err("non-object base must error");
+        assert_eq!(err.code, "WFG-NEST-005");
+    }
 }

--- a/src/workflow/operators/barrier.rs
+++ b/src/workflow/operators/barrier.rs
@@ -24,14 +24,13 @@ impl Operator for BarrierOperator {
     }
 
     fn validate_params(&self, params: &Value) -> Result<(), AppError> {
-        let _barrier_params: BarrierParams =
-            serde_json::from_value(params.clone()).map_err(|err| {
-                AppError::new(
-                    ErrorCategory::ValidationError,
-                    format!("Invalid barrier operator parameters: {err}"),
-                )
-            })?;
-
+        if !params.is_object() {
+            return Err(AppError::new(
+                ErrorCategory::ValidationError,
+                "barrier operator params must be an object",
+            )
+            .with_code("WFG-BARRIER-001"));
+        }
         Ok(())
     }
 
@@ -41,6 +40,7 @@ impl Operator for BarrierOperator {
                 ErrorCategory::ValidationError,
                 format!("Invalid barrier operator parameters: {err}"),
             )
+            .with_code("WFG-BARRIER-001")
         })?;
 
         // The actual barrier logic is handled by the scheduler in the executor.

--- a/src/workflow/operators/workflow.rs
+++ b/src/workflow/operators/workflow.rs
@@ -83,11 +83,11 @@ impl Operator for WorkflowOperator {
         let context_merge = Some(merge_objects_with_optional(
             &ctx.state_view.context,
             explicit_context.as_ref(),
-        ));
+        )?);
         let triggers_merge = Some(merge_objects_with_optional(
             &ctx.state_view.triggers,
             explicit_triggers.as_ref(),
-        ));
+        )?);
 
         let summary = self
             .runner
@@ -131,14 +131,34 @@ fn validate_optional_object(
     Ok(())
 }
 
-fn merge_objects_with_optional(base: &Value, overlay: Option<&Value>) -> Value {
-    let mut merged = base.as_object().cloned().unwrap_or_default();
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn merge_objects_with_optional(base: &Value, overlay: Option<&Value>) -> Result<Value, AppError> {
+    let mut merged = base.as_object().cloned().ok_or_else(|| {
+        AppError::new(
+            ErrorCategory::ValidationError,
+            format!(
+                "context/triggers base must be a JSON object, got {}",
+                json_type_name(base)
+            ),
+        )
+        .with_code("WFG-NEST-005")
+    })?;
     if let Some(overlay) = overlay.and_then(Value::as_object) {
         for (key, value) in overlay {
             merged.insert(key.clone(), value.clone());
         }
     }
-    Value::Object(merged)
+    Ok(Value::Object(merged))
 }
 
 fn resolve_and_sandbox_child_path(
@@ -230,6 +250,27 @@ mod tests {
             },
             operator_registry: crate::workflow::operator::OperatorRegistry::new(),
         }
+    }
+
+    #[test]
+    fn merge_non_object_scalar_base_returns_err() {
+        let err = merge_objects_with_optional(&json!("scalar"), None)
+            .expect_err("scalar base must error");
+        assert_eq!(err.code, "WFG-NEST-005");
+    }
+
+    #[test]
+    fn merge_non_object_array_base_returns_err() {
+        let err = merge_objects_with_optional(&json!([1, 2, 3]), Some(&json!({"k": 1})))
+            .expect_err("array base must error");
+        assert_eq!(err.code, "WFG-NEST-005");
+    }
+
+    #[test]
+    fn merge_object_base_succeeds() {
+        let result = merge_objects_with_optional(&json!({"a": 1}), Some(&json!({"b": 2})))
+            .expect("object base must succeed");
+        assert_eq!(result, json!({"a": 1, "b": 2}));
     }
 
     #[test]

--- a/src/workflow/transform/include_if.rs
+++ b/src/workflow/transform/include_if.rs
@@ -149,12 +149,17 @@ fn evaluate_include_if(
                 )
                 .with_code("WFG-INCLUDE-001"));
             }
+            let code = if field == "transition" {
+                "WFG-GRAPH-001"
+            } else {
+                "WFG-TPL-001"
+            };
             let evaluated = engine.evaluate(expr, eval_ctx).map_err(|err| {
                 AppError::new(
                     ErrorCategory::ValidationError,
                     format!("template interpolation error in '{task_id}.{field}': {err}"),
                 )
-                .with_code("WFG-TPL-001")
+                .with_code(code)
             })?;
             Ok(is_truthy(&evaluated))
         }

--- a/tests/fixtures/workflows/41_fail_immediate_task_run_persist.yaml
+++ b/tests/fixtures/workflows/41_fail_immediate_task_run_persist.yaml
@@ -1,0 +1,18 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 41: Fail Immediate Task Run Persist"
+workflow:
+  settings:
+    entry_task: "fail_task"
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "fail_task"
+      operator: "AssertCompletedOperator"
+      params:
+        require: ["nonexistent_task"]
+      terminal: success

--- a/tests/fixtures/workflows/42_nested_fail_task_run_persist.yaml
+++ b/tests/fixtures/workflows/42_nested_fail_task_run_persist.yaml
@@ -1,0 +1,18 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 42: Nested Fail Task Run Persist"
+workflow:
+  settings:
+    entry_task: "call_child"
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "call_child"
+      operator: "WorkflowOperator"
+      params:
+        workflow_path: "./42b_child_runtime_fail.yaml"
+      terminal: success

--- a/tests/fixtures/workflows/42b_child_runtime_fail.yaml
+++ b/tests/fixtures/workflows/42b_child_runtime_fail.yaml
@@ -1,0 +1,21 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 42b: Child Runtime Fail (used as child in 42)"
+workflow:
+  settings:
+    entry_task: "assert_early"
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "assert_early"
+      operator: "AssertCompletedOperator"
+      params:
+        require: ["step_two"]
+      terminal: success
+    - id: "step_two"
+      operator: "NoOpOperator"
+      terminal: success

--- a/tests/fixtures/workflows/43_transition_include_if_eval_error.yaml
+++ b/tests/fixtures/workflows/43_transition_include_if_eval_error.yaml
@@ -1,0 +1,25 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 43: Transition IncludeIf Eval Error"
+workflow:
+  settings:
+    entry_task: "start"
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "start"
+      operator: "NoOpOperator"
+      transitions:
+        - to: "bad_branch"
+          include_if: { $expr: "undefined_fn(){{{" }
+        - to: "end"
+    - id: "bad_branch"
+      operator: "NoOpOperator"
+      terminal: success
+    - id: "end"
+      operator: "NoOpOperator"
+      terminal: success

--- a/tests/fixtures/workflows/44_barrier_invalid_params.yaml
+++ b/tests/fixtures/workflows/44_barrier_invalid_params.yaml
@@ -1,0 +1,24 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 44: Barrier Invalid Params"
+workflow:
+  settings:
+    entry_task: "task_a"
+    max_time_seconds: 60
+    parallel_limit: 2
+    continue_on_error: false
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "task_a"
+      operator: "NoOpOperator"
+    - id: "sync_barrier"
+      operator: "barrier"
+      params:
+        expected: "not_an_array"
+      transitions:
+        - to: "terminal_task"
+    - id: "terminal_task"
+      operator: "NoOpOperator"
+      terminal: success

--- a/tests/fixtures/workflows/45_nested_non_object_context.yaml
+++ b/tests/fixtures/workflows/45_nested_non_object_context.yaml
@@ -1,0 +1,19 @@
+version: "2.0"
+mode: "workflow_graph"
+metadata:
+  name: "Scenario 45: Nested Non-Object Context"
+workflow:
+  context: "bad_scalar"
+  settings:
+    entry_task: "call_child"
+    max_time_seconds: 60
+    parallel_limit: 1
+    continue_on_error: true
+    max_task_iterations: 10
+    max_workflow_iterations: 100
+  tasks:
+    - id: "call_child"
+      operator: "WorkflowOperator"
+      params:
+        workflow_path: "./01_minimal_success.yaml"
+      terminal: success

--- a/tests/integration/test_workflow_scenarios.rs
+++ b/tests/integration/test_workflow_scenarios.rs
@@ -13,11 +13,12 @@ use newton::workflow::operators::{self, BuiltinOperatorDeps};
 use newton::workflow::schema::{self, TriggerType, WorkflowTrigger};
 use newton::workflow::state::GraphSettings;
 use serde_json::{json, Value};
-use std::collections::{HashMap, VecDeque};
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub enum MockCommandStep {
@@ -305,6 +306,58 @@ impl WorkflowTestHarness {
         )
         .await
     }
+}
+
+/// Read and parse execution.json for the given UUID from `<state_root>/<execution_id>/execution.json`.
+/// Panics with a descriptive message if the file does not exist or cannot be parsed.
+pub fn read_execution_json(state_root: &Path, execution_id: Uuid) -> Value {
+    let path = state_root
+        .join(execution_id.to_string())
+        .join("execution.json");
+    let bytes = std::fs::read(&path)
+        .unwrap_or_else(|e| panic!("failed to read execution.json at {}: {e}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("failed to parse execution.json at {}: {e}", path.display()))
+}
+
+/// Return the set of `task_id` strings from `execution["task_runs"]`.
+/// Panics if `task_runs` is absent or not an array.
+pub fn task_run_ids(execution: &Value) -> HashSet<String> {
+    execution["task_runs"]
+        .as_array()
+        .expect("task_runs must be an array")
+        .iter()
+        .map(|entry| {
+            entry["task_id"]
+                .as_str()
+                .expect("task_run entry must have task_id string")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Scan all subdirectories of `state_root`, read each `execution.json`, and
+/// collect execution_ids whose `parent_execution_id` matches `parent_id`.
+pub fn find_child_executions(state_root: &Path, parent_id: Uuid) -> Vec<Uuid> {
+    let parent_id_str = parent_id.to_string();
+    let mut children = Vec::new();
+    let entries = std::fs::read_dir(state_root)
+        .unwrap_or_else(|e| panic!("failed to read state_root {}: {e}", state_root.display()));
+    for entry in entries.flatten() {
+        let exec_json = entry.path().join("execution.json");
+        if let Ok(bytes) = std::fs::read(&exec_json) {
+            if let Ok(val) = serde_json::from_slice::<Value>(&bytes) {
+                if val["parent_execution_id"].as_str() == Some(&parent_id_str) {
+                    if let Some(id_str) = val["execution_id"].as_str() {
+                        if let Ok(id) = Uuid::parse_str(id_str) {
+                            children.push(id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    children
 }
 
 /// Result of executing a workflow via CLI command
@@ -1300,22 +1353,18 @@ async fn test_scenario_37_nested_workflow_basic() {
         .as_str()
         .expect("child_execution_id must be string");
 
-    let child_execution_path = harness
-        .temp_dir
-        .path()
-        .join(".newton/state/workflows")
-        .join(child_execution_id)
-        .join("execution.json");
-    let child_execution_bytes =
-        std::fs::read(&child_execution_path).expect("read child execution.json");
-    let child_execution: Value =
-        serde_json::from_slice(&child_execution_bytes).expect("parse child execution.json");
+    let state_root = harness.temp_dir.path().join(".newton/state/workflows");
+    let child_uuid =
+        Uuid::parse_str(child_execution_id).expect("child_execution_id must be valid UUID");
+    let child_execution = read_execution_json(&state_root, child_uuid);
+    let child_task_ids = task_run_ids(&child_execution);
     assert_eq!(
         child_execution["parent_execution_id"],
         json!(summary.execution_id.to_string())
     );
     assert_eq!(child_execution["parent_task_id"], json!("call_child"));
     assert_eq!(child_execution["nesting_depth"], json!(1));
+    assert!(child_task_ids.contains("start"));
 
     assert_yaml_snapshot!(summary, {
         ".execution_id" => "[uuid]",
@@ -1420,4 +1469,182 @@ workflow:
         .get("call_child")
         .expect("call_child must complete");
     assert_eq!(call_child.error_code.as_deref(), Some("WFG-NEST-001"));
+}
+
+// -----------------------------------------------------------------------------
+// Scenario 41: Fail Task Persisted in execution.json
+// -----------------------------------------------------------------------------
+#[tokio::test]
+async fn test_scenario_41_fail_task_persisted_in_execution_json() {
+    let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    let state_root = harness.temp_dir.path().join(".newton/state/workflows");
+
+    let err = harness
+        .run_fixture("41_fail_immediate_task_run_persist.yaml", None)
+        .await
+        .expect_err("workflow must fail");
+    assert_eq!(
+        err.code, "WFG-EXEC-001",
+        "expected WFG-EXEC-001 but got: {} — {}",
+        err.code, err.message
+    );
+
+    // Find the single execution directory that was created
+    let entries: Vec<_> = std::fs::read_dir(&state_root)
+        .expect("state_root must exist after a run")
+        .flatten()
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one execution directory expected");
+    let exec_id = Uuid::parse_str(
+        entries[0]
+            .file_name()
+            .to_str()
+            .expect("valid utf8 dir name"),
+    )
+    .expect("execution dir must be a UUID");
+
+    let execution = read_execution_json(&state_root, exec_id);
+    let ids = task_run_ids(&execution);
+    assert!(
+        ids.contains("fail_task"),
+        "fail_task must appear in task_runs; found: {ids:?}"
+    );
+    let task_run = execution["task_runs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["task_id"].as_str() == Some("fail_task"))
+        .expect("fail_task run entry");
+    assert_eq!(task_run["status"].as_str(), Some("failed"));
+}
+
+// -----------------------------------------------------------------------------
+// Scenario 42: Nested Fail Child Task Persisted
+// -----------------------------------------------------------------------------
+#[tokio::test]
+async fn test_scenario_42_nested_fail_child_task_persisted() {
+    let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    let state_root = harness.temp_dir.path().join(".newton/state/workflows");
+    let err = harness
+        .run_fixture("42_nested_fail_task_run_persist.yaml", None)
+        .await
+        .expect_err("workflow must fail");
+    assert!(
+        !err.code.is_empty(),
+        "error must have a code; got: {}",
+        err.message
+    );
+
+    // Find the parent execution directory
+    let all_entries: Vec<_> = std::fs::read_dir(&state_root)
+        .expect("state_root must exist")
+        .flatten()
+        .collect();
+    assert!(
+        !all_entries.is_empty(),
+        "at least one execution directory expected"
+    );
+
+    // Find parent execution (nesting_depth == 0)
+    let parent_exec_id = all_entries
+        .iter()
+        .find_map(|entry| {
+            let exec_json = entry.path().join("execution.json");
+            let bytes = std::fs::read(&exec_json).ok()?;
+            let val: Value = serde_json::from_slice(&bytes).ok()?;
+            if val["nesting_depth"].as_u64() == Some(0) {
+                Uuid::parse_str(entry.file_name().to_str()?).ok()
+            } else {
+                None
+            }
+        })
+        .expect("parent execution directory must exist");
+
+    let child_ids = find_child_executions(&state_root, parent_exec_id);
+    assert_eq!(child_ids.len(), 1, "exactly one child execution expected");
+
+    let child_execution = read_execution_json(&state_root, child_ids[0]);
+    let ids = task_run_ids(&child_execution);
+    assert!(
+        ids.contains("assert_early"),
+        "assert_early must appear in child task_runs; found: {ids:?}"
+    );
+    let task_run = child_execution["task_runs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["task_id"].as_str() == Some("assert_early"))
+        .expect("assert_early run entry");
+    assert_eq!(task_run["status"].as_str(), Some("failed"));
+}
+
+// -----------------------------------------------------------------------------
+// Scenario 43: Transition IncludeIf Error Fails Fast
+// -----------------------------------------------------------------------------
+#[tokio::test]
+async fn test_scenario_43_transition_include_if_error_fails_fast() {
+    let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    let err = harness
+        .run_fixture("43_transition_include_if_eval_error.yaml", None)
+        .await
+        .expect_err("workflow must fail on bad transition include_if");
+
+    assert_eq!(
+        err.code, "WFG-GRAPH-001",
+        "expected WFG-GRAPH-001 but got: {} — {}",
+        err.code, err.message
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Scenario 44: Barrier Invalid Params Fails
+// -----------------------------------------------------------------------------
+#[tokio::test]
+async fn test_scenario_44_barrier_invalid_params_fails() {
+    let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    let err = harness
+        .run_fixture("44_barrier_invalid_params.yaml", None)
+        .await
+        .expect_err("workflow must fail on invalid barrier params");
+
+    assert_eq!(
+        err.code, "WFG-BARRIER-001",
+        "expected WFG-BARRIER-001 but got: {} — {}",
+        err.code, err.message
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Scenario 45: Nested Non-Object Context Fails
+// -----------------------------------------------------------------------------
+#[tokio::test]
+async fn test_scenario_45_nested_non_object_context_fails() {
+    let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    let state_root = harness.temp_dir.path().join(".newton/state/workflows");
+    let err = harness
+        .run_fixture("45_nested_non_object_context.yaml", None)
+        .await
+        .expect_err("workflow must fail when parent context is non-object");
+    assert_eq!(err.code, "WFG-EXEC-001");
+
+    let entries: Vec<_> = std::fs::read_dir(&state_root)
+        .expect("state_root must exist after a run")
+        .flatten()
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one execution directory expected");
+    let exec_id = Uuid::parse_str(
+        entries[0]
+            .file_name()
+            .to_str()
+            .expect("valid utf8 dir name"),
+    )
+    .expect("execution dir must be a UUID");
+    let execution = read_execution_json(&state_root, exec_id);
+    let task_run = execution["task_runs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["task_id"].as_str() == Some("call_child"))
+        .expect("call_child run entry");
+    assert_eq!(task_run["error_code"].as_str(), Some("WFG-NEST-005"));
 }


### PR DESCRIPTION
## Summary
- persist failing task runs before early workflow aborts and add regression coverage for execution state files
- fail fast on bad transition include_if evaluation, malformed barrier params, and non-object nested merge bases
- add shared workflow state test helpers plus fixtures and integration coverage for scenarios 41-45

## Verification
- cargo fmt --all --check
- cargo test --test test_workflow_scenarios
- cargo clippy --all-targets --all-features -- -D warnings
- pre-commit hook: formatting, clippy, unit tests
- pre-push hook: full test suite and docs build