### PR TITLE
fix(core): consume aikit-sdk normalized quota events; remove Newton-local heuristics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,13 +43,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "aikit-sdk"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cf14b1fbeacb863cb32495139009455bd52d59d028fdc1dd488b4ba02122c6"
+name = "aikit-agent"
+version = "0.1.0"
 dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aikit-sdk"
+version = "0.2.1"
+dependencies = [
+ "aikit-agent",
  "glob",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -225,14 +236,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -245,7 +256,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tower",
@@ -263,21 +274,15 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -290,12 +295,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -517,16 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,7 +584,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -611,7 +600,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "mio 1.1.1",
  "parking_lot",
@@ -791,15 +780,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -1065,25 +1045,6 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1207,17 +1168,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1235,7 +1185,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1265,30 +1215,6 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1297,9 +1223,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1312,33 +1238,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1347,7 +1259,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1360,18 +1272,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1653,7 +1565,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -1853,7 +1765,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1903,7 +1815,7 @@ dependencies = [
  "predicates",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "rhai",
  "serde",
  "serde_json",
@@ -2067,7 +1979,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -2082,7 +1994,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -2410,7 +2322,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2447,7 +2359,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2538,7 +2450,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cassowary",
  "crossterm 0.27.0",
  "indoc",
@@ -2555,7 +2467,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2564,7 +2476,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2609,61 +2521,20 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -2675,17 +2546,19 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2695,7 +2568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
 dependencies = [
  "ahash",
- "bitflags 2.11.0",
+ "bitflags",
  "no-std-compat",
  "num-traits",
  "once_cell",
@@ -2763,7 +2636,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2776,7 +2649,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2807,15 +2680,6 @@ dependencies = [
  "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2963,11 +2827,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3140,16 +3004,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -3202,7 +3056,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "crc",
@@ -3277,8 +3131,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.22.1",
- "bitflags 2.11.0",
+ "base64",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -3321,8 +3175,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.22.1",
- "bitflags 2.11.0",
+ "base64",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -3449,12 +3303,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3471,27 +3319,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3645,7 +3472,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3744,44 +3571,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -3790,17 +3615,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3831,7 +3656,7 @@ dependencies = [
  "indexmap",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -3845,12 +3670,12 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4325,12 +4150,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4355,12 +4193,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -4704,22 +4536,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wiremock"
@@ -4728,12 +4547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64 0.22.1",
+ "base64",
  "deadpool",
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",
@@ -4802,7 +4621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/gonewton/newton.git"
 clap = { version = "4.4", features = ["derive", "cargo"] }
 tokio = { version = "1.49", features = ["full"] }
 anyhow = "1.0"
-aikit-sdk = { version = "0.2.1", path = "/home/sysuser/ws001/goaikit/aikit/aikit-sdk" }
+aikit-sdk = { version = "0.2.1", git = "https://github.com/goaikit/aikit.git", branch = "main" }
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/gonewton/newton.git"
 clap = { version = "4.4", features = ["derive", "cargo"] }
 tokio = { version = "1.49", features = ["full"] }
 anyhow = "1.0"
-aikit-sdk = "0.1.50"
+aikit-sdk = { version = "0.2.1", path = "/home/sysuser/ws001/goaikit/aikit/aikit-sdk" }
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.6", features = ["v4", "serde"] }
-toml = "0.8"
+toml = "1.1"
 tempfile = "3.10"
 rand = "0.8"
 percent-encoding = "2.1"
@@ -33,7 +33,7 @@ ratatui = { version = "0.23" }
 crossterm = "0.28"
 tokio-tungstenite = { version = "0.20", features = ["__rustls-tls"] }
 tungstenite = { version = "0.20", features = ["__rustls-tls"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 url = "2"
 dirs-next = "2"
 tracing-appender = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Newton includes a production workflow runner with YAML-defined tasks and determi
 
 ### Agent quota failure behavior
 
-For SDK-backed `AgentOperator` engines (`claude`, `agent`, `codex`, `gemini`, `opencode`), Newton now fails the task with `WFG-AGENT-008` when provider quota or usage exhaustion is detected from structured SDK events (for example HTTP `429` with usage markers) or stderr text (for example `out of usage`). The task error summary keeps the existing schema and includes context like provider, quota category, and artifact links when available.
+For SDK-backed `AgentOperator` engines (`claude`, `agent`, `codex`, `gemini`, `opencode`), Newton fails the task with `WFG-AGENT-008` when quota exhaustion is detected. Newton is completely agnostic to provider-specific message formats — all quota detection logic lives in aikit-sdk.
+
+When aikit-sdk detects quota exhaustion, it sets `RunResult.quota_exceeded` and raises `RunError::QuotaExceeded`; Newton maps this directly to workflow error `WFG-AGENT-008`, enriched with artifact paths (events NDJSON and stderr). Consumers of Newton workflows should not attempt to parse provider-specific agent output for quota signals — rely on the `WFG-AGENT-008` error code and its `provider`, `quota_category`, and `raw_excerpt` context fields.
 
 ### Built-in Workflow Operators
 

--- a/crates/cli/tests/integration/test_workflow_scenarios.rs
+++ b/crates/cli/tests/integration/test_workflow_scenarios.rs
@@ -1706,9 +1706,11 @@ async fn test_scenario_45_nested_non_object_context_fails() {
 #[serial(path_env_agent)]
 async fn test_scenario_46_planner_short_circuit_on_enrich_failure() {
     let harness = WorkflowTestHarness::new(HashMap::new(), FakeInterviewer::new());
+    // Tests SDK-normalized quota detection: emit a structured error line that
+    // aikit-sdk's extract_agent_quota_signal recognizes (type=="error" with quota exceeded message).
     write_agent_stub(
         harness.temp_dir.path(),
-        "echo '{\"error\":{\"status\":429,\"message\":\"hourly quota exceeded\"}}'\nexit 0\n",
+        "echo '{\"type\":\"error\",\"message\":\"hourly quota exceeded\"}'\nexit 0\n",
     );
     let _path = PathGuard::prepend(harness.temp_dir.path());
 

--- a/crates/core/src/workflow/operators/agent.rs
+++ b/crates/core/src/workflow/operators/agent.rs
@@ -820,6 +820,28 @@ async fn execute_sdk_engine(
             }
         }
 
+        // Check RunResult.quota_exceeded: SDK detected quota exhaustion.
+        // This is the primary path for quota errors — the SDK owns all quota detection.
+        if let Some(ref info) = iter_run_result.quota_exceeded {
+            let category = format!("{:?}", info.category).to_lowercase();
+            let mut error = AppError::new(
+                ErrorCategory::ResourceError,
+                format!(
+                    "agent '{}' quota exceeded ({}): {}",
+                    info.agent_key, category, info.raw_message
+                ),
+            )
+            .with_code("WFG-AGENT-008");
+            error.add_context("provider", &info.agent_key);
+            error.add_context("quota_category", &category);
+            error.add_context("raw_excerpt", &info.raw_message);
+            error.add_context("events_artifact", &events_artifact_rel);
+            if stderr_path.exists() {
+                error.add_context("stderr_artifact", &stderr_rel);
+            }
+            return Err(error);
+        }
+
         // Update primary token usage from this iteration's RunResult (precedence over stream events).
         if let Some(ref usage) = iter_run_result.token_usage {
             primary_token_usage = serde_json::to_value(usage).ok();

--- a/crates/core/src/workflow/operators/agent.rs
+++ b/crates/core/src/workflow/operators/agent.rs
@@ -22,7 +22,6 @@ use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 
 const OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1_048_576;
-const QUOTA_EXCERPT_MAX_CHARS: usize = 240;
 
 pub struct AgentOperator {
     workspace_root: PathBuf,
@@ -602,252 +601,6 @@ struct SdkExecResult {
     token_usage: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum QuotaCategory {
-    Hourly,
-    Daily,
-    Weekly,
-    Tokens,
-    Requests,
-    Unknown,
-}
-
-impl QuotaCategory {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::Hourly => "hourly",
-            Self::Daily => "daily",
-            Self::Weekly => "weekly",
-            Self::Tokens => "tokens",
-            Self::Requests => "requests",
-            Self::Unknown => "unknown",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct QuotaSignal {
-    provider: String,
-    category: QuotaCategory,
-    raw_excerpt: String,
-    events_artifact: Option<String>,
-    stderr_artifact: Option<String>,
-}
-
-fn bounded_excerpt(text: &str) -> String {
-    text.chars().take(QUOTA_EXCERPT_MAX_CHARS).collect()
-}
-
-fn infer_quota_category(text: &str) -> QuotaCategory {
-    let lower = text.to_ascii_lowercase();
-    let ordered: &[(QuotaCategory, &[&str])] = &[
-        (QuotaCategory::Hourly, &["hourly", "per hour", "hour"]),
-        (QuotaCategory::Daily, &["daily", "per day", "day"]),
-        (QuotaCategory::Weekly, &["weekly", "per week", "week"]),
-        (
-            QuotaCategory::Tokens,
-            &["token", "tokens", "context length", "max tokens"],
-        ),
-        (
-            QuotaCategory::Requests,
-            &["request", "requests", "rate limit", "rpm", "rps"],
-        ),
-    ];
-    for (category, patterns) in ordered {
-        if patterns.iter().any(|p| lower.contains(p)) {
-            return category.clone();
-        }
-    }
-    QuotaCategory::Unknown
-}
-
-fn json_has_numeric_429(value: &serde_json::Value) -> bool {
-    match value {
-        Value::Number(n) => n.as_i64() == Some(429),
-        Value::Array(items) => items.iter().any(json_has_numeric_429),
-        Value::Object(map) => map.iter().any(|(_, v)| json_has_numeric_429(v)),
-        _ => false,
-    }
-}
-
-fn key_has_token(key: &str, candidates: &[&str]) -> bool {
-    let key_lower = key.to_ascii_lowercase();
-    candidates.iter().any(|token| key_lower.contains(token))
-}
-
-fn metric_name_from_used_key(key: &str) -> Option<String> {
-    let key_lower = key.to_ascii_lowercase();
-    for suffix in ["_used", "_consumed", "_current"] {
-        if let Some(stripped) = key_lower.strip_suffix(suffix) {
-            return Some(stripped.to_string());
-        }
-    }
-    None
-}
-
-fn metric_name_from_limit_key(key: &str) -> Option<String> {
-    let key_lower = key.to_ascii_lowercase();
-    for suffix in ["_limit", "_quota", "_max", "_allowed"] {
-        if let Some(stripped) = key_lower.strip_suffix(suffix) {
-            return Some(stripped.to_string());
-        }
-    }
-    None
-}
-
-fn extract_numeric(value: &Value) -> Option<f64> {
-    match value {
-        Value::Number(num) => num.as_f64(),
-        Value::String(text) => text.parse::<f64>().ok(),
-        _ => None,
-    }
-}
-
-fn object_has_used_limit_exhaustion(map: &Map<String, Value>) -> bool {
-    let mut used_values: HashMap<String, f64> = HashMap::new();
-    let mut limit_values: HashMap<String, f64> = HashMap::new();
-
-    for (key, value) in map {
-        if let Some(metric) = metric_name_from_used_key(key) {
-            if let Some(number) = extract_numeric(value) {
-                used_values.insert(metric, number);
-            }
-            continue;
-        }
-
-        if let Some(metric) = metric_name_from_limit_key(key) {
-            if let Some(number) = extract_numeric(value) {
-                limit_values.insert(metric, number);
-            }
-            continue;
-        }
-
-        if key_has_token(key, &["used", "consumed", "current"]) {
-            if let Some(number) = extract_numeric(value) {
-                used_values.insert(key.to_ascii_lowercase(), number);
-            }
-        }
-        if key_has_token(key, &["limit", "quota", "max", "allowed"]) {
-            if let Some(number) = extract_numeric(value) {
-                limit_values.insert(key.to_ascii_lowercase(), number);
-            }
-        }
-    }
-
-    used_values
-        .iter()
-        .any(|(metric, used)| limit_values.get(metric).is_some_and(|limit| used >= limit))
-}
-
-fn json_has_quota_exhaustion_evidence(value: &serde_json::Value) -> bool {
-    match value {
-        Value::String(s) => text_looks_like_quota(s),
-        Value::Array(items) => items.iter().any(json_has_quota_exhaustion_evidence),
-        Value::Object(map) => {
-            if object_has_used_limit_exhaustion(map) {
-                return true;
-            }
-            map.iter()
-                .any(|(_, v)| json_has_quota_exhaustion_evidence(v))
-        }
-        _ => false,
-    }
-}
-
-fn text_looks_like_quota(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    lower.contains("out of usage")
-        || lower.contains("usage exhausted")
-        || lower.contains("quota exceeded")
-        || lower.contains("rate limit")
-        || lower.contains("too many requests")
-        || lower.contains("resource exhausted")
-        || (lower.contains("429") && (lower.contains("usage") || lower.contains("quota")))
-}
-
-fn detect_quota_signal_from_events(
-    engine_name: &str,
-    events: &[aikit_sdk::AgentEvent],
-    events_artifact: Option<String>,
-    stderr_artifact: Option<String>,
-) -> Option<QuotaSignal> {
-    for event in events {
-        if let aikit_sdk::AgentEventPayload::JsonLine(payload) = &event.payload {
-            let payload_text = payload.to_string();
-            let has_structured_quota =
-                json_has_numeric_429(payload) || json_has_quota_exhaustion_evidence(payload);
-            let has_quota = has_structured_quota || text_looks_like_quota(&payload_text);
-            if has_quota {
-                return Some(QuotaSignal {
-                    provider: engine_name.to_string(),
-                    category: infer_quota_category(&payload_text),
-                    raw_excerpt: bounded_excerpt(&payload_text),
-                    events_artifact,
-                    stderr_artifact,
-                });
-            }
-        }
-
-        if let Some(text) = extract_text_from_sdk_event(event) {
-            if text_looks_like_quota(&text) {
-                return Some(QuotaSignal {
-                    provider: engine_name.to_string(),
-                    category: infer_quota_category(&text),
-                    raw_excerpt: bounded_excerpt(&text),
-                    events_artifact,
-                    stderr_artifact,
-                });
-            }
-        }
-    }
-    None
-}
-
-fn detect_quota_signal_from_stderr_artifact(
-    engine_name: &str,
-    stderr_path: &std::path::Path,
-    stderr_rel: &str,
-    events_artifact: Option<String>,
-) -> Option<QuotaSignal> {
-    let stderr = std::fs::read_to_string(stderr_path).ok()?;
-    let line = stderr
-        .lines()
-        .find(|l| text_looks_like_quota(l))
-        .map_or_else(|| stderr.clone(), std::string::ToString::to_string);
-    if !text_looks_like_quota(&line) {
-        return None;
-    }
-    Some(QuotaSignal {
-        provider: engine_name.to_string(),
-        category: infer_quota_category(&line),
-        raw_excerpt: bounded_excerpt(&line),
-        events_artifact,
-        stderr_artifact: Some(stderr_rel.to_string()),
-    })
-}
-
-fn quota_signal_to_error(signal: QuotaSignal) -> AppError {
-    let mut error = AppError::new(
-        ErrorCategory::ResourceError,
-        format!(
-            "agent provider quota exhausted for '{}' ({})",
-            signal.provider,
-            signal.category.as_str()
-        ),
-    )
-    .with_code("WFG-AGENT-008");
-    error.add_context("provider", &signal.provider);
-    error.add_context("quota_category", signal.category.as_str());
-    error.add_context("raw_excerpt", &signal.raw_excerpt);
-    if let Some(events_artifact) = signal.events_artifact {
-        error.add_context("events_artifact", &events_artifact);
-    }
-    if let Some(stderr_artifact) = signal.stderr_artifact {
-        error.add_context("stderr_artifact", &stderr_artifact);
-    }
-    error
-}
-
 /// Execute an AI engine via aikit-sdk, handling loop mode and signal matching.
 /// Writes a NDJSON events artifact using SDK AgentEvent JSON serialization.
 #[allow(clippy::too_many_arguments)]
@@ -924,18 +677,28 @@ async fn execute_sdk_engine(
 
         // Execute via SDK, passing remaining wall-clock time as the SDK timeout
         let remaining = timeout.saturating_sub(start.elapsed());
-        let (events, iter_run_result) = tokio::time::timeout(
+        let (events, iter_run_result) = match tokio::time::timeout(
             remaining,
             manager.execute_engine_events(engine_name, prompt, model, Some(remaining)),
         )
         .await
-        .map_err(|_| {
-            AppError::new(
-                ErrorCategory::TimeoutError,
-                "agent operator timeout exceeded during SDK execution",
-            )
-            .with_code("WFG-AGENT-005")
-        })??;
+        {
+            Err(_) => {
+                return Err(AppError::new(
+                    ErrorCategory::TimeoutError,
+                    "agent operator timeout exceeded during SDK execution",
+                )
+                .with_code("WFG-AGENT-005"));
+            }
+            Ok(Err(mut err)) if err.code == "WFG-AGENT-008" => {
+                err.add_context("events_artifact", &events_artifact_rel);
+                if stderr_path.exists() {
+                    err.add_context("stderr_artifact", &stderr_rel);
+                }
+                return Err(err);
+            }
+            Ok(result) => result?,
+        };
 
         // Write stdout events to artifact file
         let mut stdout_file = std::fs::OpenOptions::new()
@@ -980,13 +743,21 @@ async fn execute_sdk_engine(
                     fallback_token_usage = serde_json::to_value(usage).ok();
                     continue;
                 }
-                // RawBytes: MUST NOT participate in signal matching or stdout artifact
+                // RawBytes and all SDK-internal/telemetry variants must not participate in signal matching
                 aikit_sdk::AgentEventPayload::RawBytes(_) => {
+                    continue;
+                }
+                // QuotaExceeded is handled at the SDK RunError level; skip signal matching
+                aikit_sdk::AgentEventPayload::QuotaExceeded { .. } => {
                     continue;
                 }
                 // RawLine and JsonLine: write to stdout artifact and attempt signal matching
                 aikit_sdk::AgentEventPayload::RawLine(_)
                 | aikit_sdk::AgentEventPayload::JsonLine(_) => {}
+                // Forward-compat wildcard: all other SDK variants (StreamMessage, RawTransportLine, Aikit*) skip signal matching
+                _ => {
+                    continue;
+                }
             }
 
             if let Some(text) = extract_text_from_sdk_event(event) {
@@ -1043,32 +814,10 @@ async fn execute_sdk_engine(
                             stderr_bytes += text.len() + 1;
                         }
                     }
-                    aikit_sdk::AgentEventPayload::RawBytes(_)
-                    | aikit_sdk::AgentEventPayload::TokenUsageLine { .. } => {}
+                    // All other variants: skip stderr capture (telemetry, quota, transport, aikit built-in)
+                    _ => {}
                 }
             }
-        }
-
-        if let Some(signal) = detect_quota_signal_from_events(
-            engine_name,
-            &events,
-            Some(events_artifact_rel.clone()),
-            if stderr_path.exists() {
-                Some(stderr_rel.clone())
-            } else {
-                None
-            },
-        ) {
-            return Err(quota_signal_to_error(signal));
-        }
-
-        if let Some(signal) = detect_quota_signal_from_stderr_artifact(
-            engine_name,
-            stderr_path,
-            &stderr_rel,
-            Some(events_artifact_rel.clone()),
-        ) {
-            return Err(quota_signal_to_error(signal));
         }
 
         // Update primary token usage from this iteration's RunResult (precedence over stream events).
@@ -1433,7 +1182,6 @@ mod tests {
     use crate::workflow::schema::WorkflowSettings;
     use serde_json::json;
     use std::collections::HashMap;
-    use tempfile::NamedTempFile;
     use tempfile::TempDir;
 
     fn make_ctx(workspace: &TempDir) -> ExecutionContext {
@@ -1769,149 +1517,5 @@ fi"#,
         let result = op.execute(params, ctx).await.unwrap();
         // "aaa_complete" is alphabetically first and matches → it wins
         assert_eq!(result["signal"], json!("aaa_complete"));
-    }
-
-    #[test]
-    fn detects_quota_signal_from_structured_events() {
-        let events: Vec<aikit_sdk::AgentEvent> = vec![serde_json::from_value(json!({
-            "agent_key": "claude",
-            "seq": 1,
-            "stream": "stderr",
-            "payload": {
-                "json_line": {
-                    "error": {
-                        "status": 429,
-                        "message": "hourly quota exceeded for requests"
-                    }
-                }
-            }
-        }))
-        .expect("event JSON must deserialize")];
-
-        let signal = detect_quota_signal_from_events(
-            "claude",
-            &events,
-            Some("artifacts/events.ndjson".to_string()),
-            Some("artifacts/stderr.txt".to_string()),
-        )
-        .expect("quota signal expected");
-
-        assert_eq!(signal.provider, "claude");
-        assert_eq!(signal.category, QuotaCategory::Hourly);
-    }
-
-    #[test]
-    fn detects_quota_signal_from_structured_usage_without_429() {
-        let events: Vec<aikit_sdk::AgentEvent> = vec![serde_json::from_value(json!({
-            "agent_key": "claude",
-            "seq": 1,
-            "stream": "stderr",
-            "payload": {
-                "json_line": {
-                    "usage": {
-                        "requests_used": 1000,
-                        "requests_limit": 1000
-                    },
-                    "message": "usage limit reached for requests"
-                }
-            }
-        }))
-        .expect("event JSON must deserialize")];
-
-        let signal = detect_quota_signal_from_events(
-            "claude",
-            &events,
-            Some("artifacts/events.ndjson".to_string()),
-            Some("artifacts/stderr.txt".to_string()),
-        )
-        .expect("quota signal expected");
-
-        assert_eq!(signal.provider, "claude");
-        assert_eq!(signal.category, QuotaCategory::Requests);
-    }
-
-    #[test]
-    fn detects_quota_signal_from_structured_used_gte_limit_without_message() {
-        let events: Vec<aikit_sdk::AgentEvent> = vec![serde_json::from_value(json!({
-            "agent_key": "claude",
-            "seq": 1,
-            "stream": "stderr",
-            "payload": {
-                "json_line": {
-                    "usage": {
-                        "requests_used": 1000,
-                        "requests_limit": 1000
-                    }
-                }
-            }
-        }))
-        .expect("event JSON must deserialize")];
-
-        let signal = detect_quota_signal_from_events("claude", &events, None, None)
-            .expect("quota signal expected");
-        assert_eq!(signal.category, QuotaCategory::Requests);
-    }
-
-    #[test]
-    fn does_not_detect_quota_for_normal_usage_metadata() {
-        let events: Vec<aikit_sdk::AgentEvent> = vec![serde_json::from_value(json!({
-            "agent_key": "claude",
-            "seq": 1,
-            "stream": "stdout",
-            "payload": {
-                "json_line": {
-                    "usage": {
-                        "requests_used": 120,
-                        "requests_limit": 1000,
-                        "tokens_used": 2048,
-                        "tokens_limit": 200000
-                    },
-                    "message": "normal usage telemetry"
-                }
-            }
-        }))
-        .expect("event JSON must deserialize")];
-
-        let signal = detect_quota_signal_from_events("claude", &events, None, None);
-        assert!(signal.is_none(), "normal usage telemetry must not fail");
-    }
-
-    #[test]
-    fn detects_quota_signal_from_stderr_text() {
-        let stderr = NamedTempFile::new().expect("create temp stderr");
-        std::fs::write(
-            stderr.path(),
-            "provider says: out of usage for tokens this billing window",
-        )
-        .expect("write temp stderr");
-
-        let signal = detect_quota_signal_from_stderr_artifact(
-            "codex",
-            stderr.path(),
-            "stderr.txt",
-            Some("events.ndjson".to_string()),
-        )
-        .expect("quota signal expected");
-
-        assert_eq!(signal.provider, "codex");
-        assert_eq!(signal.category, QuotaCategory::Tokens);
-    }
-
-    #[test]
-    fn quota_signal_maps_to_agent_008() {
-        let err = quota_signal_to_error(QuotaSignal {
-            provider: "gemini".to_string(),
-            category: QuotaCategory::Requests,
-            raw_excerpt: "429 too many requests".to_string(),
-            events_artifact: Some("events.ndjson".to_string()),
-            stderr_artifact: Some("stderr.txt".to_string()),
-        });
-        assert_eq!(err.code, "WFG-AGENT-008");
-        assert_eq!(err.category, ErrorCategory::ResourceError);
-        assert_eq!(err.context.get("provider"), Some(&"gemini".to_string()));
-        assert_eq!(
-            err.context.get("quota_category"),
-            Some(&"requests".to_string())
-        );
     }
 }

--- a/crates/core/src/workflow/operators/engine/mod.rs
+++ b/crates/core/src/workflow/operators/engine/mod.rs
@@ -186,6 +186,21 @@ pub fn map_run_error(err: aikit_sdk::RunError) -> AppError {
             format!("aikit-sdk agent timed out after {timeout:?}"),
         )
         .with_code("WFG-SDK-001"),
+        aikit_sdk::RunError::QuotaExceeded(info) => {
+            let category = format!("{:?}", info.category).to_lowercase();
+            let mut error = AppError::new(
+                ErrorCategory::ResourceError,
+                format!(
+                    "agent '{}' quota exceeded ({}): {}",
+                    info.agent_key, category, info.raw_message
+                ),
+            )
+            .with_code("WFG-AGENT-008");
+            error.add_context("provider", &info.agent_key);
+            error.add_context("quota_category", &category);
+            error.add_context("raw_excerpt", &info.raw_message);
+            error
+        }
         _ => AppError::new(ErrorCategory::IoError, format!("aikit-sdk error: {err}"))
             .with_code("WFG-SDK-001"),
     }
@@ -196,15 +211,15 @@ pub fn map_run_error(err: aikit_sdk::RunError) -> AppError {
 /// Follows the deterministic rule order from spec section 4:
 /// 1. `RawLine` → use raw string as-is
 /// 2. `JsonLine` → ordered field extraction: `.content` → `.result.result` → `.result` → `.part.text`
-/// 3. `RawBytes` → None (MUST NOT participate in signal matching)
-/// 4. `TokenUsageLine` → None (MUST NOT participate in signal matching)
+/// 3. All other variants (RawBytes, TokenUsageLine, QuotaExceeded, StreamMessage,
+///    RawTransportLine, Aikit* built-ins) → None (MUST NOT participate in signal matching).
+///    The wildcard arm provides forward-compatibility with new SDK 0.2.x variants.
 pub fn extract_text_from_sdk_event(event: &aikit_sdk::AgentEvent) -> Option<String> {
     match &event.payload {
         aikit_sdk::AgentEventPayload::RawLine(s) => Some(s.clone()),
         aikit_sdk::AgentEventPayload::JsonLine(json) => extract_text_from_json(json),
-        // RawBytes and TokenUsageLine MUST NOT participate in signal matching
-        aikit_sdk::AgentEventPayload::RawBytes(_) => None,
-        aikit_sdk::AgentEventPayload::TokenUsageLine { .. } => None,
+        // All other variants (telemetry, quota, transport, aikit built-in) MUST NOT participate in signal matching
+        _ => None,
     }
 }
 

--- a/crates/core/tests/workflow_graph/test_agent_operator.rs
+++ b/crates/core/tests/workflow_graph/test_agent_operator.rs
@@ -467,10 +467,12 @@ fn read_enrich_error_code(workspace: &TempDir) -> String {
 #[serial(path_env_agent)]
 async fn sdk_quota_structured_event_returns_agent_008() {
     let workspace = TempDir::new().expect("create temp workspace");
+    // Tests SDK-normalized quota detection: agent emits a structured error line that
+    // aikit-sdk's extract_agent_quota_signal recognizes (type=="error" with usage limit message).
     write_agent_stub(
         &workspace,
         &[
-            "echo '{\"usage\":{\"requests_used\":1000,\"requests_limit\":1000},\"message\":\"usage limit reached for requests\"}'",
+            r#"echo '{"type":"error","message":"usage limit exceeded for requests"}'"#,
             "exit 0",
             "",
         ]
@@ -508,9 +510,11 @@ workflow:
 #[serial(path_env_agent)]
 async fn sdk_quota_stderr_event_returns_agent_008() {
     let workspace = TempDir::new().expect("create temp workspace");
+    // Tests SDK-normalized quota detection via stderr: agent emits a line that
+    // aikit-sdk's extract_agent_quota_signal recognizes via the "usage limit for" pattern.
     write_agent_stub(
         &workspace,
-        "echo 'provider says out of usage for tokens' >&2\nexit 0\n",
+        "printf 'usage limit for tokens reached\\n' >&2\nexit 0\n",
     );
     let _path = PathGuard::prepend(workspace.path());
 


### PR DESCRIPTION
## Summary
- Removes all Newton-local quota detection: `QuotaCategory`, `QuotaSignal`, `text_looks_like_quota`, `detect_quota_signal_from_events`, `detect_quota_signal_from_stderr_artifact`, and related helpers
- Maps `RunError::QuotaExceeded` from aikit-sdk directly to `WFG-AGENT-008` in `engine/mod.rs::map_run_error`, enriched with artifact paths
- Checks `RunResult.quota_exceeded` after each SDK execution iteration as the primary quota detection path
- Fixes three non-exhaustive `AgentEventPayload` match sites (extract_text_from_sdk_event, main event loop, stderr loop) for SDK 0.2.x compat
- Upgrades `reqwest` 0.11→0.12 and `toml` 0.8→1.1 to align with aikit-sdk 0.2.1
- Updates integration tests to use SDK-detectable quota patterns

Depends on: goaikit/aikit#10

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test -p newton-core --test test_agent_operator sdk_quota` passes
- [ ] `WFG-AGENT-008` still raised on quota events end-to-end (scenario 46 passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)