### PR TITLE
chore(deps): update aikit lock revision in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "aikit-agent"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit.git?branch=main#071aae29689e871e32403fd6a569cb12a02574d2"
+source = "git+https://github.com/goaikit/aikit.git?branch=main#0b0293c39337aa71d027453079ab000493436788"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 name = "aikit-sdk"
 version = "0.2.1"
-source = "git+https://github.com/goaikit/aikit.git?branch=main#071aae29689e871e32403fd6a569cb12a02574d2"
+source = "git+https://github.com/goaikit/aikit.git?branch=main#0b0293c39337aa71d027453079ab000493436788"
 dependencies = [
  "aikit-agent",
  "glob",
@@ -890,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1481,7 +1481,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2092,7 +2092,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2545,7 +2545,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2582,9 +2582,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2917,7 +2917,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3656,7 +3656,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4667,7 +4667,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update `Cargo.lock` to resolve `aikit-sdk` and `aikit-agent` from `goaikit/aikit` at commit `0b0293c`
- consume the merged aikit fix that routes large prompts via stdin (avoids E2BIG spawn failures)
- keep change scoped to dependency lock state only

## Test plan
- [x] `cargo test -p newton-core --lib`
- [x] repository pre-commit and pre-push hooks passed during commit/push

Closes #267.