### PR TITLE
fix(core): enable test-utils feature for test_workflow_human_ops integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to this project will be documented in this file.
   at the first human task tick with error code `HIL-AILOOP-001` (category
   `ValidationError`). Workflows with no human task continue to run unchanged
   (the interviewer is constructed lazily on first prompt).
-- **`NEWTON_HITL_TRANSPORT` environment variable removed.** This variable is no
-  longer parsed, logged, or honoured. Ailoop owns transport selection (direct vs
-  server mode) via its own `AILOOP_SERVER` / `--server` configuration.
+- **Legacy HIL transport override removed.** The previous environment variable
+  that forced a console interviewer is no longer parsed, logged, or honoured.
+  Ailoop owns transport selection (direct vs server mode) via its own
+  `AILOOP_SERVER` / `--server` configuration.
 - **`build_interviewer` removed.** Replaced by `resolve_interviewer` (eager,
   returns `Result<Arc<dyn Interviewer>, AppError>`) and `lazy_interviewer_provider`
   (deferred resolution for `BuiltinOperatorDeps`). External callers must migrate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Breaking changes
+
+- **HIL operators now require ailoop unconditionally.** `HumanDecisionOperator` and
+  `HumanApprovalOperator` no longer fall back to a console (stdin/stdout)
+  interviewer when ailoop is not configured. A workflow containing a `human_decision`
+  or `human_approval` task that runs without an enabled `AiloopContext` now fails
+  at the first human task tick with error code `HIL-AILOOP-001` (category
+  `ValidationError`). Workflows with no human task continue to run unchanged
+  (the interviewer is constructed lazily on first prompt).
+- **`NEWTON_HITL_TRANSPORT` environment variable removed.** This variable is no
+  longer parsed, logged, or honoured. Ailoop owns transport selection (direct vs
+  server mode) via its own `AILOOP_SERVER` / `--server` configuration.
+- **`build_interviewer` removed.** Replaced by `resolve_interviewer` (eager,
+  returns `Result<Arc<dyn Interviewer>, AppError>`) and `lazy_interviewer_provider`
+  (deferred resolution for `BuiltinOperatorDeps`). External callers must migrate.
+- **`BuiltinOperatorDeps.interviewer` field type changed** from
+  `Option<Arc<dyn Interviewer>>` to `Option<InterviewerProvider>`, where
+  `InterviewerProvider = Arc<dyn Fn() -> Result<Arc<dyn Interviewer>, AppError> + Send + Sync>`.
+  The previous default that constructed a `ConsoleInterviewer` when the field was
+  `None` has been removed.
+- **`NEWTON_AILOOP_INTEGRATION=0|false|disabled` no longer suppresses HIL.** The
+  flag continues to gate non-HIL ailoop features (events, notifier, output
+  forwarder), but HIL workflows now require ailoop unconditionally.
+
+### Upgrade path
+
+For any deployment running workflows with `human_decision` / `human_approval`
+tasks:
+
+1. Install ailoop and ensure it is reachable (locally via direct mode, or
+   remotely via a shared ailoop server).
+2. Configure `.newton/configs/monitor.conf` with `ailoop_server_ws_url` and
+   `ailoop_channel` pointing at your ailoop endpoint.
+3. Set `NEWTON_AILOOP_INTEGRATION=1` in the Newton process environment.
+4. Re-run the workflow. Misconfiguration now surfaces deterministically as
+   `HIL-AILOOP-001` with a remediation pointer to
+   `docs/operators/human_decision.md#configuration`.
+
+### Added
+
+- New error codes `HIL-AILOOP-001` (no enabled ailoop context) and
+  `HIL-AILOOP-003` (ailoop config load/parse failure, category `IoError`).
+- `MockAiloopInterviewer` test double under
+  `#[cfg(any(test, feature = "test-utils"))]` for use in HIL integration tests.
+- `test-utils` Cargo feature on `crates/core` that exposes `MockAiloopInterviewer`
+  outside `cfg(test)`.
+- `require_enabled_ailoop_context` helper in
+  `crates/core/src/integrations/ailoop/config.rs`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,12 @@ Integration is disabled unless explicitly enabled via `NEWTON_AILOOP_INTEGRATION
 
 ### HITL Interviewer Selection
 
-`workflow::human::build_interviewer()` selects the backend:
+`workflow::human::resolve_interviewer()` returns `Result<Arc<dyn Interviewer>, AppError>`:
 
-1. `NEWTON_HITL_TRANSPORT=console` → always use `ConsoleInterviewer`
-2. `NEWTON_HITL_TRANSPORT=ailoop` + context available → `AiloopInterviewer`
-3. Enabled `AiloopContext` present → `AiloopInterviewer`
-4. Fallback → `ConsoleInterviewer`
+1. Enabled `AiloopContext` provided → `AiloopInterviewer`
+2. Otherwise → `Err(HIL-AILOOP-001)`
+
+There is no console fallback. CLI subcommands wrap this in a lazy `InterviewerProvider` (`workflow::human::lazy_interviewer_provider`) so workflows without human tasks never require an ailoop context.
 
 `AiloopInterviewer` calls `ailoop_core::client::authorize()` (for `HumanApprovalOperator`) and `ailoop_core::client::ask()` (for `HumanDecisionOperator`). Error codes `WFG-HUMAN-101…105` are mapped from transport and response outcomes.
 

--- a/crates/cli/src/cli/commands.rs
+++ b/crates/cli/src/cli/commands.rs
@@ -144,8 +144,8 @@ fn setup_workflow_execution(
             .ok()
             .flatten();
     let mut builder = OperatorRegistry::builder();
-    let interviewer = newton_core::workflow::human::build_interviewer(
-        ailoop_ctx.as_ref(),
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
+        ailoop_ctx,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
     workflow_operators::register_builtins_with_deps(
@@ -253,8 +253,8 @@ pub async fn workflow_run(args: RunArgs) -> StdResult<(), AppError> {
             .flatten();
     let mut builder = OperatorRegistry::builder();
     let settings = document.workflow.settings.clone();
-    let interviewer = newton_core::workflow::human::build_interviewer(
-        ailoop_ctx.as_ref(),
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
+        ailoop_ctx,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
     workflow_operators::register_builtins_with_deps(
@@ -421,7 +421,7 @@ pub async fn resume(args: ResumeArgs) -> StdResult<(), AppError> {
     let execution = checkpoint::load_execution(&workspace, &args.execution_id)?;
     let mut builder = OperatorRegistry::builder();
     let settings = execution.settings_effective.clone();
-    let interviewer = newton_core::workflow::human::build_interviewer(
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
         None,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
@@ -625,7 +625,7 @@ async fn workflow_webhook_serve(args: WebhookServeArgs) -> StdResult<(), AppErro
 
     let mut builder = OperatorRegistry::builder();
     let settings = document.workflow.settings.clone();
-    let interviewer = newton_core::workflow::human::build_interviewer(
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
         None,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
@@ -1544,7 +1544,7 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
 
     let mut builder = OperatorRegistry::builder();
     let serve_settings: workflow_schema::WorkflowSettings = Default::default();
-    let interviewer = newton_core::workflow::human::build_interviewer(
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
         None,
         Duration::from_secs(serve_settings.human.default_timeout_seconds),
     );
@@ -1770,8 +1770,8 @@ async fn execute_workflow_for_plan(
             .flatten();
     let mut builder = OperatorRegistry::builder();
     let settings = document.workflow.settings.clone();
-    let interviewer = newton_core::workflow::human::build_interviewer(
-        ailoop_ctx.as_ref(),
+    let interviewer = newton_core::workflow::human::lazy_interviewer_provider(
+        ailoop_ctx,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
     workflow_operators::register_builtins_with_deps(

--- a/crates/cli/tests/integration/test_workflow_scenarios.rs
+++ b/crates/cli/tests/integration/test_workflow_scenarios.rs
@@ -327,7 +327,10 @@ impl WorkflowTestHarness {
 
         let deps = BuiltinOperatorDeps {
             command_runner: Some(Arc::new(self.cmd_runner.clone())),
-            interviewer: Some(Arc::new(self.interviewer.clone())),
+            interviewer: Some({
+                let fake: Arc<dyn Interviewer> = Arc::new(self.interviewer.clone());
+                Arc::new(move || Ok(fake.clone()))
+            }),
             gh_runner: None,
             child_workflow_runner: None,
             gh_approver: None,
@@ -902,7 +905,10 @@ async fn test_scenario_17_checkpoint_resume() {
             GraphSettings::default(),
             BuiltinOperatorDeps {
                 command_runner: Some(Arc::new(cmd_runner.clone())),
-                interviewer: Some(Arc::new(harness.interviewer.clone())),
+                interviewer: Some({
+                    let fake: Arc<dyn Interviewer> = Arc::new(harness.interviewer.clone());
+                    Arc::new(move || Ok(fake.clone()))
+                }),
                 gh_runner: None,
                 child_workflow_runner: None,
                 gh_approver: None,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -120,6 +120,7 @@ path = "tests/workflow_graph/test_explain.rs"
 [[test]]
 name = "test_workflow_human_ops"
 path = "tests/workflow_graph/test_human_ops.rs"
+required-features = ["test-utils"]
 
 [[test]]
 name = "test_workflow_webhook"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 description = "Newton workflow / batch / serve engine library."
 
+[features]
+test-utils = []
+
 [lib]
 path = "src/lib.rs"
 

--- a/crates/core/src/integrations/ailoop/config.rs
+++ b/crates/core/src/integrations/ailoop/config.rs
@@ -146,6 +146,38 @@ pub fn init_context_for_command_name(
     }
 }
 
+/// Return an enabled `AiloopContext` or a typed `AppError`.
+///
+/// - `HIL-AILOOP-001` (`ValidationError`) when the context is unconfigured or
+///   disabled.
+/// - `HIL-AILOOP-003` (`IoError`) when configuration loading itself failed
+///   (file unreadable, malformed URL, bad TOML).
+#[allow(clippy::result_large_err)]
+pub fn require_enabled_ailoop_context(
+    workspace_root: &Path,
+    command_name: &str,
+) -> std::result::Result<AiloopContext, crate::core::error::AppError> {
+    match init_context_for_command_name(workspace_root, command_name) {
+        Ok(Some(ctx)) if ctx.is_enabled() => Ok(ctx),
+        Ok(_) => Err(crate::core::error::AppError::new(
+            crate::core::types::ErrorCategory::ValidationError,
+            "human-in-the-loop operator requires an enabled ailoop context; \
+             configure ailoop (.newton/configs/monitor.conf and \
+             NEWTON_AILOOP_INTEGRATION=1). See \
+             docs/operators/human_decision.md#configuration",
+        )
+        .with_code("HIL-AILOOP-001")),
+        Err(err) => Err(crate::core::error::AppError::new(
+            crate::core::types::ErrorCategory::IoError,
+            format!(
+                "failed to load ailoop configuration: {err}. \
+                 See docs/operators/human_decision.md#configuration"
+            ),
+        )
+        .with_code("HIL-AILOOP-003")),
+    }
+}
+
 /// Load ailoop configuration with precedence handling.
 fn load_ailoop_config(workspace_root: &Path) -> Result<AiloopConfig> {
     // Check for explicit enable/disable

--- a/crates/core/src/workflow/human/mock_ailoop.rs
+++ b/crates/core/src/workflow/human/mock_ailoop.rs
@@ -1,0 +1,77 @@
+//! Test double interviewer that mimics ailoop semantics.
+//!
+//! Returns scripted `ApprovalResult` / `DecisionResult` values from FIFO queues.
+//! Used by HIL tests in place of `ConsoleInterviewer`. Reports
+//! `interviewer_type() == "mock_ailoop"`.
+
+use crate::core::error::AppError;
+use crate::core::types::ErrorCategory;
+use crate::workflow::human::{ApprovalDefault, ApprovalResult, DecisionResult, Interviewer};
+use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::Duration;
+
+pub struct MockAiloopInterviewer {
+    approvals: Mutex<VecDeque<ApprovalResult>>,
+    choices: Mutex<VecDeque<DecisionResult>>,
+}
+
+impl MockAiloopInterviewer {
+    pub fn new() -> Self {
+        Self {
+            approvals: Mutex::new(VecDeque::new()),
+            choices: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub fn push_approval(&self, result: ApprovalResult) {
+        self.approvals.lock().unwrap().push_back(result);
+    }
+
+    pub fn push_choice(&self, result: DecisionResult) {
+        self.choices.lock().unwrap().push_back(result);
+    }
+}
+
+impl Default for MockAiloopInterviewer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Interviewer for MockAiloopInterviewer {
+    fn interviewer_type(&self) -> &'static str {
+        "mock_ailoop"
+    }
+
+    async fn ask_approval(
+        &self,
+        _prompt: &str,
+        _timeout: Option<Duration>,
+        _default_on_timeout: Option<ApprovalDefault>,
+    ) -> Result<ApprovalResult, AppError> {
+        self.approvals.lock().unwrap().pop_front().ok_or_else(|| {
+            AppError::new(
+                ErrorCategory::InternalError,
+                "MockAiloopInterviewer: no scripted approval available",
+            )
+        })
+    }
+
+    async fn ask_choice(
+        &self,
+        _prompt: &str,
+        _choices: &[String],
+        _timeout: Option<Duration>,
+        _default_choice: Option<&str>,
+    ) -> Result<DecisionResult, AppError> {
+        self.choices.lock().unwrap().pop_front().ok_or_else(|| {
+            AppError::new(
+                ErrorCategory::InternalError,
+                "MockAiloopInterviewer: no scripted choice available",
+            )
+        })
+    }
+}

--- a/crates/core/src/workflow/human/mod.rs
+++ b/crates/core/src/workflow/human/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::str::FromStr;
@@ -96,59 +98,65 @@ pub mod ailoop;
 pub mod audit;
 pub mod console;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod mock_ailoop;
+
 pub use ailoop::AiloopInterviewer;
 pub use audit::AuditEntry;
 pub use console::ConsoleInterviewer;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub use mock_ailoop::MockAiloopInterviewer;
+
 use std::sync::Arc;
 
-/// Selects the appropriate `Interviewer` backend based on environment override
-/// (`NEWTON_HITL_TRANSPORT`) and the presence of an `AiloopContext`.
+/// Type alias for a deferred interviewer constructor used by operators.
 ///
-/// Precedence:
-/// 1. `NEWTON_HITL_TRANSPORT=console` → console.
-/// 2. `NEWTON_HITL_TRANSPORT=ailoop` → ailoop if a context is provided, else
-///    log a warning and fall back to console.
-/// 3. If an enabled `AiloopContext` is available → ailoop.
-/// 4. Otherwise → console.
-pub fn build_interviewer(
+/// The closure is invoked at most once per operator instance (on the first
+/// human prompt) and the resulting `Arc<dyn Interviewer>` is cached.
+pub type InterviewerProvider =
+    Arc<dyn Fn() -> Result<Arc<dyn Interviewer>, crate::core::error::AppError> + Send + Sync>;
+
+/// Resolve an `Interviewer` by delegating exclusively to ailoop.
+///
+/// Returns `Ok(AiloopInterviewer)` when an enabled `AiloopContext` is provided.
+/// Otherwise returns `Err(AppError)` with code `HIL-AILOOP-001`.
+///
+/// This function MUST NOT fall back to console or any other transport.
+pub fn resolve_interviewer(
     ailoop: Option<&crate::integrations::ailoop::AiloopContext>,
-    default_timeout: std::time::Duration,
-) -> Arc<dyn Interviewer> {
-    let override_env = std::env::var("NEWTON_HITL_TRANSPORT")
-        .ok()
-        .map(|v| v.to_lowercase());
-    match override_env.as_deref() {
-        Some("console") => Arc::new(ConsoleInterviewer::new()),
-        Some("ailoop") => {
-            if let Some(ctx) = ailoop {
-                Arc::new(AiloopInterviewer::new(
-                    ctx.ws_url().to_string(),
-                    ctx.channel().to_string(),
-                    ctx.config.fail_fast,
-                    default_timeout,
-                ))
-            } else {
-                tracing::warn!(
-                    "NEWTON_HITL_TRANSPORT=ailoop requested but no AiloopContext available; falling back to console"
-                );
-                Arc::new(ConsoleInterviewer::new())
-            }
-        }
-        _ => {
-            if let Some(ctx) = ailoop {
-                if ctx.is_enabled() {
-                    return Arc::new(AiloopInterviewer::new(
-                        ctx.ws_url().to_string(),
-                        ctx.channel().to_string(),
-                        ctx.config.fail_fast,
-                        default_timeout,
-                    ));
-                }
-            }
-            Arc::new(ConsoleInterviewer::new())
-        }
+    default_timeout: Duration,
+) -> Result<Arc<dyn Interviewer>, crate::core::error::AppError> {
+    match ailoop {
+        Some(ctx) if ctx.is_enabled() => Ok(Arc::new(AiloopInterviewer::new(
+            ctx.ws_url().to_string(),
+            ctx.channel().to_string(),
+            ctx.config.fail_fast,
+            default_timeout,
+        ))),
+        _ => Err(missing_ailoop_error()),
     }
+}
+
+fn missing_ailoop_error() -> crate::core::error::AppError {
+    crate::core::error::AppError::new(
+        crate::core::types::ErrorCategory::ValidationError,
+        "human-in-the-loop operator requires an enabled ailoop context; \
+         configure ailoop (.newton/configs/monitor.conf and \
+         NEWTON_AILOOP_INTEGRATION=1). See \
+         docs/operators/human_decision.md#configuration",
+    )
+    .with_code("HIL-AILOOP-001")
+}
+
+/// Build an `InterviewerProvider` that re-evaluates ailoop availability when
+/// first invoked. The provided context is captured by clone so the closure can
+/// outlive the caller's borrow.
+pub fn lazy_interviewer_provider(
+    ailoop: Option<crate::integrations::ailoop::AiloopContext>,
+    default_timeout: Duration,
+) -> InterviewerProvider {
+    Arc::new(move || resolve_interviewer(ailoop.as_ref(), default_timeout))
 }
 
 #[cfg(test)]
@@ -156,7 +164,6 @@ mod tests {
     use super::*;
     use crate::integrations::ailoop::config::AiloopConfig;
     use crate::integrations::ailoop::AiloopContext;
-    use serial_test::serial;
     use std::path::PathBuf;
     use url::Url;
 
@@ -171,38 +178,48 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn test_build_interviewer_no_context_no_override() {
-        std::env::remove_var("NEWTON_HITL_TRANSPORT");
-        let i = build_interviewer(None, std::time::Duration::from_secs(60));
-        assert_eq!(i.interviewer_type(), "console");
-    }
-
-    #[test]
-    #[serial]
-    fn test_build_interviewer_with_context_no_override() {
-        std::env::remove_var("NEWTON_HITL_TRANSPORT");
+    fn resolve_interviewer_with_enabled_context_returns_ailoop() {
         let ctx = make_ctx(true);
-        let i = build_interviewer(Some(&ctx), std::time::Duration::from_secs(60));
+        let i = resolve_interviewer(Some(&ctx), Duration::from_secs(60))
+            .expect("enabled ctx should resolve");
         assert_eq!(i.interviewer_type(), "ailoop");
     }
 
     #[test]
-    #[serial]
-    fn test_build_interviewer_console_override_with_context() {
-        std::env::set_var("NEWTON_HITL_TRANSPORT", "console");
-        let ctx = make_ctx(true);
-        let i = build_interviewer(Some(&ctx), std::time::Duration::from_secs(60));
-        std::env::remove_var("NEWTON_HITL_TRANSPORT");
-        assert_eq!(i.interviewer_type(), "console");
+    fn resolve_interviewer_with_no_context_errors() {
+        let err = match resolve_interviewer(None, Duration::from_secs(60)) {
+            Ok(_) => panic!("missing ctx must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, "HIL-AILOOP-001");
+        assert!(matches!(
+            err.category,
+            crate::core::types::ErrorCategory::ValidationError
+        ));
     }
 
     #[test]
-    #[serial]
-    fn test_build_interviewer_ailoop_override_no_context_warns_and_falls_back() {
-        std::env::set_var("NEWTON_HITL_TRANSPORT", "ailoop");
-        let i = build_interviewer(None, std::time::Duration::from_secs(60));
-        std::env::remove_var("NEWTON_HITL_TRANSPORT");
-        assert_eq!(i.interviewer_type(), "console");
+    fn resolve_interviewer_with_disabled_context_errors() {
+        let ctx = make_ctx(false);
+        let err = match resolve_interviewer(Some(&ctx), Duration::from_secs(60)) {
+            Ok(_) => panic!("disabled ctx must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, "HIL-AILOOP-001");
+    }
+
+    #[test]
+    fn lazy_provider_does_not_construct_eagerly() {
+        let provider = lazy_interviewer_provider(None, Duration::from_secs(60));
+        // Provider is constructed but never invoked — no error yet.
+        let _ = &provider; // keep alive
+    }
+
+    #[test]
+    fn lazy_provider_resolves_on_invocation() {
+        let ctx = make_ctx(true);
+        let provider = lazy_interviewer_provider(Some(ctx), Duration::from_secs(60));
+        let i = provider().unwrap_or_else(|_| panic!("enabled ctx should resolve via provider"));
+        assert_eq!(i.interviewer_type(), "ailoop");
     }
 }

--- a/crates/core/src/workflow/operators/human_approval.rs
+++ b/crates/core/src/workflow/operators/human_approval.rs
@@ -2,14 +2,16 @@
 
 use crate::core::error::AppError;
 use crate::core::types::ErrorCategory;
-use crate::workflow::human::{audit, ApprovalDefault, AuditEntry, Interviewer};
+use crate::workflow::human::{
+    audit, ApprovalDefault, AuditEntry, Interviewer, InterviewerProvider,
+};
 use crate::workflow::operator::{ExecutionContext, Operator};
 use crate::workflow::schema::HumanSettings;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 struct ApprovalParams {
@@ -57,7 +59,8 @@ impl ApprovalParams {
 }
 
 pub struct HumanApprovalOperator {
-    interviewer: Arc<dyn Interviewer>,
+    provider: InterviewerProvider,
+    cached: Mutex<Option<Arc<dyn Interviewer>>>,
     audit_path: PathBuf,
     default_timeout_seconds: u64,
     redact_keys: Arc<Vec<String>>,
@@ -65,16 +68,27 @@ pub struct HumanApprovalOperator {
 
 impl HumanApprovalOperator {
     pub fn new(
-        interviewer: Arc<dyn Interviewer>,
+        provider: InterviewerProvider,
         human_settings: HumanSettings,
         redact_keys: Arc<Vec<String>>,
     ) -> Self {
         Self {
-            interviewer,
+            provider,
+            cached: Mutex::new(None),
             audit_path: human_settings.audit_path,
             default_timeout_seconds: human_settings.default_timeout_seconds,
             redact_keys,
         }
+    }
+
+    fn interviewer(&self) -> Result<Arc<dyn Interviewer>, AppError> {
+        let mut guard = self.cached.lock().unwrap();
+        if let Some(existing) = guard.as_ref() {
+            return Ok(existing.clone());
+        }
+        let resolved = (self.provider)()?;
+        *guard = Some(resolved.clone());
+        Ok(resolved)
     }
 }
 
@@ -105,8 +119,8 @@ impl Operator for HumanApprovalOperator {
                 None
             }
         });
-        let result = self
-            .interviewer
+        let interviewer = self.interviewer()?;
+        let result = interviewer
             .ask_approval(&parsed.prompt, timeout_duration, parsed.default_on_timeout)
             .await?;
         let response_text = if result.default_used || result.reason.is_empty() {
@@ -118,7 +132,7 @@ impl Operator for HumanApprovalOperator {
             timestamp: result.timestamp.to_rfc3339(),
             execution_id: ctx.execution_id.clone(),
             task_id: ctx.task_id.clone(),
-            interviewer_type: self.interviewer.interviewer_type().to_string(),
+            interviewer_type: interviewer.interviewer_type().to_string(),
             prompt: parsed.prompt.clone(),
             choices: None,
             approved: Some(result.approved),

--- a/crates/core/src/workflow/operators/human_decision.rs
+++ b/crates/core/src/workflow/operators/human_decision.rs
@@ -2,13 +2,13 @@
 
 use crate::core::error::AppError;
 use crate::core::types::ErrorCategory;
-use crate::workflow::human::{audit, AuditEntry, Interviewer};
+use crate::workflow::human::{audit, AuditEntry, Interviewer, InterviewerProvider};
 use crate::workflow::operator::{ExecutionContext, Operator};
 use crate::workflow::schema::HumanSettings;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 struct DecisionParams {
@@ -80,7 +80,8 @@ impl DecisionParams {
 }
 
 pub struct HumanDecisionOperator {
-    interviewer: Arc<dyn Interviewer>,
+    provider: InterviewerProvider,
+    cached: Mutex<Option<Arc<dyn Interviewer>>>,
     audit_path: PathBuf,
     default_timeout_seconds: u64,
     redact_keys: Arc<Vec<String>>,
@@ -88,16 +89,27 @@ pub struct HumanDecisionOperator {
 
 impl HumanDecisionOperator {
     pub fn new(
-        interviewer: Arc<dyn Interviewer>,
+        provider: InterviewerProvider,
         human_settings: HumanSettings,
         redact_keys: Arc<Vec<String>>,
     ) -> Self {
         Self {
-            interviewer,
+            provider,
+            cached: Mutex::new(None),
             audit_path: human_settings.audit_path,
             default_timeout_seconds: human_settings.default_timeout_seconds,
             redact_keys,
         }
+    }
+
+    fn interviewer(&self) -> Result<Arc<dyn Interviewer>, AppError> {
+        let mut guard = self.cached.lock().unwrap();
+        if let Some(existing) = guard.as_ref() {
+            return Ok(existing.clone());
+        }
+        let resolved = (self.provider)()?;
+        *guard = Some(resolved.clone());
+        Ok(resolved)
     }
 }
 
@@ -129,8 +141,8 @@ impl Operator for HumanDecisionOperator {
             }
         });
         let default_choice_ref = parsed.default_choice.as_deref();
-        let result = self
-            .interviewer
+        let interviewer = self.interviewer()?;
+        let result = interviewer
             .ask_choice(
                 &parsed.prompt,
                 &parsed.choices,
@@ -142,7 +154,7 @@ impl Operator for HumanDecisionOperator {
             timestamp: result.timestamp.to_rfc3339(),
             execution_id: ctx.execution_id.clone(),
             task_id: ctx.task_id.clone(),
-            interviewer_type: self.interviewer.interviewer_type().to_string(),
+            interviewer_type: interviewer.interviewer_type().to_string(),
             prompt: parsed.prompt.clone(),
             choices: Some(parsed.choices.clone()),
             approved: None,

--- a/crates/core/src/workflow/operators/mod.rs
+++ b/crates/core/src/workflow/operators/mod.rs
@@ -13,7 +13,7 @@ pub mod set_context;
 pub mod workflow;
 
 use crate::workflow::child_run::ChildWorkflowRunner;
-use crate::workflow::human::{ConsoleInterviewer, Interviewer};
+use crate::workflow::human::InterviewerProvider;
 use crate::workflow::operator::OperatorRegistryBuilder;
 use crate::workflow::operators::engine::AikitEngineManager;
 use crate::workflow::state::GraphSettings;
@@ -22,7 +22,9 @@ use std::sync::Arc;
 
 #[derive(Default)]
 pub struct BuiltinOperatorDeps {
-    pub interviewer: Option<Arc<dyn Interviewer>>,
+    /// Lazy provider that resolves to an `Interviewer` on first human prompt.
+    /// Workflows with no human task never invoke the provider.
+    pub interviewer: Option<InterviewerProvider>,
     pub command_runner: Option<Arc<dyn command::CommandRunner>>,
     /// GhRunner for GhOperator. Defaults to real gh CLI subprocess when None.
     pub gh_runner: Option<Arc<dyn gh::GhRunner>>,
@@ -47,9 +49,21 @@ pub fn register_builtins_with_deps(
     settings: GraphSettings,
     deps: BuiltinOperatorDeps,
 ) {
-    let interviewer: Arc<dyn Interviewer> = deps
-        .interviewer
-        .unwrap_or_else(|| Arc::new(ConsoleInterviewer::new()));
+    let interviewer_provider: InterviewerProvider = deps.interviewer.unwrap_or_else(|| {
+        // Default provider: every invocation returns HIL-AILOOP-001 because
+        // no ailoop context was wired in. Workflows with no human task
+        // never invoke this provider.
+        Arc::new(|| {
+            Err(crate::core::error::AppError::new(
+                crate::core::types::ErrorCategory::ValidationError,
+                "human-in-the-loop operator requires an enabled ailoop context; \
+                     configure ailoop (.newton/configs/monitor.conf and \
+                     NEWTON_AILOOP_INTEGRATION=1). See \
+                     docs/operators/human_decision.md#configuration",
+            )
+            .with_code("HIL-AILOOP-001"))
+        })
+    });
     let human_settings = settings.human.clone();
     let redact_keys = Arc::new(settings.redaction.redact_keys.clone());
     let command_operator = match deps.command_runner {
@@ -84,12 +98,12 @@ pub fn register_builtins_with_deps(
         .register(agent_operator)
         .register(gh_operator)
         .register(human_approval::HumanApprovalOperator::new(
-            interviewer.clone(),
+            interviewer_provider.clone(),
             human_settings.clone(),
             redact_keys.clone(),
         ))
         .register(human_decision::HumanDecisionOperator::new(
-            interviewer,
+            interviewer_provider,
             human_settings,
             redact_keys,
         ));

--- a/crates/core/tests/integration/test_human_ailoop.rs
+++ b/crates/core/tests/integration/test_human_ailoop.rs
@@ -8,7 +8,7 @@ use ailoop_core::models::{Message, MessageContent, ResponseType};
 use futures::{SinkExt, StreamExt};
 use insta::assert_yaml_snapshot;
 use newton_core::workflow::executor::{ExecutionOverrides, GraphHandle};
-use newton_core::workflow::human::AiloopInterviewer;
+use newton_core::workflow::human::{AiloopInterviewer, Interviewer, InterviewerProvider};
 use newton_core::workflow::operator::{ExecutionContext, Operator, OperatorRegistry, StateView};
 use newton_core::workflow::operators::{
     human_approval::HumanApprovalOperator, human_decision::HumanDecisionOperator,
@@ -60,6 +60,11 @@ fn build_ailoop_interviewer(ws_url: &str, channel: &str) -> Arc<AiloopInterviewe
     ))
 }
 
+fn provider_for(interviewer: Arc<AiloopInterviewer>) -> InterviewerProvider {
+    let cloned: Arc<dyn Interviewer> = interviewer;
+    Arc::new(move || Ok(cloned.clone()))
+}
+
 fn build_execution_context(workspace: &TempDir, execution_id: String) -> ExecutionContext {
     let empty = Value::Object(Map::new());
     ExecutionContext {
@@ -109,8 +114,11 @@ async fn human_decision_via_ailoop_happy_path() {
     .await;
 
     let interviewer = build_ailoop_interviewer(&ws_url, channel);
-    let operator =
-        HumanDecisionOperator::new(interviewer, HumanSettings::default(), Arc::new(Vec::new()));
+    let operator = HumanDecisionOperator::new(
+        provider_for(interviewer),
+        HumanSettings::default(),
+        Arc::new(Vec::new()),
+    );
     let mut ctx = build_execution_context(&workspace, execution_id.clone());
     ctx.task_id = "decision".to_string();
 
@@ -163,8 +171,11 @@ async fn human_approval_via_ailoop_timeout_default() {
     .await;
 
     let interviewer = build_ailoop_interviewer(&ws_url, channel);
-    let operator =
-        HumanApprovalOperator::new(interviewer, HumanSettings::default(), Arc::new(Vec::new()));
+    let operator = HumanApprovalOperator::new(
+        provider_for(interviewer),
+        HumanSettings::default(),
+        Arc::new(Vec::new()),
+    );
     let mut ctx = build_execution_context(&workspace, execution_id.clone());
     ctx.task_id = "approval".to_string();
 
@@ -203,4 +214,71 @@ async fn human_approval_via_ailoop_timeout_default() {
 
     redact_audit(&mut entry);
     assert_yaml_snapshot!("human_approval_via_ailoop_timeout_default", entry);
+}
+
+#[tokio::test]
+async fn human_decision_without_ailoop_emits_hil_001() {
+    let workspace = TempDir::new().unwrap();
+    let execution_id = Uuid::new_v4().to_string();
+    let provider: InterviewerProvider =
+        newton_core::workflow::human::lazy_interviewer_provider(None, Duration::from_secs(60));
+    let operator =
+        HumanDecisionOperator::new(provider, HumanSettings::default(), Arc::new(Vec::new()));
+    let mut ctx = build_execution_context(&workspace, execution_id);
+    ctx.task_id = "decision".to_string();
+    let err = operator
+        .execute(
+            json!({
+                "prompt": "Pick",
+                "choices": ["a", "b"],
+                "timeout_seconds": 1,
+                "default_choice": "a",
+            }),
+            ctx,
+        )
+        .await
+        .expect_err("expected HIL-AILOOP-001");
+    assert_eq!(err.code, "HIL-AILOOP-001");
+}
+
+#[test]
+fn require_enabled_ailoop_context_malformed_returns_hil_003() {
+    use std::fs;
+    let workspace = TempDir::new().unwrap();
+    let configs = workspace.path().join(".newton").join("configs");
+    fs::create_dir_all(&configs).unwrap();
+    fs::write(
+        configs.join("monitor.conf"),
+        "ailoop_server_ws_url=not a valid url\nailoop_channel=test\n",
+    )
+    .unwrap();
+    std::env::set_var("NEWTON_AILOOP_INTEGRATION", "1");
+    std::env::remove_var("NEWTON_AILOOP_WS_URL");
+    std::env::remove_var("NEWTON_AILOOP_CHANNEL");
+    let result = newton_core::integrations::ailoop::config::require_enabled_ailoop_context(
+        workspace.path(),
+        "run",
+    );
+    std::env::remove_var("NEWTON_AILOOP_INTEGRATION");
+    let err = result.expect_err("malformed config must error");
+    assert_eq!(err.code, "HIL-AILOOP-003");
+}
+
+#[tokio::test]
+async fn lazy_provider_not_invoked_when_no_human_task() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_clone = counter.clone();
+    let provider: InterviewerProvider = Arc::new(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+        Err(newton_core::core::error::AppError::new(
+            newton_core::core::types::ErrorCategory::ValidationError,
+            "should not be invoked",
+        )
+        .with_code("HIL-AILOOP-001"))
+    });
+    // Build operator but never call execute — provider must not run.
+    let _operator =
+        HumanDecisionOperator::new(provider, HumanSettings::default(), Arc::new(Vec::new()));
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
 }

--- a/crates/core/tests/workflow_graph/test_human_ops.rs
+++ b/crates/core/tests/workflow_graph/test_human_ops.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use chrono::Utc;
-use newton_core::core::error::AppError;
-use newton_core::core::types::ErrorCategory;
 use newton_core::workflow::{
     executor::{ExecutionOverrides, GraphHandle},
-    human::{ApprovalDefault, ApprovalResult, DecisionResult, Interviewer},
+    human::{
+        ApprovalResult, DecisionResult, Interviewer, InterviewerProvider, MockAiloopInterviewer,
+    },
     operator::{ExecutionContext, Operator, OperatorRegistry, StateView},
     operators::{human_approval::HumanApprovalOperator, human_decision::HumanDecisionOperator},
     schema::HumanSettings,
@@ -17,65 +16,14 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use uuid::Uuid;
 
-#[derive(Clone)]
-struct FakeInterviewer {
-    approval_result: Option<ApprovalResult>,
-    choice_result: Option<DecisionResult>,
+fn provider_from_mock(mock: Arc<MockAiloopInterviewer>) -> InterviewerProvider {
+    let cloned = mock as Arc<dyn Interviewer>;
+    Arc::new(move || Ok(cloned.clone()))
 }
 
-impl FakeInterviewer {
-    fn new() -> Self {
-        Self {
-            approval_result: None,
-            choice_result: None,
-        }
-    }
-
-    fn with_approval(mut self, value: ApprovalResult) -> Self {
-        self.approval_result = Some(value);
-        self
-    }
-
-    fn with_choice(mut self, value: DecisionResult) -> Self {
-        self.choice_result = Some(value);
-        self
-    }
-}
-
-#[async_trait]
-impl Interviewer for FakeInterviewer {
-    fn interviewer_type(&self) -> &'static str {
-        "fake"
-    }
-
-    async fn ask_approval(
-        &self,
-        _prompt: &str,
-        _timeout: Option<std::time::Duration>,
-        _default_on_timeout: Option<ApprovalDefault>,
-    ) -> Result<ApprovalResult, AppError> {
-        self.approval_result.clone().ok_or_else(|| {
-            AppError::new(
-                ErrorCategory::InternalError,
-                "no approval response configured",
-            )
-        })
-    }
-
-    async fn ask_choice(
-        &self,
-        _prompt: &str,
-        _choices: &[String],
-        _timeout: Option<std::time::Duration>,
-        _default_choice: Option<&str>,
-    ) -> Result<DecisionResult, AppError> {
-        self.choice_result.clone().ok_or_else(|| {
-            AppError::new(
-                ErrorCategory::InternalError,
-                "no decision response configured",
-            )
-        })
-    }
+fn empty_provider() -> InterviewerProvider {
+    let mock = Arc::new(MockAiloopInterviewer::new()) as Arc<dyn Interviewer>;
+    Arc::new(move || Ok(mock.clone()))
 }
 
 fn build_execution_context(workspace: &TempDir, execution_id: String) -> ExecutionContext {
@@ -114,9 +62,13 @@ async fn human_approval_logs_timeout_default() -> Result<()> {
         timeout_applied: true,
         default_used: true,
     };
-    let interviewer = Arc::new(FakeInterviewer::new().with_approval(approval_result.clone()));
-    let operator =
-        HumanApprovalOperator::new(interviewer, HumanSettings::default(), Arc::new(Vec::new()));
+    let mock = Arc::new(MockAiloopInterviewer::new());
+    mock.push_approval(approval_result.clone());
+    let operator = HumanApprovalOperator::new(
+        provider_from_mock(mock),
+        HumanSettings::default(),
+        Arc::new(Vec::new()),
+    );
     let ctx = build_execution_context(&workspace, execution_id.clone());
     let output = operator
         .execute(
@@ -143,7 +95,7 @@ async fn human_approval_logs_timeout_default() -> Result<()> {
     let entry: Value = serde_json::from_str(entry_line)?;
     assert_eq!(entry["execution_id"], json!(execution_id));
     assert_eq!(entry["task_id"], json!("approval"));
-    assert_eq!(entry["interviewer_type"], json!("fake"));
+    assert_eq!(entry["interviewer_type"], json!("mock_ailoop"));
     assert_eq!(entry["prompt"], json!("Approve release?"));
     assert_eq!(entry["approved"], json!(true));
     assert_eq!(entry["default_used"], json!(true));
@@ -155,7 +107,7 @@ async fn human_approval_logs_timeout_default() -> Result<()> {
 #[test]
 fn human_approval_requires_default() -> Result<()> {
     let operator = HumanApprovalOperator::new(
-        Arc::new(FakeInterviewer::new()),
+        empty_provider(),
         HumanSettings::default(),
         Arc::new(Vec::new()),
     );
@@ -172,7 +124,7 @@ fn human_approval_requires_default() -> Result<()> {
 #[test]
 fn human_decision_requires_default_choice() -> Result<()> {
     let operator = HumanDecisionOperator::new(
-        Arc::new(FakeInterviewer::new()),
+        empty_provider(),
         HumanSettings::default(),
         Arc::new(Vec::new()),
     );
@@ -198,9 +150,13 @@ async fn human_decision_logs_choice() -> Result<()> {
         default_used: false,
         response_text: Some("2".to_string()),
     };
-    let interviewer = Arc::new(FakeInterviewer::new().with_choice(decision_result.clone()));
-    let operator =
-        HumanDecisionOperator::new(interviewer, HumanSettings::default(), Arc::new(Vec::new()));
+    let mock = Arc::new(MockAiloopInterviewer::new());
+    mock.push_choice(decision_result.clone());
+    let operator = HumanDecisionOperator::new(
+        provider_from_mock(mock),
+        HumanSettings::default(),
+        Arc::new(Vec::new()),
+    );
     let mut ctx = build_execution_context(&workspace, execution_id.clone());
     ctx.task_id = "decision".to_string();
     let output = operator

--- a/crates/core/tests/workflow_graph/test_workflow_comprehensive_matrix.rs
+++ b/crates/core/tests/workflow_graph/test_workflow_comprehensive_matrix.rs
@@ -732,7 +732,10 @@ async fn scenario_human_approval_and_decision_path() -> Result<(), String> {
     const NAME: &str = "human_approval_and_decision_path";
     let workspace = scenario_workspace(NAME)?;
     let deps = BuiltinOperatorDeps {
-        interviewer: Some(Arc::new(FakeInterviewer::approve_and_choose("ship"))),
+        interviewer: Some({
+            let fake: Arc<dyn Interviewer> = Arc::new(FakeInterviewer::approve_and_choose("ship"));
+            Arc::new(move || Ok(fake.clone()))
+        }),
         command_runner: None,
         gh_runner: None,
         child_workflow_runner: None,

--- a/docs/operators/human_approval.md
+++ b/docs/operators/human_approval.md
@@ -20,23 +20,51 @@ outcome.
 { "approved": true, "reason": "<reason or empty>", "timestamp": "<RFC3339>" }
 ```
 
-## Transport
+## Configuration
 
-The operator delegates the prompt to an `Interviewer` backend. Two backends
-are available; selection is automatic per workflow run:
+Human-in-the-loop operators **require ailoop**. Newton always delegates the
+prompt to ailoop; there is no console fallback. Ailoop itself decides whether
+to render the prompt on a local TTY (direct mode) or relay it to a remote
+operator over WebSocket (server mode). See
+[`init_context_for_command_name`](../../crates/core/src/integrations/ailoop/config.rs).
 
-| Backend  | When selected                                         | Behavior                                  |
-| -------- | ----------------------------------------------------- | ----------------------------------------- |
-| console  | Default; no `AiloopContext` initialized for the run.  | Reads the answer from stdin.              |
-| ailoop   | An `AiloopContext` is initialized and enabled.        | Posts an `authorize` request to ailoop.   |
+Required configuration:
 
-### Environment override
+- Env vars (highest precedence):
+  - `NEWTON_AILOOP_INTEGRATION=1` — opt in to the ailoop integration.
+  - `NEWTON_AILOOP_WS_URL` — WebSocket URL of the ailoop endpoint.
+  - `NEWTON_AILOOP_CHANNEL` — channel name for messages.
+- File-based fallback: `.newton/configs/monitor.conf` with keys
+  `ailoop_server_ws_url=…` and `ailoop_channel=…`.
 
-`NEWTON_HITL_TRANSPORT` forces the backend regardless of the `AiloopContext`:
+### Local / developer setup
 
-- `NEWTON_HITL_TRANSPORT=console` — always use the console backend.
-- `NEWTON_HITL_TRANSPORT=ailoop` — require ailoop; if no `AiloopContext` is
-  available the run logs a warning and falls back to console.
+Run ailoop in **direct mode** locally (no remote server) and point
+`.newton/configs/monitor.conf` at the local instance, e.g.:
+
+```
+ailoop_server_ws_url=ws://localhost:8765/
+ailoop_channel=newton-dev
+```
+
+Set `NEWTON_AILOOP_INTEGRATION=1` and run the workflow normally; ailoop
+renders the prompt on the local TTY.
+
+### Error reference
+
+When a workflow contains a `human_approval` task but no enabled
+`AiloopContext` is available, the first prompt fails with error code
+`HIL-AILOOP-001` (category `ValidationError`). If the configuration file is
+present but malformed (bad URL, unreadable file), the helper
+`require_enabled_ailoop_context` returns `HIL-AILOOP-003` (category
+`IoError`).
+
+### Upgrade note
+
+Earlier versions of Newton silently fell back to `ConsoleInterviewer` (stdin
+prompts) when ailoop was not configured, and honoured a
+`NEWTON_HITL_TRANSPORT` override. Both behaviours are gone: human-in-the-loop
+workflows now require ailoop unconditionally.
 
 ### `fail_fast` interaction
 
@@ -53,12 +81,6 @@ non-2xx response, deserialization error, timeout):
 ## Audit log
 
 Audit entries are written to
-`<workspace>/.newton/state/workflows/<execution_id>/audit.jsonl`. The schema
-is unchanged across backends; the `interviewer_type` field reports
-`"console"` or `"ailoop"` depending on which transport was selected.
-
-## Breaking change note
-
-When ailoop is enabled in a workspace the operator no longer prompts on
-stdin. To preserve the prior console behavior set
-`NEWTON_HITL_TRANSPORT=console`.
+`<workspace>/.newton/state/workflows/<execution_id>/audit.jsonl`. The
+`interviewer_type` field reports `"ailoop"` in production and `"mock_ailoop"`
+under tests using the test double.

--- a/docs/operators/human_approval.md
+++ b/docs/operators/human_approval.md
@@ -61,10 +61,9 @@ present but malformed (bad URL, unreadable file), the helper
 
 ### Upgrade note
 
-Earlier versions of Newton silently fell back to `ConsoleInterviewer` (stdin
-prompts) when ailoop was not configured, and honoured a
-`NEWTON_HITL_TRANSPORT` override. Both behaviours are gone: human-in-the-loop
-workflows now require ailoop unconditionally.
+Earlier versions of Newton silently fell back to a console interviewer (stdin
+prompts) when ailoop was not configured. That behaviour is gone:
+human-in-the-loop workflows now require ailoop unconditionally.
 
 ### `fail_fast` interaction
 

--- a/docs/operators/human_decision.md
+++ b/docs/operators/human_decision.md
@@ -62,10 +62,9 @@ present but malformed (bad URL, unreadable file), the helper
 
 ### Upgrade note
 
-Earlier versions of Newton silently fell back to `ConsoleInterviewer` (stdin
-prompts) when ailoop was not configured, and honoured a
-`NEWTON_HITL_TRANSPORT` override. Both behaviours are gone: human-in-the-loop
-workflows now require ailoop unconditionally.
+Earlier versions of Newton silently fell back to a console interviewer (stdin
+prompts) when ailoop was not configured. That behaviour is gone:
+human-in-the-loop workflows now require ailoop unconditionally.
 
 ### `fail_fast` interaction
 

--- a/docs/operators/human_decision.md
+++ b/docs/operators/human_decision.md
@@ -21,23 +21,51 @@ value into the task output.
 { "choice": "<one of choices>", "timestamp": "<RFC3339>" }
 ```
 
-## Transport
+## Configuration
 
-The operator delegates the prompt to an `Interviewer` backend. Two backends
-are available; selection is automatic per workflow run:
+Human-in-the-loop operators **require ailoop**. Newton always delegates the
+prompt to ailoop; there is no console fallback. Ailoop itself decides whether
+to render the prompt on a local TTY (direct mode) or relay it to a remote
+operator over WebSocket (server mode). See
+[`init_context_for_command_name`](../../crates/core/src/integrations/ailoop/config.rs).
 
-| Backend  | When selected                                         | Behavior                                |
-| -------- | ----------------------------------------------------- | --------------------------------------- |
-| console  | Default; no `AiloopContext` initialized for the run.  | Reads the answer from stdin.            |
-| ailoop   | An `AiloopContext` is initialized and enabled.        | Posts an `ask` request to ailoop.       |
+Required configuration:
 
-### Environment override
+- Env vars (highest precedence):
+  - `NEWTON_AILOOP_INTEGRATION=1` — opt in to the ailoop integration.
+  - `NEWTON_AILOOP_WS_URL` — WebSocket URL of the ailoop endpoint.
+  - `NEWTON_AILOOP_CHANNEL` — channel name for messages.
+- File-based fallback: `.newton/configs/monitor.conf` with keys
+  `ailoop_server_ws_url=…` and `ailoop_channel=…`.
 
-`NEWTON_HITL_TRANSPORT` forces the backend regardless of the `AiloopContext`:
+### Local / developer setup
 
-- `NEWTON_HITL_TRANSPORT=console` — always use the console backend.
-- `NEWTON_HITL_TRANSPORT=ailoop` — require ailoop; if no `AiloopContext` is
-  available the run logs a warning and falls back to console.
+Run ailoop in **direct mode** locally (no remote server) and point
+`.newton/configs/monitor.conf` at the local instance, e.g.:
+
+```
+ailoop_server_ws_url=ws://localhost:8765/
+ailoop_channel=newton-dev
+```
+
+Set `NEWTON_AILOOP_INTEGRATION=1` and run the workflow normally; ailoop
+renders the prompt on the local TTY.
+
+### Error reference
+
+When a workflow contains a `human_decision` task but no enabled
+`AiloopContext` is available, the first prompt fails with error code
+`HIL-AILOOP-001` (category `ValidationError`). If the configuration file is
+present but malformed (bad URL, unreadable file), the helper
+`require_enabled_ailoop_context` returns `HIL-AILOOP-003` (category
+`IoError`).
+
+### Upgrade note
+
+Earlier versions of Newton silently fell back to `ConsoleInterviewer` (stdin
+prompts) when ailoop was not configured, and honoured a
+`NEWTON_HITL_TRANSPORT` override. Both behaviours are gone: human-in-the-loop
+workflows now require ailoop unconditionally.
 
 ### `fail_fast` interaction
 
@@ -54,12 +82,6 @@ non-2xx response, deserialization error, timeout):
 ## Audit log
 
 Audit entries are written to
-`<workspace>/.newton/state/workflows/<execution_id>/audit.jsonl`. The schema
-is unchanged across backends; the `interviewer_type` field reports
-`"console"` or `"ailoop"` depending on which transport was selected.
-
-## Breaking change note
-
-When ailoop is enabled in a workspace the operator no longer prompts on
-stdin. To preserve the prior console behavior set
-`NEWTON_HITL_TRANSPORT=console`.
+`<workspace>/.newton/state/workflows/<execution_id>/audit.jsonl`. The
+`interviewer_type` field reports `"ailoop"` in production and `"mock_ailoop"`
+under tests using the test double.


### PR DESCRIPTION
## Summary

- Integration tests in `tests/` are compiled as separate crates; `cfg(test)` is NOT set on the library when it is compiled as a dependency for those tests
- `MockAiloopInterviewer` is gated by `#[cfg(any(test, feature = "test-utils"))]` in `crates/core/src/workflow/human/mod.rs`, so it was compiled out and unavailable to `test_human_ops.rs`
- Added `required-features = ["test-utils"]` to the `[[test]]` entry in `crates/core/Cargo.toml` so cargo enables the feature when building the library for that test
