### PR TITLE
feat(cli): migrate Newton CLI to cli-framework (#228)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -70,6 +71,38 @@ dependencies = [
  "tracing",
  "walkdir",
  "zip",
+]
+
+[[package]]
+name = "ailoop-core"
+version = "0.1.29"
+source = "git+https://github.com/goailoop/ailoop.git?rev=83508e764a18b9073bfc5f34a9060247634b3833#83508e764a18b9073bfc5f34a9060247634b3833"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "clap",
+ "crossbeam-queue",
+ "crossterm 0.27.0",
+ "dashmap 5.5.3",
+ "dirs",
+ "fs2",
+ "futures-util",
+ "jsonschema",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "toml 0.8.23",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "warp",
 ]
 
 [[package]]
@@ -167,6 +200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anthropic-sdk"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e11a7c14d8af2206c110597bf7f2919ea0c1dc5011c017d2d4dc9d033f5363"
+dependencies = [
+ "anyhow",
+ "dotenv",
+ "futures",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +252,40 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
+name = "async-openai"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e97f9c5e0ee3260caee9700ba1bb61a6fdc34d2b6786a31e018c5de5198491"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "futures",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -316,6 +398,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +428,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -373,6 +484,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -500,6 +617,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cli-framework"
+version = "0.3.0"
+source = "git+https://github.com/aroff/cli-framework#9af4fc7d66ef3a4850cd844ed1b61a62de75b357"
+dependencies = [
+ "ailoop-core 0.1.29",
+ "anthropic-sdk",
+ "anyhow",
+ "async-openai",
+ "async-trait",
+ "clap",
+ "crossterm 0.28.1",
+ "dirs",
+ "httpdate",
+ "log",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "toml 0.8.23",
+ "uuid",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +706,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -689,6 +842,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +965,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +1067,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1141,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,12 +1222,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1075,6 +1346,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1444,6 +1721,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1465,6 +1743,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,9 +1776,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1599,6 +1895,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1967,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1996,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1728,6 +2048,36 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1888,6 +2238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +2296,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "newton-backend"
 version = "0.1.0"
 dependencies = [
@@ -1968,6 +2341,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "cli-framework",
  "crossterm 0.28.1",
  "dirs-next",
  "futures",
@@ -2008,7 +2382,7 @@ name = "newton-core"
 version = "0.5.86"
 dependencies = [
  "aikit-sdk",
- "ailoop-core",
+ "ailoop-core 0.1.37",
  "anyhow",
  "assert_cmd",
  "async-stream",
@@ -2081,6 +2455,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2486,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2109,6 +2526,21 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2133,6 +2565,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2171,6 +2614,49 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -2771,7 +3257,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -2791,27 +3277,35 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -2823,6 +3317,22 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom 7.1.3",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2947,6 +3457,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3539,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3574,39 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3632,8 +4196,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -3641,6 +4216,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3814,6 +4399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,6 +4498,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -4716,6 +5312,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ name = "logging_integration_helper"
 path = "tests/bin/logging_integration_helper.rs"
 
 [dependencies]
+cli-framework = { git = "https://github.com/aroff/cli-framework" }
 newton-core = { path = "../core" }
 newton-types = { path = "../types" }
 newton-backend = { path = "../backend" }

--- a/crates/cli/src/cli/context.rs
+++ b/crates/cli/src/cli/context.rs
@@ -1,21 +1,19 @@
 //! Newton CLI context for framework-driven command dispatch (Issue #228 Stage 2).
-//!
-//! `NewtonContext` is the shared, mutation-free state container that future
-//! `cli-framework` `App<NewtonContext>` execute closures will receive. It is
-//! introduced now as scaffolding so the migration referenced by the
-//! `feature/228-054-migrate-cli-framework` spec can land in stages without
-//! breaking the existing clap-based dispatch path.
 
-/// Shared context handed to every command execute closure once the migration
-/// to `cli-framework` is wired up. Holds no mutable, command-specific state.
+use cli_framework::app::AppContext;
+
+/// Shared context handed to every command execute closure.
+/// Holds no mutable, command-specific state — logging is initialised in main
+/// before the framework runs, so no guard handle is needed here.
 #[derive(Default)]
 pub struct NewtonContext {
     _private: (),
 }
 
 impl NewtonContext {
-    /// Construct a fresh `NewtonContext`.
     pub fn new() -> Self {
         Self { _private: () }
     }
 }
+
+impl AppContext for NewtonContext {}

--- a/crates/cli/src/cli/context.rs
+++ b/crates/cli/src/cli/context.rs
@@ -1,0 +1,21 @@
+//! Newton CLI context for framework-driven command dispatch (Issue #228 Stage 2).
+//!
+//! `NewtonContext` is the shared, mutation-free state container that future
+//! `cli-framework` `App<NewtonContext>` execute closures will receive. It is
+//! introduced now as scaffolding so the migration referenced by the
+//! `feature/228-054-migrate-cli-framework` spec can land in stages without
+//! breaking the existing clap-based dispatch path.
+
+/// Shared context handed to every command execute closure once the migration
+/// to `cli-framework` is wired up. Holds no mutable, command-specific state.
+#[derive(Default)]
+pub struct NewtonContext {
+    _private: (),
+}
+
+impl NewtonContext {
+    /// Construct a fresh `NewtonContext`.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}

--- a/crates/cli/src/cli/framework_setup.rs
+++ b/crates/cli/src/cli/framework_setup.rs
@@ -1,0 +1,61 @@
+//! Framework registration scaffolding for the Newton CLI (Issue #228 Stage 2).
+//!
+//! This module is the eventual home of `cli-framework` `Command` /
+//! `CommandSpec` / `ArgSpec` declarations and the `build_app()` entry point
+//! used by `crates/cli/src/main.rs`. The full migration is staged across
+//! multiple deliverables (see spec §10); this file currently provides the
+//! public API surface so dependent crates and tests can compile against the
+//! new boundary while the underlying implementation continues to use the
+//! existing clap-driven dispatch defined in `crate::cli::run`.
+//!
+//! Once `cli-framework` is added as a workspace dependency, the body of
+//! `build_app` will be replaced by `AppBuilder::new()...build(ctx)` and the
+//! per-command `Command` registrations enumerated in §5 of the spec.
+
+use crate::cli::context::NewtonContext;
+use crate::Result;
+
+/// Error codes raised by the framework migration adapter layer.
+///
+/// See spec §6 for the full taxonomy.
+pub mod error_codes {
+    /// `AppBuilder::build()` is missing a currently-supported Newton command.
+    pub const CLI_MIG_001: &str = "CLI-MIG-001";
+    /// `TryFrom<CommandArgs>` adapter cannot construct a required Newton DTO field.
+    pub const CLI_MIG_002: &str = "CLI-MIG-002";
+    /// Framework parsing accepts ambiguous or conflicting flags.
+    pub const CLI_MIG_003: &str = "CLI-MIG-003";
+    /// Help-output contract check fails for a migrated command.
+    pub const CLI_MIG_004: &str = "CLI-MIG-004";
+    /// Framework parser returned a command path with no registered execute closure.
+    pub const CLI_MIG_005: &str = "CLI-MIG-005";
+}
+
+/// Newton CLI app handle returned by [`build_app`].
+///
+/// During the staged migration this is a thin wrapper that defers to the
+/// existing clap-based [`crate::cli::run`] dispatch. Once Stage 5 lands it
+/// will hold a `cli_framework::App<NewtonContext>` and surface the framework
+/// directly.
+pub struct NewtonApp {
+    _ctx: NewtonContext,
+}
+
+impl NewtonApp {
+    /// Drive the CLI to completion using the current dispatch path.
+    pub async fn run(self) -> Result<()> {
+        use clap::Parser;
+        let parsed = crate::cli::Args::parse();
+        crate::cli::run(parsed).await
+    }
+}
+
+/// Build the Newton CLI application with framework-style entry semantics.
+///
+/// This is the function `crates/cli/src/main.rs` will eventually call once
+/// the cli-framework dependency is wired in. Today it returns a wrapper that
+/// runs the existing clap-based dispatch so the public API surface stays
+/// stable across the staged migration.
+pub fn build_app(ctx: NewtonContext) -> Result<NewtonApp> {
+    Ok(NewtonApp { _ctx: ctx })
+}

--- a/crates/cli/src/cli/framework_setup.rs
+++ b/crates/cli/src/cli/framework_setup.rs
@@ -1,61 +1,2005 @@
-//! Framework registration scaffolding for the Newton CLI (Issue #228 Stage 2).
+//! cli-framework registration for Newton CLI (Issue #228 Stage 2).
 //!
-//! This module is the eventual home of `cli-framework` `Command` /
-//! `CommandSpec` / `ArgSpec` declarations and the `build_app()` entry point
-//! used by `crates/cli/src/main.rs`. The full migration is staged across
-//! multiple deliverables (see spec §10); this file currently provides the
-//! public API surface so dependent crates and tests can compile against the
-//! new boundary while the underlying implementation continues to use the
-//! existing clap-driven dispatch defined in `crate::cli::run`.
+//! All Command / CommandSpec / ArgSpec declarations and the `build_app()`
+//! entry point used by `crates/cli/src/main.rs` live here.
 //!
-//! Once `cli-framework` is added as a workspace dependency, the body of
-//! `build_app` will be replaced by `AppBuilder::new()...build(ctx)` and the
-//! per-command `Command` registrations enumerated in §5 of the spec.
+//! ## Nested-command note
+//! The framework routes via its root-level `commands` map; nested paths in
+//! `tree_commands` are not yet dispatched by the clap adapter.  Group
+//! commands (checkpoints, artifacts, webhook, log) are therefore registered
+//! at root level and dispatch internally via their first positional arg.
+//! Proper hierarchical routing is deferred to Stage 3/4 once the framework
+//! adds nested-subcommand clap support.
 
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use cli_framework::app::{App, AppBuilder};
+use cli_framework::command::{Command, CommandArgs};
+use cli_framework::spec::arg_spec::{ArgKind, ArgSpec, ArgValueType, Cardinality};
+use cli_framework::spec::command_tree::CommandSpec;
+use uuid::Uuid;
+
+use crate::cli::args::{
+    ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,
+    ExplainArgs, InitArgs, LintArgs, LogArgs, LogCommand, MonitorArgs, OutputFormat, ResumeArgs,
+    RunArgs, ServeArgs, ValidateArgs, WebhookArgs, WebhookCommand, WebhookServeArgs,
+    WebhookStatusArgs,
+};
 use crate::cli::context::NewtonContext;
-use crate::Result;
+use crate::cli::{commands, init};
 
-/// Error codes raised by the framework migration adapter layer.
-///
-/// See spec §6 for the full taxonomy.
+/// Stable error codes for the migration adapter layer (spec §6).
 pub mod error_codes {
-    /// `AppBuilder::build()` is missing a currently-supported Newton command.
     pub const CLI_MIG_001: &str = "CLI-MIG-001";
-    /// `TryFrom<CommandArgs>` adapter cannot construct a required Newton DTO field.
     pub const CLI_MIG_002: &str = "CLI-MIG-002";
-    /// Framework parsing accepts ambiguous or conflicting flags.
     pub const CLI_MIG_003: &str = "CLI-MIG-003";
-    /// Help-output contract check fails for a migrated command.
     pub const CLI_MIG_004: &str = "CLI-MIG-004";
-    /// Framework parser returned a command path with no registered execute closure.
     pub const CLI_MIG_005: &str = "CLI-MIG-005";
 }
 
-/// Newton CLI app handle returned by [`build_app`].
-///
-/// During the staged migration this is a thin wrapper that defers to the
-/// existing clap-based [`crate::cli::run`] dispatch. Once Stage 5 lands it
-/// will hold a `cli_framework::App<NewtonContext>` and surface the framework
-/// directly.
-pub struct NewtonApp {
-    _ctx: NewtonContext,
+// ── help-text constants ───────────────────────────────────────────────────────
+
+const RUN_LONG_ABOUT: &str = "\
+Run executes a workflow graph defined in YAML, with optional trigger payload \
+from input file or arguments.
+
+Accepted forms:
+  newton run [WORKFLOW] [INPUT_FILE] [OPTIONS]
+  newton run --file <PATH> [OPTIONS]
+
+EXAMPLES:
+  Basic workflow execution:
+    newton run workflow.yaml
+
+  With workspace and trigger data:
+    newton run workflow.yaml --workspace ./output --arg key=value
+
+  Multiple arguments:
+    newton run workflow.yaml --arg env=prod --arg version=1.2.3
+
+  With input file and verbose output:
+    newton run workflow.yaml input.txt --workspace ./workspace --verbose";
+
+const INIT_LONG_ABOUT: &str = "\
+Init creates the .newton workspace layout, installs the Newton template with \
+aikit-sdk, and writes default configs so you can run immediately.
+
+EXAMPLES:
+  Initialize current directory:
+    newton init .
+
+  Initialize a specific directory:
+    newton init ./workspace
+
+  Initialize with custom template source:
+    newton init . --template-source gonewton/newton-templates";
+
+const BATCH_LONG_ABOUT: &str = "\
+Batch reads plan files from .newton/plan/<project_id> and drives headless \
+workflow orchestration.
+
+EXAMPLES:
+  Process queued plans for a project:
+    newton batch project-alpha
+
+  With workspace override:
+    newton batch project-alpha --workspace ./workspace
+
+  Process one plan and exit:
+    newton batch project-alpha --once
+
+  Custom poll interval:
+    newton batch project-alpha --sleep 30";
+
+// Combined serve long_about: route-group description + examples block.
+// The framework renders only long_about in --help, so both must be here.
+const SERVE_LONG_ABOUT: &str = "\
+Serve runs the Newton HTTP/WebSocket API for UIs, agents, and integrations.
+Full REST contract: openapi/newton-backend-parity.yaml.
+Schemas and query parameters: skill/newton/references/serve-api.md.
+
+Mounted route groups (see OpenAPI for exact methods, params, and bodies):
+  \u{2022} Workflows       /api/workflows, /api/workflows/{id}, /api/workflows/{id}/nodes/{node_id}
+  \u{2022} HIL             /api/hil/instances, /api/hil/workflows/{id}
+  \u{2022} Streaming       /api/stream/workflow/{id}/{ws,sse}, /api/stream/logs/{id}/{node_id}/ws
+  \u{2022} Operators       /api/operators
+  \u{2022} Dashboard       /api/products, /api/components, /api/pending-approvals,
+                    /api/regressions, /api/indicators, /api/recent-actions
+  \u{2022} Portfolio       /api/repos, /api/repo-dependencies, /api/module-dependencies,
+                    /api/saved-views
+  \u{2022} Opportunities   /api/opportunities, /api/opportunities/{id}
+  \u{2022} Requests        /api/requests
+  \u{2022} Plans           /api/plans, /api/plans/{id}/{approve,reject}, /api/executions
+  \u{2022} Persistence     /api/persistence/{key}
+  \u{2022} Testing reset   /api/testing/reset
+Always available: GET /health.
+
+CORS is enabled for local development by default.
+
+EXAMPLES:
+  Start API server on default port:
+    newton serve
+
+  Start on custom host and port:
+    newton serve --host 0.0.0.0 --port 9000
+
+  Run in background:
+    newton serve --host 0.0.0.0 --port 8080 &
+
+See openapi/newton-backend-parity.yaml for the full HTTP/WebSocket/SSE contract.";
+
+const MONITOR_LONG_ABOUT: &str = "\
+Monitor listens to every project/branch channel from the workspace using a \
+WebSocket/HTTP mix and lets you answer questions or approve authorizations in a queue.
+
+CONFIGURATION:
+  Monitor requires both HTTP and WebSocket endpoints to connect to the ailoop server.
+  Endpoints can come from CLI overrides (--http-url, --ws-url) or workspace config files.
+  Partial overrides are supported: one flag can be set while the other comes from config.
+
+Endpoint discovery order:
+    1. CLI overrides: --http-url and --ws-url (merged with config if partial)
+    2. .newton/configs/monitor.conf (if present)
+    3. First alphabetical .conf file in .newton/configs/ containing both keys
+
+Config files use simple key=value format:
+  ailoop_server_http_url = http://127.0.0.1:8081
+  ailoop_server_ws_url = ws://127.0.0.1:8080
+
+EXAMPLES:
+  Using both CLI overrides:
+    newton monitor --http-url http://127.0.0.1:8081 --ws-url ws://127.0.0.1:8080
+
+  Using .newton/configs/monitor.conf:
+    newton monitor
+
+  Partial override (HTTP from CLI, WS from config):
+    newton monitor --http-url http://192.168.1.10:8081
+
+TROUBLESHOOTING:
+  Missing URL configuration:
+    If both endpoints are not found, ensure .newton/configs/monitor.conf exists
+    or provide both --http-url and --ws-url on the command line.";
+
+const VALIDATE_LONG_ABOUT: &str = "\
+Validate checks your workflow YAML file for syntax errors, schema compliance, \
+and logical issues before execution.
+
+Accepted forms:
+  newton validate [WORKFLOW]
+  newton validate --file <PATH>
+
+EXAMPLES:
+  Validate a workflow file:
+    newton validate workflow.yaml
+
+  Validate with alternative syntax:
+    newton validate --file ./workflows/my-workflow.yaml
+
+RETURN CODES:
+  0: Workflow is valid and ready to run
+  1: Validation errors found (details printed to stderr)";
+
+const DOT_LONG_ABOUT: &str = "\
+Dot creates a Graphviz DOT file from your workflow definition that can be \
+rendered into visual diagrams.
+
+This command analyzes your workflow's task dependencies and generates a directed \
+graph showing task execution flow.
+
+Accepted forms:
+  newton dot [WORKFLOW]
+  newton dot --file <PATH>
+
+EXAMPLES:
+  Generate DOT file to stdout:
+    newton dot workflow.yaml
+
+  Save DOT file for rendering:
+    newton dot workflow.yaml --out graph.dot
+
+  Create PNG diagram (requires Graphviz):
+    newton dot workflow.yaml --out graph.dot && dot -Tpng graph.dot -o workflow.png
+
+VISUALIZATION:
+  Use online Graphviz viewers or install Graphviz locally.";
+
+const LINT_LONG_ABOUT: &str = "\
+Lint analyzes your workflow definition against Newton's best practices and \
+coding standards to identify potential issues.
+
+Unlike validate (which checks syntax), lint focuses on quality and best practices. \
+All lint warnings are advisory and won't prevent workflow execution.
+
+Accepted forms:
+  newton lint [WORKFLOW]
+  newton lint --file <PATH>
+
+EXAMPLES:
+  Check workflow with human-readable output:
+    newton lint workflow.yaml
+
+  Generate JSON report for CI/CD integration:
+    newton lint workflow.yaml --format json
+
+OUTPUT FORMATS:
+  text: Human-readable summary (default)
+  json: Machine-readable structured data for tooling integration";
+
+const EXPLAIN_LONG_ABOUT: &str = "\
+Explain creates detailed documentation about what your workflow does and how \
+it will execute.
+
+This command analyzes your workflow definition and produces explanations covering:
+  \u{2022} Step-by-step execution flow
+  \u{2022} Task dependencies and timing
+  \u{2022} Configuration settings and their effects
+  \u{2022} Expected inputs and outputs
+
+Accepted forms:
+  newton explain [WORKFLOW]
+  newton explain --file <PATH>
+
+EXAMPLES:
+  Generate structured explanation:
+    newton explain workflow.yaml --format text
+
+  Create natural language description:
+    newton explain workflow.yaml --format prose
+
+  Explain with custom trigger data:
+    newton explain workflow.yaml --arg env=production --format prose
+
+OUTPUT FORMATS:
+  text: Structured technical breakdown
+  prose: Natural language description
+  json: Machine-readable analysis for documentation generation";
+
+const RESUME_LONG_ABOUT: &str = "\
+Resume restarts a workflow execution from its last saved checkpoint, allowing \
+you to continue from where it left off after an interrupted execution.
+
+EXAMPLES:
+  Resume a specific workflow execution:
+    newton resume --execution-id 12345678-1234-1234-1234-123456789abc
+
+  Resume with custom workspace:
+    newton resume --execution-id abcdef01-2345-6789-abcd-ef0123456789 --workspace ./project
+
+  Resume and allow workflow definition changes:
+    newton resume --execution-id 12345678-1234-1234-1234-123456789abc --allow-workflow-change
+
+FINDING EXECUTION IDs:
+  List available executions to resume:
+    newton checkpoints list --workspace ./workspace
+
+SAFETY:
+  By default, resume requires the workflow definition to be unchanged since the checkpoint.
+  Use --allow-workflow-change to override this safety check.";
+
+const CHECKPOINTS_LONG_ABOUT: &str = "\
+Checkpoints provides tools to manage the saved states that allow workflow \
+resumption after interruption.
+
+Newton automatically creates checkpoints during workflow execution to preserve \
+progress and enable recovery.
+
+Subcommands:
+  list   Display available workflow executions and their checkpoint details
+  clean  Remove old checkpoint files to free up disk space
+
+EXAMPLES:
+  List all available checkpoints:
+    newton checkpoints list --workspace ./workspace
+
+  Get checkpoint details in JSON format:
+    newton checkpoints list --workspace ./workspace --format-json
+
+  Clean old checkpoints (older than 7 days):
+    newton checkpoints clean --workspace ./workspace --older-than 7d
+
+  Clean checkpoints with custom retention:
+    newton checkpoints clean --workspace ./workspace --older-than 30d
+
+CHECKPOINT STORAGE:
+  Checkpoints are stored in .newton/checkpoints/ within your workspace.";
+
+const ARTIFACTS_LONG_ABOUT: &str = "\
+Artifacts provides tools to manage the output files, logs, and execution data \
+generated during workflow execution.  Regular cleanup helps maintain good \
+performance and disk space usage.
+
+Subcommands:
+  clean  Remove old workflow output files and execution artifacts to free disk space
+
+EXAMPLES:
+  Clean artifacts older than 7 days:
+    newton artifacts clean --workspace ./workspace --older-than 7d
+
+  Clean with custom retention period:
+    newton artifacts clean --workspace ./workspace --older-than 30d
+
+RETENTION FORMATS:
+  Supported time formats for --older-than: 7d, 30d, 1w, 2w, 24h, 48h
+
+ARTIFACT STORAGE:
+  Artifacts are stored in .newton/artifacts/ within your workspace.";
+
+const WEBHOOK_LONG_ABOUT: &str = "\
+Webhook provides HTTP endpoints that can trigger workflow executions in \
+response to external events.
+
+This command enables integration with Git hosting services (GitHub, GitLab, \
+Bitbucket), CI/CD platforms, monitoring systems, and custom applications.
+
+Subcommands:
+  serve   Start an HTTP server to receive webhook events and trigger workflows
+  status  Display webhook endpoint configuration and server status
+
+EXAMPLES:
+  Start webhook server for a workflow:
+    newton webhook serve workflow.yaml --workspace ./workspace
+
+  Check webhook configuration status:
+    newton webhook status workflow.yaml --workspace ./workspace
+
+  Serve webhook with alternative file syntax:
+    newton webhook serve --file ./workflows/deploy.yaml --workspace ./project
+
+INTEGRATION:
+  Configure your external services to send POST requests to the webhook URL.
+  The webhook server will parse the incoming payload and trigger the workflow.
+
+SECURITY:
+  Webhook endpoints include built-in security features like request validation \
+and rate limiting.  Configure authentication tokens and HTTPS for production deployments.";
+
+const LOG_LONG_ABOUT: &str = "\
+Log provides access to the per-task execution history stored in .newton/state/workflows/.
+
+Use 'log list' to enumerate executions, and 'log show <execution-id>' to display
+the resolved inputs, operator, and output for every task in that run.
+
+Subcommands: list, show
+
+DEFAULT LOG PATH:
+    <workspace>/.newton/logs/newton.log
+
+LOG LOCATION CONTROLS:
+    --log-dir PATH         Override log directory (highest priority)
+    logging.toml log_dir   Config file setting (second priority)
+    workspace default      <workspace>/.newton/logs/ (fallback)
+
+FILTER/VERBOSITY:
+    RUST_LOG=debug         Sets tracing filter level only; does NOT change log directory.
+
+EXAMPLES:
+  List recent executions:
+    newton log list --last 10
+    newton log list --workspace ./workspace
+
+  Show full execution log:
+    newton log show <execution-id>
+    newton log show <execution-id> --task <task-id> --verbose";
+
+// ── shared helpers ────────────────────────────────────────────────────────────
+
+/// Parse a comma-joined repeated-arg string (framework serialises `--arg k=v
+/// --arg k2=v2` as `"k=v,k2=v2"`).  Values containing commas are not supported.
+fn parse_kvp_list(s: &str) -> anyhow::Result<Vec<crate::cli::args::KeyValuePair>> {
+    use std::str::FromStr;
+    if s.is_empty() {
+        return Ok(vec![]);
+    }
+    s.split(',')
+        .map(|part| {
+            crate::cli::args::KeyValuePair::from_str(part.trim())
+                .map_err(|e| anyhow!("{}: {}", error_codes::CLI_MIG_002, e))
+        })
+        .collect()
 }
 
-impl NewtonApp {
-    /// Drive the CLI to completion using the current dispatch path.
-    pub async fn run(self) -> Result<()> {
-        use clap::Parser;
-        let parsed = crate::cli::Args::parse();
-        crate::cli::run(parsed).await
+fn get_bool(args: &CommandArgs, key: &str) -> bool {
+    args.named.get(key).map(|s| s == "true").unwrap_or(false)
+}
+
+fn get_opt_path(args: &CommandArgs, key: &str) -> Option<PathBuf> {
+    args.named.get(key).map(PathBuf::from)
+}
+
+fn get_opt_str(args: &CommandArgs, key: &str) -> Option<String> {
+    args.named.get(key).cloned()
+}
+
+fn parse_output_format(args: &CommandArgs) -> OutputFormat {
+    match args.named.get("format").map(String::as_str) {
+        Some("json") => OutputFormat::Json,
+        Some("prose") => OutputFormat::Prose,
+        _ => OutputFormat::Text,
     }
 }
 
-/// Build the Newton CLI application with framework-style entry semantics.
+// ── command constructors ──────────────────────────────────────────────────────
+
+fn run_command() -> Command {
+    Command {
+        id: "run",
+        summary: "Execute a workflow graph",
+        syntax: Some("[WORKFLOW] [INPUT_FILE] [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Execute a workflow graph",
+            long_about: Some(RUN_LONG_ABOUT),
+            examples: vec![
+                "newton run workflow.yaml",
+                "newton run workflow.yaml --workspace ./output --arg key=value",
+                "newton run workflow.yaml --arg env=prod --arg version=1.2.3",
+                "newton run workflow.yaml input.txt --workspace ./workspace --verbose",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "input-file",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Optional path written into triggers.payload.input_file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace root directory",
+                },
+                ArgSpec {
+                    name: "arg",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("arg"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Repeated,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Merge KEY=VALUE into triggers.payload (repeatable)",
+                },
+                ArgSpec {
+                    name: "set",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("set"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Repeated,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Merge KEY=VALUE into workflow.context at runtime (repeatable)",
+                },
+                ArgSpec {
+                    name: "trigger-json",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("trigger-json"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Load JSON object as base trigger payload before --arg overrides",
+                },
+                ArgSpec {
+                    name: "parallel-limit",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("parallel-limit"),
+                    value_type: ArgValueType::Int,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Runtime override for bounded task concurrency",
+                },
+                ArgSpec {
+                    name: "max-time-seconds",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("max-time-seconds"),
+                    value_type: ArgValueType::Int,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Runtime wall-clock limit override (seconds)",
+                },
+                ArgSpec {
+                    name: "verbose",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("verbose"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Print task stdout/stderr to terminal after each task completes",
+                },
+                ArgSpec {
+                    name: "server",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("server"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Newton server URL to register this run (optional)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = RunArgs::try_from(args)?;
+                commands::run(dto).await
+            })
+        }),
+    }
+}
+
+fn init_command() -> Command {
+    Command {
+        id: "init",
+        summary: "Initialize a Newton workspace with the default template",
+        syntax: Some("[PATH] [OPTIONS]"),
+        category: Some("workspace"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Initialize a Newton workspace with the default template",
+            long_about: Some(INIT_LONG_ABOUT),
+            examples: vec![
+                "newton init .",
+                "newton init ./workspace",
+                "newton init . --template-source gonewton/newton-templates",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "path",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help:
+                        "Directory where .newton/ will be created (defaults to current directory)",
+                },
+                ArgSpec {
+                    name: "template-source",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("template-source"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Template source (GitHub repo, URL, or local path)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = InitArgs::try_from(args)?;
+                init::run(dto)
+            })
+        }),
+    }
+}
+
+fn batch_command() -> Command {
+    Command {
+        id: "batch",
+        summary: "Process queued work items for a project",
+        syntax: Some("<PROJECT_ID> [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Process queued work items for a project",
+            long_about: Some(BATCH_LONG_ABOUT),
+            examples: vec![
+                "newton batch project-alpha",
+                "newton batch project-alpha --workspace ./workspace",
+                "newton batch project-alpha --once",
+                "newton batch project-alpha --sleep 30",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "project-id",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Project identifier that maps to .newton/configs/<project_id>.conf",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace root containing the .newton directory",
+                },
+                ArgSpec {
+                    name: "once",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("once"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Process a single plan and exit instead of running as a daemon",
+                },
+                ArgSpec {
+                    name: "sleep",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("sleep"),
+                    value_type: ArgValueType::Int,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Sleep interval in seconds when the queue is empty (default: 60)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = BatchArgs::try_from(args)?;
+                commands::batch(dto).await
+            })
+        }),
+    }
+}
+
+fn serve_command() -> Command {
+    Command {
+        id: "serve",
+        summary: "Start the Newton HTTP API server",
+        syntax: Some("[OPTIONS]"),
+        category: Some("server"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Start the Newton HTTP API server",
+            long_about: Some(SERVE_LONG_ABOUT),
+            examples: vec![
+                "newton serve",
+                "newton serve --host 0.0.0.0 --port 9000",
+                "newton serve --host 0.0.0.0 --port 8080 &",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "host",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("host"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Host address to bind the server to (default: 127.0.0.1)",
+                },
+                ArgSpec {
+                    name: "port",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("port"),
+                    value_type: ArgValueType::Int,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Port to listen on (default: 8080)",
+                },
+                ArgSpec {
+                    name: "ui-dir",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("ui-dir"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the built Newton UI dist directory (optional)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = ServeArgs::try_from(args)?;
+                commands::serve(dto).await.map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn monitor_command() -> Command {
+    Command {
+        id: "monitor",
+        summary: "Monitor live ailoop channels via a terminal UI",
+        syntax: Some("[OPTIONS]"),
+        category: Some("server"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Monitor live ailoop channels via a terminal UI",
+            long_about: Some(MONITOR_LONG_ABOUT),
+            examples: vec![
+                "newton monitor --http-url http://127.0.0.1:8081 --ws-url ws://127.0.0.1:8080",
+                "newton monitor",
+                "newton monitor --http-url http://192.168.1.10:8081",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "http-url",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("http-url"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Override HTTP endpoint for the ailoop server",
+                },
+                ArgSpec {
+                    name: "ws-url",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("ws-url"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Override WebSocket endpoint for the ailoop server",
+                },
+                ArgSpec {
+                    name: "backend",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("backend"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Also start the HTTP API backend server",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = MonitorArgs::try_from(args)?;
+                commands::monitor(dto).await
+            })
+        }),
+    }
+}
+
+fn validate_command() -> Command {
+    Command {
+        id: "validate",
+        summary: "Validate a workflow graph definition",
+        syntax: Some("[WORKFLOW] [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Validate a workflow graph definition",
+            long_about: Some(VALIDATE_LONG_ABOUT),
+            examples: vec![
+                "newton validate workflow.yaml",
+                "newton validate --file ./workflows/my-workflow.yaml",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = ValidateArgs::try_from(args)?;
+                commands::validate(dto).map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn dot_command() -> Command {
+    Command {
+        id: "dot",
+        summary: "Generate a visual diagram of the workflow graph",
+        syntax: Some("[WORKFLOW] [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Generate a visual diagram of the workflow graph",
+            long_about: Some(DOT_LONG_ABOUT),
+            examples: vec![
+                "newton dot workflow.yaml",
+                "newton dot workflow.yaml --out graph.dot",
+                "newton dot workflow.yaml --out graph.dot && dot -Tpng graph.dot -o workflow.png",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+                ArgSpec {
+                    name: "out",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("out"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Write DOT output to file instead of stdout",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = DotArgs::try_from(args)?;
+                commands::dot(dto).map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn lint_command() -> Command {
+    Command {
+        id: "lint",
+        summary: "Check workflow for best practices and potential issues",
+        syntax: Some("[WORKFLOW] [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Check workflow for best practices and potential issues",
+            long_about: Some(LINT_LONG_ABOUT),
+            examples: vec![
+                "newton lint workflow.yaml",
+                "newton lint workflow.yaml --format json",
+                "newton lint --file ./workflows/production.yaml --format json",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+                ArgSpec {
+                    name: "format",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("format"),
+                    value_type: ArgValueType::Enum(vec!["text", "json", "prose"]),
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Output format: text (default), json, prose",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = LintArgs::try_from(args)?;
+                commands::lint(dto).map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn explain_command() -> Command {
+    Command {
+        id: "explain",
+        summary: "Generate human-readable explanations of workflow behavior",
+        syntax: Some("[WORKFLOW] [OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Generate human-readable explanations of workflow behavior",
+            long_about: Some(EXPLAIN_LONG_ABOUT),
+            examples: vec![
+                "newton explain workflow.yaml --format text",
+                "newton explain workflow.yaml --format prose",
+                "newton explain workflow.yaml --arg env=production --format prose",
+                "newton explain workflow.yaml --format json",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace root directory",
+                },
+                ArgSpec {
+                    name: "set",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("set"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Repeated,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Merge KEY=VALUE into workflow.context at runtime (repeatable)",
+                },
+                ArgSpec {
+                    name: "arg",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("arg"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Repeated,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Trigger payload override KEY=VALUE (repeatable)",
+                },
+                ArgSpec {
+                    name: "format",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("format"),
+                    value_type: ArgValueType::Enum(vec!["text", "json", "prose"]),
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Output format: text (default), json, prose",
+                },
+                ArgSpec {
+                    name: "trigger-json",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("trigger-json"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to JSON file containing manual trigger payload",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = ExplainArgs::try_from(args)?;
+                commands::explain(dto).map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn resume_command() -> Command {
+    Command {
+        id: "resume",
+        summary: "Continue a workflow that was interrupted or stopped",
+        syntax: Some("[OPTIONS]"),
+        category: Some("workflow"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Continue a workflow that was interrupted or stopped",
+            long_about: Some(RESUME_LONG_ABOUT),
+            examples: vec![
+                "newton resume --execution-id 12345678-1234-1234-1234-123456789abc",
+                "newton resume --execution-id abcdef01-2345-6789-abcd-ef0123456789 --workspace ./project",
+                "newton resume --execution-id 12345678-1234-1234-1234-123456789abc --allow-workflow-change",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "execution-id",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("execution-id"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "UUID of the workflow execution to resume",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace root directory",
+                },
+                ArgSpec {
+                    name: "allow-workflow-change",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("allow-workflow-change"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Allow resuming even if the workflow definition changed since checkpoint",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let dto = ResumeArgs::try_from(args)?;
+                commands::resume(dto).await.map_err(anyhow::Error::from)
+            })
+        }),
+    }
+}
+
+fn checkpoints_command() -> Command {
+    Command {
+        id: "checkpoints",
+        summary: "Manage and inspect workflow execution checkpoints",
+        syntax: Some("<list|clean> [OPTIONS]"),
+        category: Some("management"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Manage and inspect workflow execution checkpoints",
+            long_about: Some(CHECKPOINTS_LONG_ABOUT),
+            examples: vec![
+                "newton checkpoints list --workspace ./workspace",
+                "newton checkpoints list --workspace ./workspace --format-json",
+                "newton checkpoints clean --workspace ./workspace --older-than 7d",
+                "newton checkpoints clean --workspace ./workspace --older-than 30d",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "subcommand",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::Enum(vec!["list", "clean"]),
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Subcommand: list or clean",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace path",
+                },
+                ArgSpec {
+                    name: "format-json",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("format-json"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Output as JSON (list only)",
+                },
+                ArgSpec {
+                    name: "older-than",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("older-than"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Duration threshold for clean (e.g. 7d, 1w, 24h); required for clean",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let subcmd = args
+                    .named
+                    .get("subcommand")
+                    .map(String::as_str)
+                    .unwrap_or("");
+                match subcmd {
+                    "list" => {
+                        let dto = CheckpointsArgs {
+                            command: CheckpointCommand::List {
+                                workspace: get_opt_path(&args, "workspace"),
+                                format_json: get_bool(&args, "format-json"),
+                            },
+                        };
+                        commands::checkpoints(dto).map_err(anyhow::Error::from)
+                    }
+                    "clean" => {
+                        let older_than =
+                            args.named.get("older-than").cloned().ok_or_else(|| {
+                                anyhow!(
+                                    "{}: --older-than is required for checkpoints clean",
+                                    error_codes::CLI_MIG_002
+                                )
+                            })?;
+                        let dto = CheckpointsArgs {
+                            command: CheckpointCommand::Clean {
+                                workspace: get_opt_path(&args, "workspace"),
+                                older_than,
+                            },
+                        };
+                        commands::checkpoints(dto).map_err(anyhow::Error::from)
+                    }
+                    _ => Err(anyhow!(
+                        "{}: unknown checkpoints subcommand '{}'",
+                        error_codes::CLI_MIG_005,
+                        subcmd
+                    )),
+                }
+            })
+        }),
+    }
+}
+
+fn artifacts_command() -> Command {
+    Command {
+        id: "artifacts",
+        summary: "Manage workflow output files and execution artifacts",
+        syntax: Some("<clean> [OPTIONS]"),
+        category: Some("management"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Manage workflow output files and execution artifacts",
+            long_about: Some(ARTIFACTS_LONG_ABOUT),
+            examples: vec![
+                "newton artifacts clean --workspace ./workspace --older-than 7d",
+                "newton artifacts clean --workspace ./workspace --older-than 30d",
+                "newton artifacts clean --workspace /path/to/project --older-than 1w",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "subcommand",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::Enum(vec!["clean"]),
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Subcommand: clean",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace path",
+                },
+                ArgSpec {
+                    name: "older-than",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("older-than"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Duration threshold (e.g. 7d, 30d, 1w); required for clean",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let subcmd = args
+                    .named
+                    .get("subcommand")
+                    .map(String::as_str)
+                    .unwrap_or("");
+                match subcmd {
+                    "clean" => {
+                        let older_than =
+                            args.named.get("older-than").cloned().ok_or_else(|| {
+                                anyhow!(
+                                    "{}: --older-than is required for artifacts clean",
+                                    error_codes::CLI_MIG_002
+                                )
+                            })?;
+                        let dto = ArtifactsArgs {
+                            command: ArtifactCommand::Clean {
+                                workspace: get_opt_path(&args, "workspace"),
+                                older_than,
+                            },
+                        };
+                        commands::artifacts(dto).map_err(anyhow::Error::from)
+                    }
+                    _ => Err(anyhow!(
+                        "{}: unknown artifacts subcommand '{}'",
+                        error_codes::CLI_MIG_005,
+                        subcmd
+                    )),
+                }
+            })
+        }),
+    }
+}
+
+fn webhook_command() -> Command {
+    Command {
+        id: "webhook",
+        summary: "Run webhooks to trigger workflows from external events",
+        syntax: Some("<serve|status> [WORKFLOW] --workspace <PATH>"),
+        category: Some("integration"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "Run webhooks to trigger workflows from external events",
+            long_about: Some(WEBHOOK_LONG_ABOUT),
+            examples: vec![
+                "newton webhook serve workflow.yaml --workspace ./workspace",
+                "newton webhook status workflow.yaml --workspace ./workspace",
+                "newton webhook serve --file ./workflows/deploy.yaml --workspace ./project",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "subcommand",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::Enum(vec!["serve", "status"]),
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Subcommand: serve or status",
+                },
+                ArgSpec {
+                    name: "workflow",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file",
+                },
+                ArgSpec {
+                    name: "file",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("file"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path to the workflow YAML file (alternative to positional; takes precedence)",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace root directory (required)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let subcmd = args.named.get("subcommand").map(String::as_str).unwrap_or("").to_string();
+                let workspace_str = args
+                    .named
+                    .get("workspace")
+                    .cloned()
+                    .ok_or_else(|| anyhow!("{}: --workspace is required for webhook {}", error_codes::CLI_MIG_002, subcmd))?;
+                let workspace = PathBuf::from(workspace_str);
+                let workflow_pos = get_opt_path(&args, "workflow");
+                let file = get_opt_path(&args, "file");
+                if let (Some(f), Some(p)) = (&file, &workflow_pos) {
+                    if f != p {
+                        return Err(anyhow!(
+                            "{}: --file '{}' and positional workflow '{}' disagree; use one or the other",
+                            error_codes::CLI_MIG_003, f.display(), p.display()
+                        ));
+                    }
+                }
+                match subcmd.as_str() {
+                    "serve" => {
+                        let dto = WebhookArgs {
+                            command: WebhookCommand::Serve(WebhookServeArgs {
+                                workflow_positional: workflow_pos,
+                                file,
+                                workspace,
+                            }),
+                        };
+                        commands::webhook(dto).await.map_err(anyhow::Error::from)
+                    }
+                    "status" => {
+                        let dto = WebhookArgs {
+                            command: WebhookCommand::Status(WebhookStatusArgs {
+                                workflow_positional: workflow_pos,
+                                file,
+                                workspace,
+                            }),
+                        };
+                        commands::webhook(dto).await.map_err(anyhow::Error::from)
+                    }
+                    _ => Err(anyhow!("{}: unknown webhook subcommand '{}'", error_codes::CLI_MIG_005, subcmd)),
+                }
+            })
+        }),
+    }
+}
+
+fn log_command() -> Command {
+    Command {
+        id: "log",
+        summary: "List and replay workflow execution history",
+        syntax: Some("<list|show> [OPTIONS]"),
+        category: Some("management"),
+        spec: Some(Arc::new(CommandSpec {
+            summary: "List and replay workflow execution history",
+            long_about: Some(LOG_LONG_ABOUT),
+            examples: vec![
+                "newton log list --workspace ./workspace",
+                "newton log list --last 10 --json",
+                "newton log show <execution-id> --workspace ./workspace",
+                "newton log show <execution-id> --task my-task --verbose",
+            ],
+            args: vec![
+                ArgSpec {
+                    name: "subcommand",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::Enum(vec!["list", "show"]),
+                    cardinality: Cardinality::Required,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Subcommand: list or show",
+                },
+                ArgSpec {
+                    name: "execution-id",
+                    kind: ArgKind::Positional,
+                    short: None,
+                    long: None,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Execution UUID (required for log show)",
+                },
+                ArgSpec {
+                    name: "workspace",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("workspace"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Workspace path",
+                },
+                ArgSpec {
+                    name: "last",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("last"),
+                    value_type: ArgValueType::Int,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Only list the N most recent executions (list only)",
+                },
+                ArgSpec {
+                    name: "json",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("json"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Emit machine-readable JSON",
+                },
+                ArgSpec {
+                    name: "task",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("task"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Filter output to a single task ID (show only)",
+                },
+                ArgSpec {
+                    name: "verbose",
+                    kind: ArgKind::Flag,
+                    short: Some('v'),
+                    long: Some("verbose"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Expand single-task output for debugging (show only)",
+                },
+            ],
+            ..Default::default()
+        })),
+        validator: None,
+        execute: Arc::new(|_ctx, args| {
+            Box::pin(async move {
+                let subcmd = args
+                    .named
+                    .get("subcommand")
+                    .map(String::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                match subcmd.as_str() {
+                    "list" => {
+                        let last = args
+                            .named
+                            .get("last")
+                            .map(|s| {
+                                let n: usize = s.parse().map_err(|_| {
+                                    anyhow!(
+                                        "{}: --last must be a positive integer",
+                                        error_codes::CLI_MIG_002
+                                    )
+                                })?;
+                                if n == 0 {
+                                    return Err(anyhow!(
+                                        "{}: --last must be a positive integer",
+                                        error_codes::CLI_MIG_002
+                                    ));
+                                }
+                                Ok(n)
+                            })
+                            .transpose()?;
+                        let dto = LogArgs {
+                            command: LogCommand::List {
+                                workspace: get_opt_path(&args, "workspace"),
+                                last,
+                                json: get_bool(&args, "json"),
+                            },
+                        };
+                        commands::log(dto).map_err(anyhow::Error::from)
+                    }
+                    "show" => {
+                        let exec_id_str =
+                            args.named.get("execution-id").cloned().ok_or_else(|| {
+                                anyhow!(
+                                    "{}: execution-id is required for log show",
+                                    error_codes::CLI_MIG_002
+                                )
+                            })?;
+                        let execution_id = Uuid::parse_str(&exec_id_str).map_err(|e| {
+                            anyhow!(
+                                "{}: invalid execution-id UUID: {}",
+                                error_codes::CLI_MIG_002,
+                                e
+                            )
+                        })?;
+                        let dto = LogArgs {
+                            command: LogCommand::Show {
+                                execution_id,
+                                workspace: get_opt_path(&args, "workspace"),
+                                task: get_opt_str(&args, "task"),
+                                verbose: get_bool(&args, "verbose"),
+                                json: get_bool(&args, "json"),
+                            },
+                        };
+                        commands::log(dto).map_err(anyhow::Error::from)
+                    }
+                    _ => Err(anyhow!(
+                        "{}: unknown log subcommand '{}'",
+                        error_codes::CLI_MIG_005,
+                        subcmd
+                    )),
+                }
+            })
+        }),
+    }
+}
+
+// ── public entry point ────────────────────────────────────────────────────────
+
+/// Build the Newton CLI application backed by `cli-framework`.
 ///
-/// This is the function `crates/cli/src/main.rs` will eventually call once
-/// the cli-framework dependency is wired in. Today it returns a wrapper that
-/// runs the existing clap-based dispatch so the public API surface stays
-/// stable across the staged migration.
-pub fn build_app(ctx: NewtonContext) -> Result<NewtonApp> {
-    Ok(NewtonApp { _ctx: ctx })
+/// All 14 top-level commands are registered here.  Group commands
+/// (checkpoints, artifacts, webhook, log) dispatch to their sub-actions
+/// internally via the first positional arg.
+pub fn build_app(ctx: NewtonContext) -> anyhow::Result<App<NewtonContext>> {
+    AppBuilder::new()
+        .with_version("newton", env!("CARGO_PKG_VERSION"))
+        .register_command(run_command())?
+        .register_command(init_command())?
+        .register_command(batch_command())?
+        .register_command(serve_command())?
+        .register_command(monitor_command())?
+        .register_command(validate_command())?
+        .register_command(dot_command())?
+        .register_command(lint_command())?
+        .register_command(explain_command())?
+        .register_command(resume_command())?
+        .register_command(checkpoints_command())?
+        .register_command(artifacts_command())?
+        .register_command(webhook_command())?
+        .register_command(log_command())?
+        .build(ctx)
+        .map_err(|e| anyhow!("{}: {}", error_codes::CLI_MIG_001, e))
+}
+
+// ── TryFrom<CommandArgs> adapters ─────────────────────────────────────────────
+//
+// Each adapter converts the framework's flat CommandArgs (named: HashMap<String,String>)
+// into the typed Newton DTO that the handler expects.
+
+impl TryFrom<CommandArgs> for RunArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let workflow_positional = get_opt_path(&args, "workflow");
+        let input_file = get_opt_path(&args, "input-file");
+        let file = get_opt_path(&args, "file");
+        // CLI-MIG-003: both positional and --file supplied with different paths
+        if let (Some(f), Some(p)) = (&file, &workflow_positional) {
+            if f != p {
+                return Err(anyhow!(
+                    "{}: --file '{}' and positional workflow '{}' disagree",
+                    error_codes::CLI_MIG_003,
+                    f.display(),
+                    p.display()
+                ));
+            }
+        }
+        let workspace = get_opt_path(&args, "workspace");
+        let arg = parse_kvp_list(args.named.get("arg").map(String::as_str).unwrap_or(""))?;
+        let set = parse_kvp_list(args.named.get("set").map(String::as_str).unwrap_or(""))?;
+        let trigger_json = get_opt_path(&args, "trigger-json");
+        let parallel_limit = args
+            .named
+            .get("parallel-limit")
+            .map(|s| {
+                s.parse::<usize>().map_err(|_| {
+                    anyhow!(
+                        "{}: --parallel-limit must be a positive integer",
+                        error_codes::CLI_MIG_002
+                    )
+                })
+            })
+            .transpose()?;
+        let max_time_seconds = args
+            .named
+            .get("max-time-seconds")
+            .map(|s| {
+                s.parse::<u64>().map_err(|_| {
+                    anyhow!(
+                        "{}: --max-time-seconds must be a non-negative integer",
+                        error_codes::CLI_MIG_002
+                    )
+                })
+            })
+            .transpose()?;
+        let verbose = get_bool(&args, "verbose");
+        let server = get_opt_str(&args, "server");
+        Ok(RunArgs {
+            workflow_positional,
+            input_file,
+            file,
+            workspace,
+            arg,
+            set,
+            trigger_json,
+            parallel_limit,
+            max_time_seconds,
+            verbose,
+            server,
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for InitArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        Ok(InitArgs {
+            path: get_opt_path(&args, "path"),
+            template_source: get_opt_str(&args, "template-source"),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for BatchArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let project_id = args
+            .named
+            .get("project-id")
+            .cloned()
+            .ok_or_else(|| anyhow!("{}: project-id is required", error_codes::CLI_MIG_002))?;
+        let sleep = args
+            .named
+            .get("sleep")
+            .map(|s| {
+                s.parse::<u64>().map_err(|_| {
+                    anyhow!(
+                        "{}: --sleep must be a non-negative integer",
+                        error_codes::CLI_MIG_002
+                    )
+                })
+            })
+            .transpose()?
+            .unwrap_or(60);
+        Ok(BatchArgs {
+            project_id,
+            workspace: get_opt_path(&args, "workspace"),
+            once: get_bool(&args, "once"),
+            sleep,
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for ServeArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let host = args
+            .named
+            .get("host")
+            .cloned()
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let port = args
+            .named
+            .get("port")
+            .map(|s| {
+                s.parse::<i64>()
+                    .map_err(|_| anyhow!("{}: --port must be an integer", error_codes::CLI_MIG_002))
+                    .and_then(|n| {
+                        u16::try_from(n).map_err(|_| {
+                            anyhow!(
+                                "{}: --port must be in range 0-65535",
+                                error_codes::CLI_MIG_002
+                            )
+                        })
+                    })
+            })
+            .transpose()?
+            .unwrap_or(8080);
+        Ok(ServeArgs {
+            host,
+            port,
+            ui_dir: get_opt_path(&args, "ui-dir"),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for MonitorArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        Ok(MonitorArgs {
+            http_url: get_opt_str(&args, "http-url"),
+            ws_url: get_opt_str(&args, "ws-url"),
+            backend: get_bool(&args, "backend"),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for ValidateArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let workflow_positional = get_opt_path(&args, "workflow");
+        let file = get_opt_path(&args, "file");
+        if let (Some(f), Some(p)) = (&file, &workflow_positional) {
+            if f != p {
+                return Err(anyhow!(
+                    "{}: --file '{}' and positional workflow '{}' disagree",
+                    error_codes::CLI_MIG_003,
+                    f.display(),
+                    p.display()
+                ));
+            }
+        }
+        Ok(ValidateArgs {
+            workflow_positional,
+            file,
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for DotArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let workflow_positional = get_opt_path(&args, "workflow");
+        let file = get_opt_path(&args, "file");
+        if let (Some(f), Some(p)) = (&file, &workflow_positional) {
+            if f != p {
+                return Err(anyhow!(
+                    "{}: --file '{}' and positional workflow '{}' disagree",
+                    error_codes::CLI_MIG_003,
+                    f.display(),
+                    p.display()
+                ));
+            }
+        }
+        Ok(DotArgs {
+            workflow_positional,
+            file,
+            out: get_opt_path(&args, "out"),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for LintArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let workflow_positional = get_opt_path(&args, "workflow");
+        let file = get_opt_path(&args, "file");
+        if let (Some(f), Some(p)) = (&file, &workflow_positional) {
+            if f != p {
+                return Err(anyhow!(
+                    "{}: --file '{}' and positional workflow '{}' disagree",
+                    error_codes::CLI_MIG_003,
+                    f.display(),
+                    p.display()
+                ));
+            }
+        }
+        Ok(LintArgs {
+            workflow_positional,
+            file,
+            format: parse_output_format(&args),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for ExplainArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let workflow_positional = get_opt_path(&args, "workflow");
+        let file = get_opt_path(&args, "file");
+        if let (Some(f), Some(p)) = (&file, &workflow_positional) {
+            if f != p {
+                return Err(anyhow!(
+                    "{}: --file '{}' and positional workflow '{}' disagree",
+                    error_codes::CLI_MIG_003,
+                    f.display(),
+                    p.display()
+                ));
+            }
+        }
+        let set = parse_kvp_list(args.named.get("set").map(String::as_str).unwrap_or(""))?;
+        let arg = parse_kvp_list(args.named.get("arg").map(String::as_str).unwrap_or(""))?;
+        Ok(ExplainArgs {
+            workflow_positional,
+            file,
+            workspace: get_opt_path(&args, "workspace"),
+            set,
+            arg,
+            format: parse_output_format(&args),
+            trigger_json: get_opt_path(&args, "trigger-json"),
+        })
+    }
+}
+
+impl TryFrom<CommandArgs> for ResumeArgs {
+    type Error = anyhow::Error;
+
+    fn try_from(args: CommandArgs) -> Result<Self, Self::Error> {
+        let execution_id = args
+            .named
+            .get("execution-id")
+            .ok_or_else(|| anyhow!("{}: --execution-id is required", error_codes::CLI_MIG_002))
+            .and_then(|s| {
+                Uuid::parse_str(s).map_err(|e| {
+                    anyhow!(
+                        "{}: --execution-id must be a valid UUID: {}",
+                        error_codes::CLI_MIG_002,
+                        e
+                    )
+                })
+            })?;
+        Ok(ResumeArgs {
+            execution_id,
+            workspace: get_opt_path(&args, "workspace"),
+            allow_workflow_change: get_bool(&args, "allow-workflow-change"),
+        })
+    }
 }

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -6,7 +6,7 @@ pub mod framework_setup;
 pub mod init;
 
 pub use context::NewtonContext;
-pub use framework_setup::{build_app, NewtonApp};
+pub use framework_setup::build_app;
 
 pub use args::{
     ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,7 +1,12 @@
 //! CLI scaffolding for Newton: argument parsing, command definitions, and command dispatch logic.
 pub mod args;
 pub mod commands;
+pub mod context;
+pub mod framework_setup;
 pub mod init;
+
+pub use context::NewtonContext;
+pub use framework_setup::{build_app, NewtonApp};
 
 pub use args::{
     ArtifactCommand, ArtifactsArgs, BatchArgs, CheckpointCommand, CheckpointsArgs, DotArgs,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod cli;
 pub mod monitor;
 
-pub use cli::{build_app, NewtonApp, NewtonContext};
+pub use cli::context::NewtonContext;
+pub use cli::framework_setup::build_app;
 pub use newton_core::Result;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,5 +2,6 @@
 pub mod cli;
 pub mod monitor;
 
+pub use cli::{build_app, NewtonApp, NewtonContext};
 pub use newton_core::Result;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,10 +1,77 @@
-use clap::Parser;
+use std::path::PathBuf;
+
+use newton_cli::cli::context::NewtonContext;
+use newton_cli::cli::framework_setup::build_app;
 use newton_cli::Result;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    let args = newton_cli::cli::Args::parse();
-    let log_invocation = newton_cli::cli::log_invocation_from_command(&args.command);
-    let _log_guard = newton_core::logging::init(&log_invocation, args.log_dir.as_deref())?;
-    newton_cli::cli::run(args).await
+    let raw_args: Vec<String> = std::env::args().collect();
+    let (log_dir, app_args) = extract_log_dir(&raw_args);
+    let log_inv = infer_log_invocation(&app_args);
+    let _log_guard = newton_core::logging::init(&log_inv, log_dir.as_deref())?;
+
+    let ctx = NewtonContext::new();
+    let mut app = build_app(ctx)?;
+    app.run_with_args(app_args).await
+}
+
+/// Strip `--log-dir <value>` / `--log-dir=<value>` from argv, preserving argv[0].
+fn extract_log_dir(argv: &[String]) -> (Option<PathBuf>, Vec<String>) {
+    let mut log_dir: Option<PathBuf> = None;
+    let mut filtered: Vec<String> = Vec::with_capacity(argv.len());
+    let mut i = 0;
+    while i < argv.len() {
+        if argv[i] == "--log-dir" && i + 1 < argv.len() {
+            log_dir = Some(PathBuf::from(&argv[i + 1]));
+            i += 2;
+        } else if let Some(val) = argv[i].strip_prefix("--log-dir=") {
+            log_dir = Some(PathBuf::from(val));
+            i += 1;
+        } else {
+            filtered.push(argv[i].clone());
+            i += 1;
+        }
+    }
+    (log_dir, filtered)
+}
+
+/// Infer a `LogInvocation` from argv without full parsing — used to initialise
+/// logging before the framework dispatches.  Falls back gracefully when argv
+/// is too short or the command name is unrecognised.
+fn infer_log_invocation(argv: &[String]) -> newton_core::logging::LogInvocation {
+    use newton_core::logging::{LogInvocation, LogInvocationKind};
+
+    // argv[0] is the binary name; argv[1] is the subcommand (may be prefixed by --log-dir
+    // already stripped, but skip any remaining flags just in case).
+    let command = argv.iter().skip(1).find(|a| !a.starts_with('-'));
+
+    // Best-effort workspace extraction from --workspace flag.
+    let workspace: Option<PathBuf> = argv.windows(2).find_map(|w| {
+        if w[0] == "--workspace" {
+            Some(PathBuf::from(&w[1]))
+        } else {
+            None
+        }
+    });
+
+    let kind = match command.map(String::as_str) {
+        Some("run") => LogInvocationKind::Run,
+        Some("init") => LogInvocationKind::Init,
+        Some("batch") => LogInvocationKind::Batch,
+        Some("validate") => LogInvocationKind::Validate,
+        Some("dot") => LogInvocationKind::Dot,
+        Some("lint") => LogInvocationKind::Lint,
+        Some("explain") => LogInvocationKind::Explain,
+        Some("resume") => LogInvocationKind::Resume,
+        Some("checkpoints") => LogInvocationKind::Checkpoints,
+        Some("artifacts") => LogInvocationKind::Artifacts,
+        Some("webhook") => LogInvocationKind::Webhook,
+        Some("log") => LogInvocationKind::Log,
+        Some("monitor") => LogInvocationKind::Monitor,
+        Some("serve") => LogInvocationKind::Serve,
+        _ => LogInvocationKind::Run,
+    };
+
+    LogInvocation::new(kind, workspace)
 }


### PR DESCRIPTION
## Summary

- Replaces all direct clap 4.x wiring in `crates/cli` with the `cli-framework` `AppBuilder`/`Command`/`CommandSpec`/`ArgSpec` pattern
- Covers all 14 top-level commands: `run`, `init`, `batch`, `serve`, `monitor`, `validate`, `dot`, `lint`, `explain`, `resume`, `checkpoints`, `artifacts`, `webhook`, `log` (plus 7 nested subcommands)
- Introduces `NewtonContext` implementing `AppContext`, `build_app()` factory, and `TryFrom<CommandArgs>` adapters for all 14 DTO types
- `--log-dir` is pre-stripped from argv in `main.rs` before framework dispatch (framework has no global-option support); logging is initialised via `infer_log_invocation()` before the app runs
- Group commands (`checkpoints`, `artifacts`, `webhook`, `log`) are registered at root level and dispatch internally via their first positional argument (hierarchical routing deferred to Stage 3/4)

## Test plan

- [x] All 63 `newton-cli` tests pass (including 54 help-text parity tests and 9 integration tests)
- [x] Full suite (all crates) passes — 0 failures across ~500 tests
- [x] `cargo fmt` and `cargo clippy -D warnings` clean
- [x] Pre-push hook ran full suite and docs build before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)