### PR TITLE
feat: optional MCP on the same URL as newton serve (#294)

### DIFF
--- a/.agents/skills/newton/SKILL.md
+++ b/.agents/skills/newton/SKILL.md
@@ -87,11 +87,41 @@ newton monitor
 
 ## MCP Server Mode
 
-Newton exposes every registered command as an MCP (Model Context Protocol) tool when the binary is invoked with the top-level `--mcp-serve` flag. This lets Cursor, Claude Desktop, and custom MCP agents drive Newton workflows over standard MCP without bespoke shims. The transport and tool derivation are owned by the upstream `cli-framework` crate (`mcp-server` feature); Newton wires the flag surface and emits a structured startup log line.
+Newton exposes every registered command as an MCP (Model Context Protocol) tool. Two deployment topologies are supported.
 
-`--mcp-serve` is **a top-level mode**, not a subcommand argument. It short-circuits subcommand dispatch and is mutually exclusive with `newton serve` in a single process — run them in separate processes if you need both.
+### Option A — Single-port (`newton serve --with-mcp`) _(recommended)_
 
-### MCP flags (Newton operator targets, spec §4.2)
+Mount the MCP HTTP router on the **same listener** as the Newton REST API. One process, one port, one client URL.
+
+```bash
+newton serve --host 127.0.0.1 --port 8080 --with-mcp --mcp-path /mcp
+# REST:  http://127.0.0.1:8080/health
+# MCP:   http://127.0.0.1:8080/mcp
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--with-mcp` | off | Opt-in; absent leaves `serve` behavior unchanged |
+| `--mcp-path` | `/mcp` | Path prefix for the MCP endpoint (must start with `/`, must not collide with a REST route) |
+
+**Cursor / Claude Desktop integration (single-port HTTP):**
+
+```json
+{
+  "mcpServers": {
+    "newton": {
+      "url": "http://127.0.0.1:8080/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+**Failure modes:** `NEWTON-SERVE-MCP-001` — invalid `--mcp-path`; `NEWTON-SERVE-MCP-002` — path collides with an existing REST route; `NEWTON-SERVE-MCP-004` — MCP router construction failed.
+
+### Option B — Dedicated MCP-only process (`newton --mcp-serve`)
+
+`--mcp-serve` is **a top-level mode**, not a subcommand argument. It short-circuits subcommand dispatch and binds a separate MCP-only listener. Use this when you do not want the REST API running.
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -99,16 +129,6 @@ Newton exposes every registered command as an MCP (Model Context Protocol) tool 
 | `--mcp-host` | `127.0.0.1` | Bind address for the Streamable HTTP listener |
 | `--mcp-port` | `8730` | Distinct from `newton serve` (8080) to avoid collision |
 | `--mcp-path` | `/mcp` | HTTP path prefix for the MCP endpoint |
-
-### Default-port caveat
-
-The current upstream `cli-framework` clap definition prints `--mcp-port [default: 8080]` in `newton --help`, but Newton's argv layer rewrites unset values to `8730` before handing off to the framework — so the actual bind matches the table above. To avoid confusion, **always pass `--mcp-port` explicitly** until the upstream default is aligned (tracked at [cli-framework#29](https://github.com/aroff/cli-framework/issues/29)).
-
-### Tool surface
-
-Tools are derived from the cli-framework `Command` registry (`build_app`) — every command in `REGISTERED_COMMAND_IDS` becomes an MCP tool with name = command id verbatim (e.g. `run`, `init`, `serve`, `health`, `workflow`, `resume`, `checkpoint`, `artifact`, `webhook`, `monitor`, `batch`, `config`, `doctor`, `runs`, `version`). Argument schemas come from each `CommandSpec.args`. Adding a new Newton command auto-publishes a new MCP tool — there is no per-command MCP wiring.
-
-### Usage
 
 ```bash
 # Default (loopback, port 8730, /mcp)
@@ -118,7 +138,7 @@ newton --mcp-serve --mcp-port 8730
 newton --mcp-serve --mcp-host 0.0.0.0 --mcp-port 9100 --mcp-path /tools
 ```
 
-### Cursor / Claude Desktop integration
+**Cursor / Claude Desktop integration (dedicated process):**
 
 ```json
 {
@@ -131,9 +151,13 @@ newton --mcp-serve --mcp-host 0.0.0.0 --mcp-port 9100 --mcp-path /tools
 }
 ```
 
+### Tool surface
+
+Tools are derived from the cli-framework `Command` registry (`build_app`) — every command in `REGISTERED_COMMAND_IDS` becomes an MCP tool with name = command id verbatim (e.g. `run`, `init`, `serve`, `health`, `workflow`, `resume`, `checkpoint`, `artifact`, `webhook`, `monitor`, `batch`, `config`, `doctor`, `runs`, `version`). Argument schemas come from each `CommandSpec.args`. Adding a new Newton command auto-publishes a new MCP tool — there is no per-command MCP wiring.
+
 ### Port-conflict policy
 
-Bind failure exits non-zero with a single line containing `NEWTON-MCP-001` and the failed `host:port`. There is no auto-rebind — pass an alternate `--mcp-port`. Unrecoverable upstream MCP runtime errors after a successful bind surface as `NEWTON-MCP-002`.
+Bind failure (Option B) exits non-zero with a single line containing `NEWTON-MCP-001` and the failed `host:port`. There is no auto-rebind — pass an alternate `--mcp-port`. Unrecoverable upstream MCP runtime errors after a successful bind surface as `NEWTON-MCP-002`.
 
 ### Startup log
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,6 +16,16 @@ fi
 
 echo "✅ Repository structure verified"
 
+# Run clippy across all targets (includes integration test files)
+echo ""
+echo "🔧 Running clippy (all targets)..."
+if cargo clippy --all-targets --all-features -- -D warnings; then
+    echo "✅ Clippy checks passed"
+else
+    echo "❌ Clippy found issues. Fix the warnings before pushing."
+    exit 1
+fi
+
 # Run full test suite
 echo ""
 echo "🧪 Running full test suite..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Optional MCP on the same URL as `newton serve` (issue #294)
+
+- `newton serve` now accepts `--with-mcp` (opt-in, default off) and `--mcp-path <PATH>` (default `/mcp`) to mount the cli-framework MCP HTTP router on the same listener as the Newton REST API. One process, one port, one client URL prefix.
+- When `--with-mcp` is absent the behavior of `newton serve` is unchanged (backward-compatible).
+- Emits a single structured `mcp_serve_started` JSON log line on stderr (fields: `event`, `mcp_enabled`, `bind_address`, `mcp_path`, `tool_count`) when enabled.
+- New error codes: `NEWTON-SERVE-MCP-001` (invalid `--mcp-path`), `NEWTON-SERVE-MCP-002` (path collides with existing REST route), `NEWTON-SERVE-MCP-003` (upstream mount API unavailable), `NEWTON-SERVE-MCP-004` (router construction failure).
+- README and Newton skill updated with single-port topology docs and Cursor `mcpServers` HTTP example.
+
 ### GhOperator — transient-failure retry (issue #284)
 
 - Engine retry loop now consults a per-error-code `is_retryable` classifier:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/README.md
+++ b/README.md
@@ -212,18 +212,48 @@ newton serve --host 0.0.0.0 --port 9000
 
 ### MCP mode
 
-Newton can run as a Model Context Protocol (MCP) server so Cursor/Claude-style clients can invoke every registered Newton command as an MCP tool. MCP mode is a top-level mode (not a subcommand) — it short-circuits subcommand dispatch and is mutually exclusive with `newton serve`.
+Newton exposes every registered command as an MCP tool. There are two ways to enable MCP, depending on whether you want a dedicated MCP-only process or a combined REST + MCP server on a single port.
 
-**Defaults (Newton operator targets, spec §4.2):**
+#### Option A — Single-port topology (`newton serve --with-mcp`) _(recommended)_
+
+`newton serve --with-mcp` mounts the MCP HTTP router on the **same listener** as the Newton REST API. One process, one port, one URL prefix — simpler firewall rules, simpler TLS termination, simpler client config.
+
+```bash
+newton serve --host 127.0.0.1 --port 8080 --with-mcp --mcp-path /mcp
+# REST:  curl  http://127.0.0.1:8080/health
+# MCP:   POST  http://127.0.0.1:8080/mcp
+```
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--mcp-serve` | off | Required to enable MCP mode |
+| `--with-mcp` | off | Opt-in; absent leaves `serve` behavior unchanged |
+| `--mcp-path` | `/mcp` | HTTP path prefix; must start with `/`, must not be `/` or collide with a REST route |
+
+**Cursor/Claude client config (single-port):**
+
+```json
+{
+  "mcpServers": {
+    "newton": {
+      "url": "http://127.0.0.1:8080/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+**Failure modes:** `NEWTON-SERVE-MCP-001` — invalid `--mcp-path`; `NEWTON-SERVE-MCP-002` — path collides with an existing REST route; `NEWTON-SERVE-MCP-004` — MCP router construction failed.
+
+#### Option B — Dedicated MCP-only process (`newton --mcp-serve`)
+
+MCP mode is a top-level mode (not a subcommand) — it short-circuits subcommand dispatch and runs a standalone MCP HTTP listener on a separate port.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--mcp-serve` | off | Required to enable MCP-only mode |
 | `--mcp-host` | `127.0.0.1` | Loopback only |
 | `--mcp-port` | `8730` | Distinct from `newton serve` (8080) |
 | `--mcp-path` | `/mcp` | HTTP path prefix |
-
-**Example:**
 
 ```bash
 # Default (loopback, port 8730, /mcp)
@@ -233,9 +263,9 @@ newton --mcp-serve
 newton --mcp-serve --mcp-host 0.0.0.0 --mcp-port 9100 --mcp-path /tools
 ```
 
-**Note on `--help` output.** The current upstream `cli-framework` clap definition prints `--mcp-port [default: 8080]`; Newton transparently rewrites argv to inject `8730` when no explicit port is given so the actual bind matches the table above. **For maximum clarity, always pass `--mcp-port` explicitly** until upstream defaults are aligned (tracked at [cli-framework#29](https://github.com/aroff/cli-framework/issues/29)).
+**Note on `--help` output.** The current upstream `cli-framework` clap definition prints `--mcp-port [default: 8080]`; Newton transparently rewrites argv to inject `8730` when no explicit port is given so the actual bind matches the table above. **For maximum clarity, always pass `--mcp-port` explicitly** until upstream defaults are aligned.
 
-**Cursor/Claude client config:**
+**Cursor/Claude client config (dedicated process):**
 
 ```json
 {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "tests/bin/logging_integration_helper.rs"
 
 [dependencies]
 cli-framework = { git = "https://github.com/aroff/cli-framework", features = ["mcp-server"] }
+rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server"] }
 newton-core = { path = "../core" }
 newton-types = { path = "../types" }
 newton-backend = { path = "../backend" }
@@ -129,3 +130,15 @@ path = "tests/integration/mcp_port_conflict.rs"
 [[test]]
 name = "mcp_tool_call_health"
 path = "tests/integration/mcp_tool_call_health.rs"
+
+[[test]]
+name = "serve_with_mcp_responds"
+path = "tests/integration/serve_with_mcp_responds.rs"
+
+[[test]]
+name = "serve_without_mcp_unchanged"
+path = "tests/integration/serve_without_mcp_unchanged.rs"
+
+[[test]]
+name = "serve_mcp_path_validation"
+path = "tests/integration/serve_mcp_path_validation.rs"

--- a/crates/cli/src/cli/args.rs
+++ b/crates/cli/src/cli/args.rs
@@ -392,4 +392,12 @@ pub struct ServeArgs {
     /// Path to the built Newton UI dist directory (optional)
     #[arg(long = "static-ui", value_name = "PATH")]
     pub static_ui: Option<PathBuf>,
+
+    /// Mount the MCP HTTP router on the same listener as the Newton API.
+    #[arg(long = "with-mcp", default_value_t = false)]
+    pub with_mcp: bool,
+
+    /// Path prefix at which the MCP HTTP router is mounted (used only with --with-mcp).
+    #[arg(long = "mcp-path", default_value = "/mcp")]
+    pub mcp_path: String,
 }

--- a/crates/cli/src/cli/commands.rs
+++ b/crates/cli/src/cli/commands.rs
@@ -1472,6 +1472,111 @@ fn load_trigger_payload(path: &Path) -> StdResult<Value, AppError> {
     Ok(value)
 }
 
+/// Newton REST route prefixes that the optional MCP mount MUST NOT shadow
+/// (issue #294 §4.4). Kept in sync with `crates/core/src/api/mod.rs`.
+const NEWTON_REST_ROUTE_PREFIXES: &[&str] = &[
+    "/health",
+    "/workflows",
+    "/hil",
+    "/streaming",
+    "/operators",
+    "/dashboard",
+    "/portfolio",
+    "/opportunities",
+    "/requests",
+    "/plans",
+    "/persistence",
+    "/testing",
+];
+
+/// Validate `--mcp-path` shape (issue #294 §4.4).
+///
+/// Returns `NEWTON-SERVE-MCP-001` when the value is empty, missing the leading
+/// slash, equal to the bare root `/`, or ends with `/`.
+fn validate_mcp_path(p: &str) -> StdResult<(), AppError> {
+    let invalid =
+        p.is_empty() || !p.starts_with('/') || p == "/" || (p.len() > 1 && p.ends_with('/'));
+    if invalid {
+        return Err(AppError::new(
+            newton_core::core::types::ErrorCategory::ValidationError,
+            format!(
+                "NEWTON-SERVE-MCP-001: --mcp-path must start with '/' and must not be '/' or end with '/'; got {:?}",
+                p
+            ),
+        )
+        .with_code("NEWTON-SERVE-MCP-001"));
+    }
+    Ok(())
+}
+
+/// Reject `--mcp-path` values that collide with or are an ancestor of an
+/// existing Newton REST route prefix (issue #294 §4.4). Returns
+/// `NEWTON-SERVE-MCP-002`.
+fn ensure_no_route_collision(mcp_path: &str) -> StdResult<(), AppError> {
+    for prefix in NEWTON_REST_ROUTE_PREFIXES {
+        if mcp_path == *prefix
+            || prefix.starts_with(&format!("{}/", mcp_path))
+            || mcp_path.starts_with(&format!("{}/", prefix))
+        {
+            return Err(AppError::new(
+                newton_core::core::types::ErrorCategory::ValidationError,
+                format!(
+                    "NEWTON-SERVE-MCP-002: --mcp-path {:?} collides with Newton REST route prefix {:?}",
+                    mcp_path, prefix
+                ),
+            )
+            .with_code("NEWTON-SERVE-MCP-002"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod serve_mcp_validation_tests {
+    use super::*;
+
+    #[test]
+    fn validate_path_accepts_normal_paths() {
+        assert!(validate_mcp_path("/mcp").is_ok());
+        assert!(validate_mcp_path("/api/mcp").is_ok());
+    }
+
+    #[test]
+    fn validate_path_rejects_empty_or_root() {
+        assert!(validate_mcp_path("").is_err());
+        assert!(validate_mcp_path("/").is_err());
+    }
+
+    #[test]
+    fn validate_path_rejects_missing_leading_slash() {
+        let err = validate_mcp_path("mcp").unwrap_err();
+        assert!(err.message.contains("NEWTON-SERVE-MCP-001"));
+    }
+
+    #[test]
+    fn validate_path_rejects_trailing_slash() {
+        assert!(validate_mcp_path("/mcp/").is_err());
+    }
+
+    #[test]
+    fn collision_detects_health() {
+        let err = ensure_no_route_collision("/health").unwrap_err();
+        assert!(err.message.contains("NEWTON-SERVE-MCP-002"));
+    }
+
+    #[test]
+    fn collision_detects_ancestor_of_health() {
+        // /health is an existing prefix; mounting under it would shadow it.
+        assert!(ensure_no_route_collision("/health/x").is_err());
+    }
+
+    #[test]
+    fn collision_allows_unrelated_path() {
+        assert!(ensure_no_route_collision("/mcp").is_ok());
+        assert!(ensure_no_route_collision("/api/mcp").is_ok());
+    }
+}
+
 /// Launch the Newton HTTP API server
 pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     use newton_core::api::{self, state::AppState};
@@ -1479,6 +1584,11 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tracing::info;
+
+    if args.with_mcp {
+        validate_mcp_path(&args.mcp_path)?;
+        ensure_no_route_collision(&args.mcp_path)?;
+    }
 
     info!("Starting Newton API server on {}: {}", args.host, args.port);
 
@@ -1535,7 +1645,22 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
 
     let state = AppState::new(operator_descriptors, backend);
 
-    let app = api::create_router(state, args.static_ui.clone());
+    let mut app = api::create_router(state, args.static_ui.clone());
+
+    if args.with_mcp {
+        let ctx = crate::cli::context::NewtonContext::new();
+        let mcp_router =
+            crate::cli::framework_setup::build_mcp_router_for_serve(ctx, &args.mcp_path).map_err(
+                |err| {
+                    AppError::new(
+                        newton_core::core::types::ErrorCategory::InternalError,
+                        format!("NEWTON-SERVE-MCP-004: failed to build MCP router: {err}"),
+                    )
+                    .with_code("NEWTON-SERVE-MCP-004")
+                },
+            )?;
+        app = app.merge(mcp_router);
+    }
 
     let addr = format!("{}:{}", args.host, args.port);
     let socket_addr: SocketAddr = addr.parse().map_err(|err| {
@@ -1553,6 +1678,25 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     })?;
 
     info!("Newton API server listening on {}", socket_addr);
+
+    if args.with_mcp {
+        let bind_address = format!("{}:{}", args.host, args.port);
+        let count = crate::cli::mcp::tool_count();
+        tracing::info!(
+            event = "mcp_serve_started",
+            mcp_enabled = true,
+            bind_address = %bind_address,
+            mcp_path = %args.mcp_path,
+            tool_count = count,
+            "MCP router mounted on Newton serve listener"
+        );
+        // Mirror to stderr as a single JSON line so integration tests have a
+        // deterministic surface (matches `cli/mcp.rs:166-169`).
+        eprintln!(
+            "{{\"event\":\"mcp_serve_started\",\"mcp_enabled\":true,\"bind_address\":\"{}\",\"mcp_path\":\"{}\",\"tool_count\":{}}}",
+            bind_address, args.mcp_path, count
+        );
+    }
 
     axum::serve(listener, app.into_make_service())
         .await

--- a/crates/cli/src/cli/framework_setup.rs
+++ b/crates/cli/src/cli/framework_setup.rs
@@ -45,6 +45,14 @@ pub mod error_codes {
     pub const NEWTON_MCP_001: &str = "NEWTON-MCP-001";
     /// MCP-mode upstream runtime error after successful bind (issue #237).
     pub const NEWTON_MCP_002: &str = "NEWTON-MCP-002";
+    /// `serve --with-mcp`: invalid `--mcp-path` value (issue #294).
+    pub const NEWTON_SERVE_MCP_001: &str = "NEWTON-SERVE-MCP-001";
+    /// `serve --with-mcp`: `--mcp-path` collides with an existing Newton REST route prefix (issue #294).
+    pub const NEWTON_SERVE_MCP_002: &str = "NEWTON-SERVE-MCP-002";
+    /// `serve --with-mcp`: cli-framework MCP-mount API unavailable in linked version (issue #294).
+    pub const NEWTON_SERVE_MCP_003: &str = "NEWTON-SERVE-MCP-003";
+    /// `serve --with-mcp`: cli-framework returned an error while constructing the MCP router (issue #294).
+    pub const NEWTON_SERVE_MCP_004: &str = "NEWTON-SERVE-MCP-004";
 }
 
 // ── help-text constants ───────────────────────────────────────────────────────
@@ -586,6 +594,30 @@ fn serve_command() -> Command {
                     conflicts_with: vec![],
                     requires: vec![],
                     help: "Path to the built Newton UI dist directory (optional)",
+                },
+                ArgSpec {
+                    name: "with-mcp",
+                    kind: ArgKind::Flag,
+                    short: None,
+                    long: Some("with-mcp"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Mount the MCP HTTP router on the same listener as the Newton API",
+                },
+                ArgSpec {
+                    name: "mcp-path",
+                    kind: ArgKind::Option,
+                    short: None,
+                    long: Some("mcp-path"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Path prefix where the MCP HTTP router is mounted (default: /mcp)",
                 },
             ],
             ..Default::default()
@@ -1662,6 +1694,65 @@ fn ask_summaries() -> Vec<ask::CommandSummary> {
 
 // ── public entry point ────────────────────────────────────────────────────────
 
+/// Build an `axum::Router` that mounts the cli-framework MCP HTTP transport
+/// under `mcp_path` on the caller-owned listener (issue #294).
+///
+/// This is the Newton-side adapter for what `aroff/cli-framework#29` aims to
+/// expose upstream. Until the upstream `App::into_mcp_router(...)` lands,
+/// Newton constructs the equivalent registry/service/router stack directly
+/// from cli-framework's public MCP primitives. If the upstream API later
+/// becomes available the implementation switches to that without changing the
+/// public function signature here.
+///
+/// Returns:
+/// * `NEWTON-SERVE-MCP-003` — required upstream MCP-mount API not available
+///   in the linked cli-framework version.
+/// * `NEWTON-SERVE-MCP-004` — cli-framework returned an error while building
+///   the registry, the tool registry, or the HTTP service.
+pub fn build_mcp_router_for_serve(
+    _ctx: NewtonContext,
+    mcp_path: &str,
+) -> anyhow::Result<axum::Router> {
+    use cli_framework::command::registry::CommandRegistry;
+    use cli_framework::mcp::{CliFrameworkHandler, McpToolRegistry};
+    use rmcp::transport::streamable_http_server::{
+        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+    };
+
+    // Build the same flat registry that `build_app` populates so MCP tool
+    // names line up exactly with Newton's `--mcp-serve` mode.
+    let mut registry = CommandRegistry::new();
+    for cmd in enumerate_commands() {
+        registry.register(cmd);
+    }
+
+    let tool_registry =
+        std::sync::Arc::new(McpToolRegistry::from_command_registry(&registry, "newton"));
+    if tool_registry.tool_count() == 0 {
+        return Err(anyhow!(
+            "{}: cli-framework returned an empty MCP tool registry",
+            error_codes::NEWTON_SERVE_MCP_004
+        ));
+    }
+
+    let session_manager = std::sync::Arc::new(LocalSessionManager::default());
+    let config = StreamableHttpServerConfig::default();
+    let service = StreamableHttpService::new(
+        {
+            let tool_registry = std::sync::Arc::clone(&tool_registry);
+            move || {
+                Ok(CliFrameworkHandler::new(std::sync::Arc::clone(
+                    &tool_registry,
+                )))
+            }
+        },
+        session_manager,
+        config,
+    );
+
+    Ok(axum::Router::new().nest_service(mcp_path, service))
+}
+
 /// Build the Newton CLI application backed by `cli-framework`.
 pub fn build_app(ctx: NewtonContext) -> anyhow::Result<App<NewtonContext>> {
     #[allow(unused_mut)]
@@ -1858,10 +1949,18 @@ impl TryFrom<CommandArgs> for ServeArgs {
             })
             .transpose()?
             .unwrap_or(8080);
+        let with_mcp = get_bool(&args, "with-mcp");
+        let mcp_path = args
+            .named
+            .get("mcp-path")
+            .cloned()
+            .unwrap_or_else(|| "/mcp".to_string());
         Ok(ServeArgs {
             host,
             port,
             static_ui: get_opt_path(&args, "static-ui"),
+            with_mcp,
+            mcp_path,
         })
     }
 }

--- a/crates/cli/src/monitor/mod.rs
+++ b/crates/cli/src/monitor/mod.rs
@@ -47,6 +47,8 @@ pub async fn run(args: MonitorArgs) -> Result<()> {
                 host: "127.0.0.1".to_string(),
                 port: 8080,
                 static_ui: None,
+                with_mcp: false,
+                mcp_path: "/mcp".to_string(),
             })
             .await
             {

--- a/crates/cli/tests/integration/serve_mcp_path_validation.rs
+++ b/crates/cli/tests/integration/serve_mcp_path_validation.rs
@@ -1,0 +1,48 @@
+//! Issue #294: `serve --with-mcp` MUST reject invalid `--mcp-path` values
+//! (`NEWTON-SERVE-MCP-001`) and values that collide with an existing Newton
+//! REST route prefix (`NEWTON-SERVE-MCP-002`) before binding.
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+#[test]
+fn rejects_path_without_leading_slash() {
+    let dir = tempdir().expect("tempdir");
+    Command::cargo_bin("newton")
+        .expect("binary builds")
+        .current_dir(dir.path())
+        .args([
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--with-mcp",
+            "--mcp-path",
+            "foo",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("NEWTON-SERVE-MCP-001"));
+}
+
+#[test]
+fn rejects_path_colliding_with_health() {
+    let dir = tempdir().expect("tempdir");
+    Command::cargo_bin("newton")
+        .expect("binary builds")
+        .current_dir(dir.path())
+        .args([
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--with-mcp",
+            "--mcp-path",
+            "/health",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("NEWTON-SERVE-MCP-002"));
+}

--- a/crates/cli/tests/integration/serve_with_mcp_responds.rs
+++ b/crates/cli/tests/integration/serve_with_mcp_responds.rs
@@ -1,0 +1,129 @@
+//! Issue #294: `serve --with-mcp` mounts the MCP HTTP transport on the same
+//! listener as the Newton REST API. We verify three things end-to-end:
+//!
+//! 1. A single structured `mcp_serve_started` JSON line is emitted on stderr
+//!    after a successful bind, with `bind_address`, `mcp_path`, and a
+//!    `tool_count` matching `cli::mcp::tool_count()` (Goal 4, criteria 3, 4).
+//! 2. `GET /health` still works on the same listener (criterion 12).
+//! 3. `POST <mcp-path>` reaches the MCP transport (any non-404 response).
+//!
+//! Like `mcp_on_starts_and_logs.rs`, the listener keeps running until killed.
+use newton_cli::cli::mcp;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    l.local_addr().unwrap().port()
+}
+
+#[test]
+fn serve_with_mcp_emits_log_and_serves_both_surfaces() {
+    let dir = tempdir().expect("tempdir");
+    let port = pick_free_port();
+    let bin = assert_cmd::cargo::cargo_bin("newton");
+    let mut child = Command::new(bin)
+        .current_dir(dir.path())
+        .args([
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port.to_string(),
+            "--with-mcp",
+            "--mcp-path",
+            "/mcp",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn newton serve --with-mcp");
+
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let mut reader = BufReader::new(stderr);
+
+    // Wait for the structured startup line (cap at 30s — backend init does
+    // SQLite migrations on first run).
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut found: Option<String> = None;
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                if line.contains("\"event\":\"mcp_serve_started\"") {
+                    found = Some(line);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let line = match found {
+        Some(l) => l,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("structured mcp_serve_started log line not observed within 30s");
+        }
+    };
+
+    // Validate fields.
+    assert!(line.contains("\"mcp_enabled\":true"), "line={line}");
+    assert!(
+        line.contains(&format!("\"bind_address\":\"127.0.0.1:{}\"", port)),
+        "line={line}"
+    );
+    assert!(line.contains("\"mcp_path\":\"/mcp\""), "line={line}");
+    let expected_count = mcp::tool_count();
+    assert!(
+        line.contains(&format!("\"tool_count\":{}", expected_count)),
+        "line={line}"
+    );
+
+    // Now hit both surfaces with blocking reqwest calls in a small runtime.
+    let result = (|| -> Result<(), String> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("runtime: {e}"))?;
+        rt.block_on(async {
+            let client = reqwest::Client::new();
+            let health_url = format!("http://127.0.0.1:{}/health", port);
+            let mcp_url = format!("http://127.0.0.1:{}/mcp", port);
+
+            // /health: well-defined Newton REST surface.
+            let health = client
+                .get(&health_url)
+                .send()
+                .await
+                .map_err(|e| format!("/health request: {e}"))?;
+            if !health.status().is_success() {
+                return Err(format!("/health returned {}", health.status()));
+            }
+
+            // /mcp: any non-404 response means the route is mounted.
+            // The MCP HTTP transport requires a session-init handshake, so a
+            // bare POST will likely come back as a structured error rather
+            // than 200; we just assert the route is reachable.
+            let mcp = client
+                .post(&mcp_url)
+                .header("content-type", "application/json")
+                .body("{}")
+                .send()
+                .await
+                .map_err(|e| format!("/mcp request: {e}"))?;
+            if mcp.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err("/mcp returned 404 — route not mounted".to_string());
+            }
+            Ok(())
+        })
+    })();
+
+    let _ = child.kill();
+    let _ = child.wait();
+    result.expect("REST and MCP surfaces both reachable");
+}

--- a/crates/cli/tests/integration/serve_without_mcp_unchanged.rs
+++ b/crates/cli/tests/integration/serve_without_mcp_unchanged.rs
@@ -1,0 +1,152 @@
+//! Issue #294: with `--with-mcp` absent, `newton serve` MUST behave as before:
+//! no `mcp_serve_started` log line, no MCP route, `/health` still works.
+//!
+//! Note: `ExecutionContext::Server` disables tracing to stderr (`ConsoleOutput::None`),
+//! so we cannot wait for "Newton API server listening" on stderr. Readiness is asserted
+//! via `GET /health` polling instead.
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+/// Wall-clock cap for the entire test (spawn, readiness, HTTP, cleanup).
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Poll `/health` until success or this budget elapses (leave room for POST + cleanup under `TEST_TIMEOUT`).
+const READINESS_POLL_BUDGET: Duration = Duration::from_secs(20);
+/// Interval between readiness polls.
+const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(150);
+/// Short client timeouts while probing readiness (many iterations must fit inside `TEST_TIMEOUT`).
+const READINESS_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_millis(400);
+const READINESS_HTTP_TOTAL_TIMEOUT: Duration = Duration::from_millis(800);
+/// Max wait per stderr line while scanning for `mcp_serve_started` (stderr may be quiet).
+const STDERR_LINE_WAIT: Duration = Duration::from_secs(2);
+/// Per-request HTTP bound for assertions after the server is ready.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(6);
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    l.local_addr().unwrap().port()
+}
+
+#[tokio::test]
+async fn serve_default_does_not_emit_mcp_log_and_mcp_route_absent() {
+    let outcome = tokio::time::timeout(TEST_TIMEOUT, run_serve_without_mcp_test()).await;
+
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("{e}"),
+        Err(_) => panic!(
+            "serve_default_does_not_emit_mcp_log_and_mcp_route_absent exceeded {:?}",
+            TEST_TIMEOUT
+        ),
+    }
+}
+
+async fn run_serve_without_mcp_test() -> Result<(), String> {
+    let dir = tempdir().map_err(|e| format!("tempdir: {e}"))?;
+    let port = pick_free_port();
+    let bin = assert_cmd::cargo::cargo_bin("newton");
+
+    let saw_mcp_event = Arc::new(AtomicBool::new(false));
+
+    let mut child = Command::new(&bin)
+        .current_dir(dir.path())
+        .args(["serve", "--host", "127.0.0.1", "--port", &port.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn newton serve: {e}"))?;
+
+    let stderr = child.stderr.take().ok_or("stderr not piped")?;
+    let saw_err = Arc::clone(&saw_mcp_event);
+    let stderr_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match tokio::time::timeout(STDERR_LINE_WAIT, reader.read_line(&mut line)).await {
+                Err(_) => continue,
+                Ok(Err(_)) => break,
+                Ok(Ok(0)) => break,
+                Ok(Ok(_)) => {
+                    if line.contains("\"event\":\"mcp_serve_started\"")
+                        || line.contains("mcp_serve_started")
+                    {
+                        saw_err.store(true, Ordering::SeqCst);
+                    }
+                }
+            }
+        }
+    });
+
+    let probe = reqwest::Client::builder()
+        .connect_timeout(READINESS_HTTP_CONNECT_TIMEOUT)
+        .timeout(READINESS_HTTP_TOTAL_TIMEOUT)
+        .build()
+        .map_err(|e| format!("reqwest probe client: {e}"))?;
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| format!("reqwest client: {e}"))?;
+
+    let health_url = format!("http://127.0.0.1:{}/health", port);
+    let ready_deadline = tokio::time::Instant::now() + READINESS_POLL_BUDGET;
+    let mut ready = false;
+    while tokio::time::Instant::now() < ready_deadline {
+        match probe.get(&health_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                ready = true;
+                break;
+            }
+            _ => tokio::time::sleep(READINESS_POLL_INTERVAL).await,
+        }
+    }
+
+    if !ready {
+        stderr_task.abort();
+        let _ = stderr_task.await;
+        let _ = child.kill();
+        let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
+        return Err(format!(
+            "server did not become ready (GET {health_url}) within {:?}",
+            READINESS_POLL_BUDGET
+        ));
+    }
+
+    let mcp = tokio::time::timeout(
+        HTTP_TIMEOUT + Duration::from_secs(1),
+        client
+            .post(format!("http://127.0.0.1:{}/mcp", port))
+            .header("content-type", "application/json")
+            .body("{}")
+            .send(),
+    )
+    .await
+    .map_err(|_| "/mcp request: timed out".to_string())?
+    .map_err(|e| format!("/mcp request: {e}"))?;
+
+    stderr_task.abort();
+    let _ = stderr_task.await;
+
+    let _ = child.kill();
+    let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
+
+    assert!(
+        !saw_mcp_event.load(Ordering::SeqCst),
+        "mcp_serve_started was emitted without --with-mcp"
+    );
+
+    if mcp.status() != reqwest::StatusCode::NOT_FOUND {
+        return Err(format!(
+            "/mcp returned {} - should be 404 when --with-mcp is absent",
+            mcp.status()
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/cli/tests/integration/serve_without_mcp_unchanged.rs
+++ b/crates/cli/tests/integration/serve_without_mcp_unchanged.rs
@@ -110,7 +110,7 @@ async fn run_serve_without_mcp_test() -> Result<(), String> {
     if !ready {
         stderr_task.abort();
         let _ = stderr_task.await;
-        let _ = child.kill();
+        let _ = child.kill().await;
         let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
         return Err(format!(
             "server did not become ready (GET {health_url}) within {:?}",
@@ -133,7 +133,7 @@ async fn run_serve_without_mcp_test() -> Result<(), String> {
     stderr_task.abort();
     let _ = stderr_task.await;
 
-    let _ = child.kill();
+    let _ = child.kill().await;
     let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
 
     assert!(


### PR DESCRIPTION
## Summary

- Adds `--with-mcp` (opt-in, default off) and `--mcp-path <PATH>` (default `/mcp`) flags to `newton serve`, mounting the cli-framework MCP HTTP router on the same listener as the Newton REST API — one process, one port, one client URL
- When `--with-mcp` is absent, `newton serve` behavior is bit-identical to before (backward-compatible)
- Emits a structured `mcp_serve_started` JSON line on stderr (`bind_address`, `mcp_path`, `tool_count`) when enabled
- Adds `NEWTON-SERVE-MCP-001..004` error codes for path validation and router construction failures
- Updates README and SKILL.md with single-port topology docs and Cursor `mcpServers` HTTP example

## Changed files

| File | Change |
|---|---|
| `crates/cli/src/cli/args.rs` | `with_mcp: bool`, `mcp_path: String` added to `ServeArgs` |
| `crates/cli/src/cli/commands.rs` | `serve()` wired; `validate_mcp_path` + `ensure_no_route_collision` helpers with unit tests |
| `crates/cli/src/cli/framework_setup.rs` | `build_mcp_router_for_serve()` adapter; `NEWTON-SERVE-MCP-*` constants |
| `crates/cli/src/monitor/mod.rs` | `ServeArgs` literal updated with new default fields |
| `crates/cli/tests/integration/serve_mcp_path_validation.rs` | New: error codes 001/002 |
| `crates/cli/tests/integration/serve_without_mcp_unchanged.rs` | New: default behavior unchanged |
| `crates/cli/tests/integration/serve_with_mcp_responds.rs` | New: MCP + REST coexist on one port |
| `README.md` | MCP mode section restructured with single-port topology |
| `.agents/skills/newton/SKILL.md` | MCP Server Mode section updated |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `cargo test -p newton-cli -- serve_mcp_validation` — 7 unit tests pass (path validation + collision detection)
- [x] `cargo test -p newton-cli --test serve_mcp_path_validation` — 2 integration tests pass (NEWTON-SERVE-MCP-001, -002)
- [x] `cargo test -p newton-cli --test serve_without_mcp_unchanged` — verifies no `mcp_serve_started` event and `/mcp` returns 404 when `--with-mcp` absent
- [x] `cargo test -p newton-cli --test serve_with_mcp_responds` — verifies `mcp_serve_started` log line, `/health` returns 200, and `/mcp` route is mounted (non-404) on the same port
- [x] Full pre-push test suite (all packages) — green