### PR TITLE
feat: implement 309-feat-cli-mcp-allowlist-with-exposemcponly-for-curated-tools

### DIFF
--- a/.agents/skills/newton/SKILL.md
+++ b/.agents/skills/newton/SKILL.md
@@ -85,7 +85,7 @@ newton resume --run-id <uuid> --workspace .
 
 ## MCP Server Mode
 
-Newton exposes every registered command as an MCP (Model Context Protocol) tool. Two deployment topologies are supported.
+Newton exposes a curated subset of commands as MCP (Model Context Protocol) tools via the `ExposeMcpOnly` policy. Two deployment topologies are supported.
 
 ### Option A — Single-port (`newton serve --with-mcp`) _(recommended)_
 
@@ -151,7 +151,18 @@ newton --mcp-serve --mcp-host 0.0.0.0 --mcp-port 9100 --mcp-path /tools
 
 ### Tool surface
 
-Tools are derived from the cli-framework `Command` registry (`build_app`) — every command in `REGISTERED_COMMAND_IDS` becomes an MCP tool with name = command id verbatim (e.g. `run`, `init`, `serve`, `health`, `workflow`, `resume`, `checkpoint`, `artifact`, `webhook`, `batch`, `config`, `doctor`, `runs`, `version`). Argument schemas come from each `CommandSpec.args`. Adding a new Newton command auto-publishes a new MCP tool — there is no per-command MCP wiring.
+Newton uses `McpToolExportPolicy::ExposeMcpOnly` for both MCP entry points. Only the following six commands are exposed as MCP tools (issue #309):
+
+| MCP tool name | Command | Notes |
+| --- | --- | --- |
+| `newton.run` | `run` | Execute a workflow graph from YAML |
+| `newton.workflow` | `workflow` | validate / lint / preview / graph via positional `subcommand` |
+| `newton.resume` | `resume` | Resume interrupted runs by UUID |
+| `newton.runs` | `runs` | List and replay execution history via positional `subcommand` |
+| `newton.health` | `health` | Liveness probe |
+| `newton.config` | `config` | Redacted configuration inspection |
+
+The following commands are **NOT** available as MCP tools: `newton.init`, `newton.batch`, `newton.serve`, `newton.checkpoint`, `newton.artifact`, `newton.webhook`, `newton.doctor`, `newton.completion`. Adding a new Newton command does **not** automatically expose it as an MCP tool — it must have `expose_mcp: true` set in its `Command` definition.
 
 ### Port-conflict policy
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -141,6 +141,10 @@ name = "serve_mcp_path_validation"
 path = "tests/integration/serve_mcp_path_validation.rs"
 
 [[test]]
+name = "mcp_expose_mcp_only"
+path = "tests/integration/mcp_expose_mcp_only.rs"
+
+[[test]]
 name = "test_e2e_smoke"
 path = "tests/integration/test_e2e_smoke.rs"
 

--- a/crates/cli/src/cli/framework_setup.rs
+++ b/crates/cli/src/cli/framework_setup.rs
@@ -3,6 +3,15 @@
 //! All Command / CommandSpec / ArgSpec declarations and the `build_app()`
 //! entry point used by `crates/cli/src/main.rs` live here.
 //!
+//! ## MCP tool surface (issue #309)
+//!
+//! Newton uses `McpToolExportPolicy::ExposeMcpOnly` for both MCP entry points
+//! (`newton --mcp-serve` and `newton serve --with-mcp`). Only commands with
+//! `expose_mcp: true` appear in `tools/list`. The curated allowlist is:
+//! `config`, `health`, `resume`, `run`, `runs`, `workflow`.
+//! All other commands (`init`, `batch`, `serve`, `checkpoint`, `artifact`,
+//! `webhook`, `doctor`, `completion`, `ask`) are excluded from the MCP surface.
+//!
 //! ## Nested-command note
 //! The framework routes via its root-level `commands` map; nested paths in
 //! `tree_commands` are not yet dispatched by the clap adapter.  Group
@@ -409,12 +418,7 @@ fn run_command() -> Command {
                 commands::run(dto).await
             })
         }),
-        // MCP tool exposure is managed at the serve layer via `newton serve
-        // --with-mcp` (issue #294), not per-command. All commands set
-        // `expose_mcp: false` so the cli-framework does not create a parallel
-        // per-command MCP export path; the unified MCP router reuses the same
-        // `CommandRegistry` and exposes every command as a tool automatically.
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -821,7 +825,7 @@ fn workflow_command() -> Command {
                 }
             })
         }),
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -886,7 +890,7 @@ fn resume_command() -> Command {
                 commands::resume(dto).await.map_err(anyhow::Error::from)
             })
         }),
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -1367,7 +1371,7 @@ fn runs_command() -> Command {
                 }
             })
         }),
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -1391,7 +1395,7 @@ fn health_command() -> Command {
         })),
         validator: None,
         execute: Arc::new(|_ctx, _args| Box::pin(async move { ops::health::run() })),
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -1505,7 +1509,7 @@ fn config_command() -> Command {
                 ops::config_show::run(ops::config_show::ConfigShowArgs { workspace })
             })
         }),
-        expose_mcp: false,
+        expose_mcp: true,
     }
 }
 
@@ -1667,7 +1671,7 @@ pub fn build_mcp_router_for_serve(
     mcp_path: &str,
 ) -> anyhow::Result<axum::Router> {
     use cli_framework::command::registry::CommandRegistry;
-    use cli_framework::mcp::{CliFrameworkHandler, McpToolRegistry};
+    use cli_framework::mcp::{CliFrameworkHandler, McpToolExportPolicy, McpToolRegistry};
     use rmcp::transport::streamable_http_server::{
         session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
     };
@@ -1679,8 +1683,11 @@ pub fn build_mcp_router_for_serve(
         registry.register(cmd);
     }
 
-    let tool_registry =
-        std::sync::Arc::new(McpToolRegistry::from_command_registry(&registry, "newton"));
+    let tool_registry = std::sync::Arc::new(McpToolRegistry::from_command_registry_with_policy(
+        &registry,
+        "newton",
+        McpToolExportPolicy::ExposeMcpOnly,
+    ));
     if tool_registry.tool_count() == 0 {
         return Err(anyhow!(
             "{}: cli-framework returned an empty MCP tool registry",
@@ -1708,6 +1715,7 @@ pub fn build_mcp_router_for_serve(
 
 /// Build the Newton CLI application backed by `cli-framework`.
 pub fn build_app(ctx: NewtonContext) -> anyhow::Result<App<NewtonContext>> {
+    use cli_framework::mcp::McpToolExportPolicy;
     #[allow(unused_mut)]
     let mut builder = AppBuilder::new()
         .with_version("newton", env!("CARGO_PKG_VERSION"))
@@ -1730,6 +1738,7 @@ pub fn build_app(ctx: NewtonContext) -> anyhow::Result<App<NewtonContext>> {
         builder = builder.register_command(ask_command())?;
     }
     builder
+        .with_mcp_export_policy(McpToolExportPolicy::ExposeMcpOnly)
         .build(ctx)
         .map_err(|e| anyhow!("{}: {}", error_codes::CLI_MIG_001, e))
 }
@@ -1751,6 +1760,11 @@ pub const REGISTERED_COMMAND_IDS: &[&str] = &[
     "config",
     "completion",
 ];
+
+/// Commands exposed as MCP tools under the ExposeMcpOnly policy (issue #309).
+/// The order is alphabetical for readability; it does not affect registration order.
+pub const MCP_EXPOSED_COMMAND_IDS: &[&str] =
+    &["config", "health", "resume", "run", "runs", "workflow"];
 
 /// Returns every `Command` registered by `build_app`, in registration order.
 pub fn enumerate_commands() -> Vec<Command> {

--- a/crates/cli/src/cli/mcp.rs
+++ b/crates/cli/src/cli/mcp.rs
@@ -11,7 +11,7 @@
 //!    error after a successful bind).
 //!
 //! See spec `tmp/237-046-newton-consumption-of-cli-framework-mcp-mode.md`.
-use crate::cli::framework_setup::{error_codes, REGISTERED_COMMAND_IDS};
+use crate::cli::framework_setup::{error_codes, MCP_EXPOSED_COMMAND_IDS};
 
 /// Newton's documented MCP defaults (spec §4.2). cli-framework currently
 /// defaults `--mcp-port` to `8080`; Newton overrides to `8730` to avoid
@@ -90,14 +90,11 @@ pub fn parse_mcp_flags(argv: &[String]) -> McpFlags {
     flags
 }
 
-/// Compile-time tool count: top-level Newton commands registered in
-/// [`REGISTERED_COMMAND_IDS`], +1 when the optional `ask` feature is on.
+/// Returns the number of Newton commands exposed as MCP tools under the
+/// ExposeMcpOnly policy (issue #309). Does not include `ask` (excluded
+/// from the curated MCP surface regardless of feature flag).
 pub fn tool_count() -> usize {
-    let mut n = REGISTERED_COMMAND_IDS.len();
-    if cfg!(feature = "ask") {
-        n += 1;
-    }
-    n
+    MCP_EXPOSED_COMMAND_IDS.len()
 }
 
 /// Build the argv that cli-framework expects: ensure host/port/path flags are

--- a/crates/cli/tests/integration/mcp_expose_mcp_only.rs
+++ b/crates/cli/tests/integration/mcp_expose_mcp_only.rs
@@ -1,0 +1,63 @@
+//! Issue #309: verify that ExposeMcpOnly policy produces exactly the six
+//! expected tool ids and excludes the eight non-exposed command ids.
+use cli_framework::command::registry::CommandRegistry;
+use cli_framework::mcp::{McpToolExportPolicy, McpToolRegistry};
+use newton_cli::cli::framework_setup::{enumerate_commands, MCP_EXPOSED_COMMAND_IDS};
+
+fn build_exposed_registry() -> McpToolRegistry {
+    let mut registry = CommandRegistry::new();
+    for cmd in enumerate_commands() {
+        registry.register(cmd);
+    }
+    McpToolRegistry::from_command_registry_with_policy(
+        &registry,
+        "newton",
+        McpToolExportPolicy::ExposeMcpOnly,
+    )
+}
+
+#[test]
+fn expose_mcp_only_tool_count_equals_allowlist() {
+    let registry = build_exposed_registry();
+    assert_eq!(
+        registry.tool_count(),
+        MCP_EXPOSED_COMMAND_IDS.len(),
+        "ExposeMcpOnly policy should expose exactly {} tools",
+        MCP_EXPOSED_COMMAND_IDS.len()
+    );
+}
+
+#[test]
+fn expose_mcp_only_includes_allowed_tools() {
+    let registry = build_exposed_registry();
+    for id in MCP_EXPOSED_COMMAND_IDS {
+        let tool_name = format!("newton.{}", id);
+        assert!(
+            registry.resolve_tool(&tool_name).is_some(),
+            "expected tool '{}' to be in MCP registry",
+            tool_name
+        );
+    }
+}
+
+#[test]
+fn expose_mcp_only_excludes_non_allowed_tools() {
+    let registry = build_exposed_registry();
+    for id in &[
+        "init",
+        "batch",
+        "serve",
+        "checkpoint",
+        "artifact",
+        "webhook",
+        "doctor",
+        "completion",
+    ] {
+        let tool_name = format!("newton.{}", id);
+        assert!(
+            registry.resolve_tool(&tool_name).is_none(),
+            "expected tool '{}' to NOT be in MCP registry",
+            tool_name
+        );
+    }
+}

--- a/crates/cli/tests/integration/mcp_on_starts_and_logs.rs
+++ b/crates/cli/tests/integration/mcp_on_starts_and_logs.rs
@@ -1,12 +1,12 @@
 //! Issue #237: MCP-mode startup emits a single structured log line containing
 //! `event="mcp_serve_started"`, `mcp_enabled=true`, `bind_address`, `mcp_path`
-//! and an integer `tool_count` matching `REGISTERED_COMMAND_IDS.len()` (+1
-//! when the optional `ask` feature is enabled).
+//! and an integer `tool_count` matching `MCP_EXPOSED_COMMAND_IDS.len()` (the
+//! curated allowlist of 6 commands; issue #309).
 //!
 //! We verify the contract end-to-end by spawning the binary on a free port
 //! and reading the JSON-line we mirror to stderr (spec §4.6). The cli-framework
 //! HTTP transport keeps running until killed; we read one line then SIGKILL.
-use newton_cli::cli::framework_setup::REGISTERED_COMMAND_IDS;
+use newton_cli::cli::framework_setup::MCP_EXPOSED_COMMAND_IDS;
 use newton_cli::cli::mcp;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
@@ -19,8 +19,7 @@ fn pick_free_port() -> u16 {
 
 #[test]
 fn tool_count_matches_registered_command_ids() {
-    let expected = REGISTERED_COMMAND_IDS.len() + if cfg!(feature = "ask") { 1 } else { 0 };
-    assert_eq!(mcp::tool_count(), expected);
+    assert_eq!(mcp::tool_count(), MCP_EXPOSED_COMMAND_IDS.len());
 }
 
 #[test]
@@ -72,9 +71,8 @@ fn mcp_serve_emits_structured_startup_log() {
         line
     );
     assert!(line.contains("\"mcp_path\":\"/mcp\""), "line={}", line);
-    let expected_count = REGISTERED_COMMAND_IDS.len() + if cfg!(feature = "ask") { 1 } else { 0 };
     assert!(
-        line.contains(&format!("\"tool_count\":{}", expected_count)),
+        line.contains(&format!("\"tool_count\":{}", MCP_EXPOSED_COMMAND_IDS.len())),
         "line={}",
         line
     );

--- a/crates/core/tests/workflow_graph/.test_explain.rs.pending-snap
+++ b/crates/core/tests/workflow_graph/.test_explain.rs.pending-snap
@@ -48,3 +48,9 @@
 {"run_id":"8c929f3f-c2a9-4554-87fe-dbb9e13368a4","line":346,"new":null,"old":null}
 {"run_id":"62bd2c51-4533-40ac-8bd3-8f21182133e7","line":55,"new":null,"old":null}
 {"run_id":"62bd2c51-4533-40ac-8bd3-8f21182133e7","line":346,"new":null,"old":null}
+{"run_id":"0e21e9e6-a2ae-497a-8cb8-93157a0d900d","line":55,"new":null,"old":null}
+{"run_id":"0e21e9e6-a2ae-497a-8cb8-93157a0d900d","line":346,"new":null,"old":null}
+{"run_id":"5161663b-04d0-4fba-8d1a-b770f01a5747","line":55,"new":null,"old":null}
+{"run_id":"5161663b-04d0-4fba-8d1a-b770f01a5747","line":346,"new":null,"old":null}
+{"run_id":"83b456b7-39b9-429f-8418-8707ee54a431","line":55,"new":null,"old":null}
+{"run_id":"83b456b7-39b9-429f-8418-8707ee54a431","line":346,"new":null,"old":null}


### PR DESCRIPTION
Implements spec. Merge with squash.