### PR TITLE
fix(ci): disable rust-cache in release job to stop Windows cache-save failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
+          # Release builds are clean one-offs per tag; caching target/ adds little
+          # and the Windows cache-save (tar over target/ while vctip.exe holds file
+          # handles) flakily fails the post step, blocking the release jobs.
+          cache: false
 
       - name: Install musl tools (for musl target)
         if: matrix.target == 'x86_64-unknown-linux-musl'


### PR DESCRIPTION
## Problem

The v0.5.100 release run failed on the Windows job — but not in a build step. All real steps (build, archive, upload) passed. The only failing step was the **`Post Install Rust toolchain`** post-action, which runs `Swatinem/rust-cache` to save the cargo/target cache via `tar` + `zstd`.

On `windows-latest`, `vctip.exe` (MSVC telemetry background process) holds open file handles inside `target/`. When `tar` reads that directory to build the cache archive, a file changes/locks under it and `tar` exits non-zero, failing the post step.

## Impact

Because the post step fails, the whole Windows matrix job is marked failed, which cascades through the job dependencies in `release.yml`:

- `create-release` (`needs: release`) → **skipped** → no GitHub Release published
- `update-package-managers` (`needs: create-release`, `if: success()`) → **skipped** → Homebrew + Scoop not updated

So binaries built fine but the release was silently never published (e.g. v0.5.100).

## Fix

Set `cache: false` on `setup-rust-toolchain` in the release job. Release builds are clean one-offs per tag, so caching `target/` adds little value — and the cache save is exactly what flakily breaks here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)