### PR TITLE
feat(agent): validation loop guardrails when validator prompt exceeds limits

### DIFF
--- a/crates/core/src/workflow/operators/agent.rs
+++ b/crates/core/src/workflow/operators/agent.rs
@@ -194,6 +194,28 @@ impl Operator for AgentOperator {
             )
         };
 
+        if config.require_signal && !config.signals.is_empty() && signal.is_none() {
+            let mut err = AppError::new(
+                ErrorCategory::ValidationError,
+                "agent did not emit any configured signal",
+            )
+            .with_code("WFG-AGENT-009");
+            err.add_context("stdout_artifact", &paths.stdout_rel);
+            err.add_context(
+                "stderr_artifact",
+                if paths.stderr_abs.exists() {
+                    &paths.stderr_rel
+                } else {
+                    "null"
+                },
+            );
+            err.add_context("engine", &engine_name);
+            if let Some(ref m) = config.model {
+                err.add_context("model", m.as_str());
+            }
+            return Err(err);
+        }
+
         Ok(output::build_agent_output(AgentOutput {
             signal,
             signal_data,

--- a/crates/core/src/workflow/operators/agent/command.rs
+++ b/crates/core/src/workflow/operators/agent/command.rs
@@ -346,6 +346,7 @@ mod tests {
     use crate::workflow::operators::agent::AgentOperator;
     use crate::workflow::schema::WorkflowSettings;
     use serde_json::json;
+    use serde_json::Value;
     use std::collections::HashMap;
     use tempfile::TempDir;
 
@@ -611,5 +612,72 @@ fi"#,
         });
         let result = op.execute(params, ctx).await.unwrap();
         assert_eq!(result["signal"], json!("aaa_complete"));
+    }
+
+    #[tokio::test]
+    async fn execute_require_signal_true_fails_with_no_signal() {
+        let tmp = TempDir::new().unwrap();
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["bash", "-c", "echo hello"],
+            "signals": { "complete": "<status>COMPLETED</status>" },
+            "require_signal": true
+        });
+        let err = op.execute(params, ctx).await.unwrap_err();
+        assert_eq!(err.code, "WFG-AGENT-009");
+    }
+
+    #[tokio::test]
+    async fn execute_require_signal_false_returns_null_on_no_match() {
+        let tmp = TempDir::new().unwrap();
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["bash", "-c", "echo hello"],
+            "signals": { "complete": "<status>COMPLETED</status>" }
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(result["signal"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn execute_require_signal_with_matching_signal_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["bash", "-c", "echo '<status>COMPLETED</status>'"],
+            "signals": { "complete": "<status>COMPLETED</status>" },
+            "require_signal": true
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(result["signal"], json!("complete"));
+    }
+
+    #[tokio::test]
+    async fn execute_require_signal_includes_context_keys() {
+        let tmp = TempDir::new().unwrap();
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["bash", "-c", "echo hello"],
+            "signals": { "valid": "<status>VALID</status>" },
+            "require_signal": true,
+            "model": "test-model"
+        });
+        let err = op.execute(params, ctx).await.unwrap_err();
+        assert_eq!(err.code, "WFG-AGENT-009");
+        assert!(err.context.contains_key("stdout_artifact"));
+        assert!(err.context.contains_key("engine"));
+        assert!(err.context.contains_key("model"));
     }
 }

--- a/crates/core/src/workflow/operators/agent/config.rs
+++ b/crates/core/src/workflow/operators/agent/config.rs
@@ -23,6 +23,8 @@ pub(super) struct AgentOperatorConfig {
     pub(super) engine_command: Option<Vec<String>>,
     /// Whether to stream stdout to the terminal. If None, uses workflow setting.
     pub(super) stream_stdout: Option<bool>,
+    /// When true and signals is non-empty, fail if no signal matches (WFG-AGENT-009).
+    pub(super) require_signal: bool,
 }
 
 impl AgentOperatorConfig {
@@ -54,6 +56,10 @@ impl AgentOperatorConfig {
             .map(|v| v as u32);
         let engine_command = Self::parse_engine_command(map);
         let stream_stdout = map.get("stream_stdout").and_then(Value::as_bool);
+        let require_signal = map
+            .get("require_signal")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
 
         Ok(AgentOperatorConfig {
             engine,
@@ -67,6 +73,7 @@ impl AgentOperatorConfig {
             max_iterations,
             engine_command,
             stream_stdout,
+            require_signal,
         })
     }
 


### PR DESCRIPTION
## Summary
- Add `require_signal` opt-in parameter to `AgentOperator` that fails with error code `WFG-AGENT-009` when signals are configured but none match assistant output, instead of silently producing `signal=null`
- Add workflow-level guardrails in `develop.yaml`: `validation_preflight` (prompt size check), `validation_signal_guard`, and `fail_validation_no_signal` terminal task
- Prevents runaway validation/implementation loops when validator returns transport/limit errors instead of parseable `<status>VALID</status>`/`<status>INVALID</status>` signals

Closes #401