### PR TITLE
fix(grading): spec 067 — grading loop remediation (R1–R3, M1–M5)

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -74,6 +74,7 @@ pub trait BackendStore: Send + Sync {
     async fn list_findings(
         &self,
         status: Option<String>,
+        scope: Option<String>,
         scope_id: Option<String>,
     ) -> Result<Vec<FindingItem>, ApiError>;
     async fn get_finding(&self, id: &str) -> Result<FindingItem, ApiError>;

--- a/crates/backend/src/store/finding.rs
+++ b/crates/backend/src/store/finding.rs
@@ -90,15 +90,25 @@ impl super::SqliteBackendStore {
     pub(super) async fn list_findings_db(
         &self,
         status: Option<String>,
+        scope: Option<String>,
         scope_id: Option<String>,
     ) -> Result<Vec<FindingItem>, ApiError> {
         let mut conditions = Vec::new();
         if status.is_some() {
-            conditions.push("f.status = ?");
+            conditions.push("f.status = ?".to_string());
         }
-        if scope_id.is_some() {
-            conditions.push("(f.componentId = ? OR f.repoId = ?)");
-        }
+        let scope_condition = if scope_id.is_some() {
+            let col = match scope.as_deref() {
+                Some("component") => "f.componentId = ?",
+                Some("repo") => "f.repoId = ?",
+                Some("module") => "f.module = ?",
+                _ => "(f.componentId = ? OR f.repoId = ?)",
+            };
+            conditions.push(col.to_string());
+            col
+        } else {
+            ""
+        };
 
         let where_clause = if conditions.is_empty() {
             String::new()
@@ -113,7 +123,12 @@ impl super::SqliteBackendStore {
             q = q.bind(s);
         }
         if let Some(ref sid) = scope_id {
-            q = q.bind(sid).bind(sid);
+            // Multi-bind for the fallback OR clause; single bind for specific columns.
+            if scope_condition == "(f.componentId = ? OR f.repoId = ?)" {
+                q = q.bind(sid).bind(sid);
+            } else {
+                q = q.bind(sid);
+            }
         }
 
         let rows = q.fetch_all(&self.pool).await.map_err(query_err)?;

--- a/crates/backend/src/store/mod.rs
+++ b/crates/backend/src/store/mod.rs
@@ -142,9 +142,10 @@ impl BackendStore for SqliteBackendStore {
     async fn list_findings(
         &self,
         status: Option<String>,
+        scope: Option<String>,
         scope_id: Option<String>,
     ) -> Result<Vec<FindingItem>, ApiError> {
-        self.list_findings_db(status, scope_id).await
+        self.list_findings_db(status, scope, scope_id).await
     }
     async fn get_finding(&self, id: &str) -> Result<FindingItem, ApiError> {
         self.get_finding_db(id).await
@@ -957,7 +958,7 @@ mod finding_store_tests {
         body2.title = "Updated title".to_string();
         let item = store.create_finding(body2).await.unwrap();
         assert_eq!(item.title, "Updated title");
-        let all = store.list_findings(None, None).await.unwrap();
+        let all = store.list_findings(None, None, None).await.unwrap();
         assert_eq!(all.iter().filter(|f| f.id == "find-002").count(), 1);
     }
 }

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -488,7 +488,7 @@ async fn dispatch_data(
                 .and_then(to_json)
         }
         (DataVerb::Get, "findings") => store
-            .list_findings(None, None)
+            .list_findings(None, None, None)
             .await
             .map_err(api_err)
             .and_then(to_json),

--- a/crates/core/src/api/findings.rs
+++ b/crates/core/src/api/findings.rs
@@ -22,6 +22,7 @@ pub fn routes(state: Arc<AppState>) -> Router {
 #[derive(Debug, Deserialize)]
 pub(crate) struct FindingQuery {
     status: Option<String>,
+    scope: Option<String>,
     scope_id: Option<String>,
 }
 
@@ -31,7 +32,8 @@ pub(crate) struct FindingQuery {
     tag = "findings",
     params(
         ("status" = Option<String>, Query, description = "Optional finding status filter"),
-        ("scope_id" = Option<String>, Query, description = "Optional component or repo id filter"),
+        ("scope" = Option<String>, Query, description = "Scope kind: component | repo | module"),
+        ("scope_id" = Option<String>, Query, description = "Optional scope entity id filter"),
     ),
     responses(
         (status = 200, description = "Finding list", body = [newton_backend::FindingItem]),
@@ -45,7 +47,7 @@ pub(crate) async fn list_findings(
     ok_json(
         state
             .backend
-            .list_findings(query.status, query.scope_id)
+            .list_findings(query.status, query.scope, query.scope_id)
             .await,
     )
 }

--- a/crates/core/src/workflow/operators/assessment.rs
+++ b/crates/core/src/workflow/operators/assessment.rs
@@ -5,6 +5,7 @@ use crate::core::types::ErrorCategory;
 use newton_backend::{BackendStore, CreateEvalRunBody, CreateGradeInlineBody};
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize)]
@@ -54,6 +55,17 @@ pub fn validate_assessment(json: &Value) -> Result<AssessmentContent, AppError> 
     Ok(content)
 }
 
+/// Build a dimension → kpi_id map by listing KPIs and matching by name.
+async fn dimension_kpi_map(store: &Arc<dyn BackendStore>) -> HashMap<String, String> {
+    match store.list_kpis().await {
+        Ok(kpis) => kpis
+            .into_iter()
+            .map(|k| (k.name.to_lowercase(), k.id))
+            .collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn persist_assessment(
     store: &Arc<dyn BackendStore>,
@@ -65,11 +77,14 @@ pub async fn persist_assessment(
     raw_json: &Value,
     evaluated_at: &str,
 ) -> Result<(), AppError> {
+    // M5: resolve dimension → kpiId when a matching KPI exists.
+    let kpi_map = dimension_kpi_map(store).await;
+
     let grades: Vec<CreateGradeInlineBody> = content
         .scores
         .iter()
         .map(|s| CreateGradeInlineBody {
-            kpi_id: None,
+            kpi_id: kpi_map.get(&s.dimension.to_lowercase()).cloned(),
             dimension: s.dimension.clone(),
             score: s.score,
             evidence: None,
@@ -110,8 +125,10 @@ pub fn build_output(content: &AssessmentContent, raw_json: Value) -> Value {
         score_by_dim.insert(s.dimension.clone(), serde_json::json!(s.score));
     }
 
+    // M3: always emit all four severity buckets + total so gate expressions like
+    // `counts.critical == 0` never encounter a missing key.
     let mut counts = serde_json::Map::new();
-    let mut by_sev: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut by_sev: HashMap<String, usize> = HashMap::new();
     for obs in &content.observations {
         *by_sev
             .entry(obs.severity.clone().unwrap_or_else(|| "medium".to_string()))
@@ -121,8 +138,11 @@ pub fn build_output(content: &AssessmentContent, raw_json: Value) -> Value {
         "total".to_string(),
         serde_json::json!(content.observations.len()),
     );
-    for (k, v) in &by_sev {
-        counts.insert(k.clone(), serde_json::json!(v));
+    for bucket in ["critical", "high", "medium", "low"] {
+        counts.insert(
+            bucket.to_string(),
+            serde_json::json!(by_sev.get(bucket).copied().unwrap_or(0)),
+        );
     }
 
     serde_json::json!({

--- a/crates/core/src/workflow/operators/change_request_op.rs
+++ b/crates/core/src/workflow/operators/change_request_op.rs
@@ -1,5 +1,5 @@
 //! ChangeRequestOperator — reads open Findings and synthesizes a ChangeRequest.
-//! Spec 064.
+//! Spec 064 + 067.
 
 #![allow(clippy::result_large_err)]
 
@@ -15,14 +15,14 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct ChangeRequestOperator {
-    _workspace_root: PathBuf,
+    workspace_root: PathBuf,
     store: Arc<dyn BackendStore>,
 }
 
 impl ChangeRequestOperator {
     pub fn new(workspace_root: PathBuf, store: Arc<dyn BackendStore>) -> Self {
         Self {
-            _workspace_root: workspace_root,
+            workspace_root,
             store,
         }
     }
@@ -30,6 +30,8 @@ impl ChangeRequestOperator {
 
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
 pub struct ChangeRequestParams {
+    /// Scope kind: product | component | repo | module.
+    pub scope: String,
     /// Scope entity ID to read findings for.
     pub scope_id: String,
     /// Maximum number of findings to include (default: 10).
@@ -38,10 +40,27 @@ pub struct ChangeRequestParams {
     /// Minimum severity to include (critical, high, medium, low).
     #[serde(default)]
     pub min_severity: Option<String>,
+    /// Engine for LLM synthesis (default: "claude").
+    #[serde(default = "default_engine")]
+    pub engine: String,
+    /// Model for LLM synthesis (optional).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Timeout for LLM synthesis in seconds (default: 60).
+    #[serde(default = "default_synthesis_timeout")]
+    pub synthesis_timeout_seconds: u64,
 }
 
 fn default_max_findings() -> usize {
     10
+}
+
+fn default_engine() -> String {
+    "claude".to_string()
+}
+
+fn default_synthesis_timeout() -> u64 {
+    60
 }
 
 #[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
@@ -50,7 +69,6 @@ pub struct ChangeRequestOutput {
     pub change_request_id: Option<String>,
 }
 
-/// Severity rank for sorting. Lower = more severe.
 fn severity_rank(s: &str) -> u8 {
     match s {
         "critical" => 0,
@@ -66,6 +84,21 @@ fn is_open_status(status: &str) -> bool {
         status,
         "awaiting_triage" | "triaged" | "approved_for_planning"
     )
+}
+
+const CR_SYNTHESIS_SCHEMA: &str = r#"{
+  "type": "object",
+  "properties": {
+    "title": {"type": "string", "maxLength": 200},
+    "body": {"type": "string"}
+  },
+  "required": ["title", "body"]
+}"#;
+
+#[derive(Debug, Deserialize)]
+struct CrSynthesis {
+    title: String,
+    body: String,
 }
 
 #[async_trait]
@@ -109,6 +142,7 @@ impl Operator for ChangeRequestOperator {
             .with_code("CR-001")
         })?;
 
+        let scope = &parsed.scope;
         let scope_id = &parsed.scope_id;
         let max_findings = parsed.max_findings;
         let min_severity_rank = parsed
@@ -117,10 +151,10 @@ impl Operator for ChangeRequestOperator {
             .map(severity_rank)
             .unwrap_or(4);
 
-        // List all findings for this scope_id
+        // R1: list findings with scope so we actually find them.
         let all_findings = self
             .store
-            .list_findings(None, Some(scope_id.clone()))
+            .list_findings(None, Some(scope.clone()), Some(scope_id.clone()))
             .await
             .map_err(|e| {
                 AppError::new(
@@ -130,25 +164,20 @@ impl Operator for ChangeRequestOperator {
                 .with_code("CR-010")
             })?;
 
-        // Filter to open statuses
         let mut open: Vec<&newton_backend::FindingItem> = all_findings
             .iter()
             .filter(|f| is_open_status(&f.status))
             .collect();
 
-        // Filter by min_severity if set
         if parsed.min_severity.is_some() {
             open.retain(|f| severity_rank(&f.severity) <= min_severity_rank);
         }
 
-        // Sort by severity rank ascending (critical first)
         open.sort_by_key(|f| severity_rank(&f.severity));
 
-        // Take max_findings
         let selected: Vec<&newton_backend::FindingItem> =
             open.into_iter().take(max_findings).collect();
 
-        // Convergence: nothing actionable
         if selected.is_empty() {
             return Ok(serde_json::json!({
                 "decision": "none",
@@ -156,35 +185,83 @@ impl Operator for ChangeRequestOperator {
             }));
         }
 
-        // Deterministic synthesis (no LLM call).
-        // TODO: replace with LLM-generated title/body for richer summaries.
-        let dims: Vec<String> = {
-            let mut seen = std::collections::HashSet::new();
-            selected
-                .iter()
-                .filter_map(|f| {
-                    if seen.insert(f.dimension.clone()) {
-                        Some(f.dimension.clone())
-                    } else {
+        let finding_ids: Vec<String> = selected.iter().map(|f| f.id.clone()).collect();
+
+        // R2: synthesize title/body via aikit Pipeline.
+        let findings_json: Vec<serde_json::Value> = selected
+            .iter()
+            .map(|f| {
+                serde_json::json!({
+                    "id": f.id,
+                    "dimension": f.dimension,
+                    "severity": f.severity,
+                    "title": f.title,
+                    "why_it_matters": f.why_it_matters,
+                    "recommended_action": f.recommended_action,
+                })
+            })
+            .collect();
+        let findings_str = serde_json::to_string_pretty(&findings_json).unwrap_or_default();
+        let scope_label = format!("{scope}/{scope_id}");
+
+        let engine = parsed.engine.clone();
+        let model = parsed.model.clone();
+        let timeout_secs = parsed.synthesis_timeout_seconds;
+        let workspace_root = self.workspace_root.clone();
+
+        let synthesis: Option<CrSynthesis> = tokio::task::spawn_blocking(move || {
+            let template = "You are a change request author. Synthesize a concise, actionable change request from the following open findings for scope {{scope}}.\n\n## Findings\n{{findings}}\n\n## Instructions\n- Write a short, specific title (under 120 chars) describing the overall action needed.\n- Write a markdown body summarizing the findings and why they matter. Reference severity.\n- Focus on what needs to change, not on describing the grader.\n\nReturn ONLY a JSON object matching the schema.";
+
+                let runner = aikit_sdk::AgentRunner::new()
+                    .agent(&engine)
+                    .working_dir(&workspace_root.to_string_lossy())
+                    .timeout(std::time::Duration::from_secs(timeout_secs));
+                let runner = if let Some(ref m) = model { runner.model(m) } else { runner };
+
+                let pipeline = aikit_sdk::pipeline::Pipeline::new(template, CR_SYNTHESIS_SCHEMA)
+                    .max_retries(1);
+
+                match pipeline.run(&[("scope", &scope_label), ("findings", &findings_str)], runner) {
+                    Ok(pr) => serde_json::from_value::<CrSynthesis>(pr.data).ok(),
+                    Err(e) => {
+                        tracing::warn!("ChangeRequestOperator: LLM synthesis failed, using fallback: {e}");
                         None
                     }
-                })
-                .collect()
+                }
+        })
+        .await
+        .unwrap_or(None);
+
+        // Fallback synthesis when LLM is unavailable.
+        let (title, body) = if let Some(s) = synthesis {
+            (s.title, s.body)
+        } else {
+            let dims: Vec<String> = {
+                let mut seen = std::collections::HashSet::new();
+                selected
+                    .iter()
+                    .filter_map(|f| {
+                        if seen.insert(f.dimension.clone()) {
+                            Some(f.dimension.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            };
+            let title = format!(
+                "Address {} finding{}: {}",
+                selected.len(),
+                if selected.len() == 1 { "" } else { "s" },
+                dims.join(", ")
+            );
+            let body_lines: Vec<String> = selected
+                .iter()
+                .map(|f| format!("- [{}] {}", f.severity, f.recommended_action))
+                .collect();
+            (title, body_lines.join("\n"))
         };
-        let title = format!(
-            "Address {} finding{}: {}",
-            selected.len(),
-            if selected.len() == 1 { "" } else { "s" },
-            dims.join(", ")
-        );
 
-        let body_lines: Vec<String> = selected
-            .iter()
-            .map(|f| format!("- [{}] {}", f.severity, f.recommended_action))
-            .collect();
-        let body = body_lines.join("\n");
-
-        let finding_ids: Vec<String> = selected.iter().map(|f| f.id.clone()).collect();
         let cr_id = Uuid::new_v4().to_string();
 
         self.store

--- a/crates/core/src/workflow/operators/change_request_op.rs
+++ b/crates/core/src/workflow/operators/change_request_op.rs
@@ -263,6 +263,11 @@ impl Operator for ChangeRequestOperator {
         };
 
         let cr_id = Uuid::new_v4().to_string();
+        let (cr_component_id, cr_repo_id) = match scope.as_str() {
+            "component" => (Some(scope_id.clone()), None),
+            "repo" => (None, Some(scope_id.clone())),
+            _ => (None, None),
+        };
 
         self.store
             .create_change_request(CreateChangeRequestBody {
@@ -271,8 +276,8 @@ impl Operator for ChangeRequestOperator {
                 body: Some(body),
                 origin: "system".to_string(),
                 author: None,
-                component_id: None,
-                repo_id: None,
+                component_id: cr_component_id,
+                repo_id: cr_repo_id,
                 finding_ids,
             })
             .await

--- a/crates/core/src/workflow/operators/grader_agent.rs
+++ b/crates/core/src/workflow/operators/grader_agent.rs
@@ -1,5 +1,5 @@
-//! GraderAgentOperator — rubric-based grader using AI via aikit-sdk.
-//! Spec 065.
+//! GraderAgentOperator — rubric-based grader using AI via aikit-sdk Pipeline.
+//! Spec 065 + 067.
 
 #![allow(clippy::result_large_err)]
 
@@ -7,7 +7,6 @@ use crate::core::error::AppError;
 use crate::core::types::ErrorCategory;
 use crate::workflow::operator::{ExecutionContext, Operator};
 use crate::workflow::operators::assessment;
-use crate::workflow::operators::engine::{extract_text_from_sdk_event, AikitEngineManager};
 use async_trait::async_trait;
 use chrono::Utc;
 use newton_backend::BackendStore;
@@ -15,25 +14,22 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use uuid::Uuid;
 
 pub struct GraderAgentOperator {
-    _workspace_root: PathBuf,
+    workspace_root: PathBuf,
     store: Arc<dyn BackendStore>,
-    engine_manager: AikitEngineManager,
 }
 
 impl GraderAgentOperator {
     pub fn new(
-        _workspace_root: PathBuf,
+        workspace_root: PathBuf,
         store: Arc<dyn BackendStore>,
-        engine_manager: AikitEngineManager,
+        _engine_manager: crate::workflow::operators::engine::AikitEngineManager,
     ) -> Self {
         Self {
-            _workspace_root,
+            workspace_root,
             store,
-            engine_manager,
         }
     }
 }
@@ -54,46 +50,79 @@ pub struct GraderAgentParams {
     /// Engine to use (default: "claude").
     #[serde(default = "default_engine")]
     pub engine: String,
+    /// Timeout in seconds (default: 120).
+    #[serde(default = "default_timeout")]
+    pub timeout_seconds: u64,
 }
 
 fn default_engine() -> String {
     "claude".to_string()
 }
 
+fn default_timeout() -> u64 {
+    120
+}
+
+/// Assessment output schema for Pipeline validation.
+const ASSESSMENT_SCHEMA: &str = r#"{
+  "type": "object",
+  "properties": {
+    "overall_score": {"type": "number", "minimum": 0, "maximum": 100},
+    "verdict": {"type": "string", "enum": ["pass", "fail", "needs_improvement"]},
+    "summary": {"type": "string"},
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dimension": {"type": "string"},
+          "score": {"type": "number"},
+          "rationale": {"type": "string"}
+        },
+        "required": ["dimension", "score"]
+      }
+    },
+    "observations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dimension": {"type": "string"},
+          "severity": {"type": "string"},
+          "observation": {"type": "string"},
+          "why_it_matters": {"type": "string"},
+          "recommended_action": {"type": "string"},
+          "confidence": {"type": "number"}
+        },
+        "required": ["dimension", "observation"]
+      }
+    }
+  },
+  "required": ["overall_score", "verdict", "scores"]
+}"#;
+
 #[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
 pub struct GraderAgentOutput {
     pub overall_score: f64,
     pub verdict: String,
+    pub score_by_dimension: Value,
+    pub counts: Value,
+    pub assessment: Value,
 }
 
 const ASSESSMENT_PROMPT_TEMPLATE: &str = r#"You are a grader evaluating quality against a rubric.
 
 Rubric:
-{rubric}
+{{rubric}}
 
-Scope: {scope}/{scope_id}
+Scope: {{scope}}/{{scope_id}}
 
-Evaluate the scope using the rubric above. Return ONLY a valid JSON Assessment object with this structure:
-{{
-  "overall_score": <number 0-100>,
-  "verdict": "<pass|fail|needs_improvement>",
-  "summary": "<brief summary>",
-  "scores": [
-    {{"dimension": "<dim>", "score": <0-100>, "rationale": "<why>"}}
-  ],
-  "observations": [
-    {{
-      "dimension": "<dim>",
-      "severity": "<critical|high|medium|low>",
-      "observation": "<what was observed>",
-      "why_it_matters": "<impact>",
-      "recommended_action": "<action>",
-      "confidence": <0.0-1.0>
-    }}
-  ]
-}}
-
-Return ONLY the JSON object, no markdown fences or other text."#;
+Evaluate the scope using the rubric above. Return ONLY a valid JSON Assessment object matching the schema provided. Include:
+- overall_score (0-100)
+- verdict (pass | fail | needs_improvement)
+- summary (brief summary)
+- scores: array of {dimension, score, rationale}
+- observations: array of {dimension, severity, observation, why_it_matters, recommended_action, confidence}"#;
 
 #[async_trait]
 impl Operator for GraderAgentOperator {
@@ -143,85 +172,80 @@ impl Operator for GraderAgentOperator {
             .with_code("GRADER-AGENT-001")
         })?;
 
-        // Build prompt
-        let prompt = ASSESSMENT_PROMPT_TEMPLATE
-            .replace("{rubric}", &parsed.rubric)
-            .replace("{scope}", &parsed.scope)
-            .replace("{scope_id}", &parsed.scope_id);
+        let engine = parsed.engine.clone();
+        let model = parsed.model.clone();
+        let rubric = parsed.rubric.clone();
+        let scope = parsed.scope.clone();
+        let scope_id = parsed.scope_id.clone();
+        let timeout_secs = parsed.timeout_seconds;
+        let workspace_root = self.workspace_root.clone();
 
         tracing::debug!(
             grader = %parsed.grader,
-            engine = %parsed.engine,
-            scope = %parsed.scope,
-            scope_id = %parsed.scope_id,
-            "GraderAgentOperator: invoking AI engine"
+            engine = %engine,
+            scope = %scope,
+            scope_id = %scope_id,
+            "GraderAgentOperator: invoking AI engine via Pipeline"
         );
 
-        // Call engine
-        let (events, run_result) = self
-            .engine_manager
-            .execute_engine_events(
-                &parsed.engine,
-                &prompt,
-                parsed.model.as_deref(),
-                Some(Duration::from_secs(120)),
-            )
-            .await?;
+        // R2: run via aikit Pipeline (schema-in → schema-out → validate → retry).
+        // Pipeline::run is blocking; wrap in spawn_blocking.
+        let pipeline_result = tokio::task::spawn_blocking(move || {
+            let runner = aikit_sdk::AgentRunner::new()
+                .agent(&engine)
+                .working_dir(&workspace_root.to_string_lossy())
+                .timeout(std::time::Duration::from_secs(timeout_secs));
+            let runner = if let Some(ref m) = model {
+                runner.model(m)
+            } else {
+                runner
+            };
 
-        // Surface engine errors
-        run_result.map_err(|e| {
+            let pipeline =
+                aikit_sdk::pipeline::Pipeline::new(ASSESSMENT_PROMPT_TEMPLATE, ASSESSMENT_SCHEMA)
+                    .max_retries(2);
+
+            pipeline.run(
+                &[
+                    ("rubric", rubric.as_str()),
+                    ("scope", scope.as_str()),
+                    ("scope_id", scope_id.as_str()),
+                ],
+                runner,
+            )
+        })
+        .await
+        .map_err(|e| {
             AppError::new(
                 ErrorCategory::ToolExecutionError,
-                format!("GraderAgentOperator: AI engine returned error: {e:?}"),
+                format!("GraderAgentOperator: spawn_blocking panicked: {e}"),
+            )
+            .with_code("GRADER-AGENT-002")
+        })?
+        .map_err(|e| {
+            AppError::new(
+                ErrorCategory::ToolExecutionError,
+                format!("GraderAgentOperator: Pipeline failed: {e}"),
             )
             .with_code("GRADER-AGENT-002")
         })?;
 
-        // Extract text from events
-        let text: String = events
-            .iter()
-            .filter_map(extract_text_from_sdk_event)
-            .collect::<Vec<_>>()
-            .join("");
+        let mut assessment_json = pipeline_result.data;
 
-        if text.is_empty() {
-            return Err(AppError::new(
-                ErrorCategory::ToolExecutionError,
-                "GraderAgentOperator: AI engine produced no text output",
-            )
-            .with_code("GRADER-AGENT-003"));
-        }
-
-        // Parse extracted text as Assessment JSON
-        // Try to find JSON in the text (strip markdown fences if present)
-        let json_text = extract_json(&text);
-        let mut assessment_json: Value = serde_json::from_str(&json_text).map_err(|e| {
-            AppError::new(
-                ErrorCategory::ToolExecutionError,
-                format!(
-                    "GraderAgentOperator: AI output is not valid Assessment JSON: {e}. text: {text}"
-                ),
-            )
-            .with_code("GRADER-AGENT-004")
-        })?;
-
-        // Stamp envelope
+        // M1: overwrite envelope fields authoritatively (ignore whatever the grader emitted).
         let now = Utc::now().to_rfc3339();
         if let Some(obj) = assessment_json.as_object_mut() {
-            obj.entry("grader")
-                .or_insert_with(|| Value::String(parsed.grader.clone()));
-            obj.entry("scope")
-                .or_insert_with(|| Value::String(parsed.scope.clone()));
-            obj.entry("scope_id")
-                .or_insert_with(|| Value::String(parsed.scope_id.clone()));
-            obj.entry("evaluated_at")
-                .or_insert_with(|| Value::String(now.clone()));
+            obj.insert("grader".to_string(), Value::String(parsed.grader.clone()));
+            obj.insert("scope".to_string(), Value::String(parsed.scope.clone()));
+            obj.insert(
+                "scope_id".to_string(),
+                Value::String(parsed.scope_id.clone()),
+            );
+            obj.insert("evaluated_at".to_string(), Value::String(now.clone()));
         }
 
-        // Validate assessment
         let content = assessment::validate_assessment(&assessment_json)?;
 
-        // Persist assessment
         let run_id = Uuid::new_v4().to_string();
         assessment::persist_assessment(
             &self.store,
@@ -237,23 +261,4 @@ impl Operator for GraderAgentOperator {
 
         Ok(assessment::build_output(&content, assessment_json))
     }
-}
-
-/// Extract JSON from text, stripping markdown code fences if present.
-fn extract_json(text: &str) -> String {
-    let trimmed = text.trim();
-    // Try to strip ```json ... ``` or ``` ... ```
-    if let Some(inner) = trimmed
-        .strip_prefix("```json")
-        .or_else(|| trimmed.strip_prefix("```"))
-    {
-        if let Some(end) = inner.rfind("```") {
-            return inner[..end].trim().to_string();
-        }
-    }
-    // Try to find first { and last }
-    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}')) {
-        return trimmed[start..=end].to_string();
-    }
-    trimmed.to_string()
 }

--- a/crates/core/src/workflow/operators/grader_command.rs
+++ b/crates/core/src/workflow/operators/grader_command.rs
@@ -68,6 +68,9 @@ fn default_shell() -> String {
 pub struct GraderCommandOutput {
     pub overall_score: f64,
     pub verdict: String,
+    pub score_by_dimension: Value,
+    pub counts: Value,
+    pub assessment: Value,
 }
 
 #[async_trait]
@@ -156,13 +159,27 @@ impl Operator for GraderCommandOperator {
         cmd.stderr(Stdio::piped());
         cmd.stdin(Stdio::null());
 
-        let output = cmd.output().await.map_err(|e| {
-            AppError::new(
-                ErrorCategory::ToolExecutionError,
-                format!("GraderCommandOperator: failed to spawn command: {e}"),
-            )
-            .with_code("GRADER-CMD-002")
-        })?;
+        // M2: enforce timeout_seconds (default 120 s).
+        let timeout_dur = std::time::Duration::from_secs(parsed.timeout_seconds.unwrap_or(120));
+        let output = tokio::time::timeout(timeout_dur, cmd.output())
+            .await
+            .map_err(|_| {
+                AppError::new(
+                    ErrorCategory::ToolExecutionError,
+                    format!(
+                        "GraderCommandOperator: command timed out after {}s",
+                        parsed.timeout_seconds.unwrap_or(120)
+                    ),
+                )
+                .with_code("GRADER-CMD-005")
+            })?
+            .map_err(|e| {
+                AppError::new(
+                    ErrorCategory::ToolExecutionError,
+                    format!("GraderCommandOperator: failed to spawn command: {e}"),
+                )
+                .with_code("GRADER-CMD-002")
+            })?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -187,17 +204,16 @@ impl Operator for GraderCommandOperator {
             .with_code("GRADER-CMD-004")
         })?;
 
-        // Stamp envelope fields if missing
+        // M1: overwrite envelope fields authoritatively (operator owns these).
         let now = Utc::now().to_rfc3339();
         if let Some(obj) = assessment_json.as_object_mut() {
-            obj.entry("grader")
-                .or_insert_with(|| Value::String(parsed.grader.clone()));
-            obj.entry("scope")
-                .or_insert_with(|| Value::String(parsed.scope.clone()));
-            obj.entry("scope_id")
-                .or_insert_with(|| Value::String(parsed.scope_id.clone()));
-            obj.entry("evaluated_at")
-                .or_insert_with(|| Value::String(now.clone()));
+            obj.insert("grader".to_string(), Value::String(parsed.grader.clone()));
+            obj.insert("scope".to_string(), Value::String(parsed.scope.clone()));
+            obj.insert(
+                "scope_id".to_string(),
+                Value::String(parsed.scope_id.clone()),
+            );
+            obj.insert("evaluated_at".to_string(), Value::String(now.clone()));
         }
 
         // Validate assessment schema

--- a/crates/core/src/workflow/operators/reconcile.rs
+++ b/crates/core/src/workflow/operators/reconcile.rs
@@ -293,7 +293,10 @@ impl Operator for ReconcileOperator {
 
         for (idx, obs) in observations.iter().enumerate() {
             let fp = stable_fingerprint(scope, scope_id, &obs.dimension, obs.location.as_ref());
-            if fp_index.contains_key(&fp) {
+            // Deterministic match only when location is present. Location-less observations
+            // share a bare-dimension fingerprint and cannot be distinguished structurally —
+            // route them to the LLM adjudicator which judges semantic sameness.
+            if obs.location.is_some() && fp_index.contains_key(&fp) {
                 matched_by_fp.push((idx, fp));
             } else {
                 unmatched.push((idx, obs));
@@ -424,12 +427,19 @@ impl Operator for ReconcileOperator {
         // Track finding IDs seen/touched in this run (for auto-resolve sweep).
         let mut seen_finding_ids: std::collections::HashSet<String> =
             std::collections::HashSet::new();
+        // Track FPs already patched to avoid double-counting when multiple observations
+        // hit the same fingerprint within a single run.
+        let mut patched_fps: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         // Phase 1: handle deterministically matched observations.
         for (idx, fp) in &matched_by_fp {
             let _ = idx; // used implicitly via fp
             if let Some(existing) = fp_index.get(fp.as_str()) {
                 seen_finding_ids.insert(existing.id.clone());
+                if !patched_fps.insert(fp.clone()) {
+                    // Already patched this finding in this run — skip to avoid double-count.
+                    continue;
+                }
                 if existing.status == "resolved" {
                     self.store
                         .patch_finding(
@@ -659,15 +669,19 @@ mod tests {
         })
     }
 
-    fn make_obs(dimension: &str, observation: &str) -> serde_json::Value {
-        json!({
+    fn make_obs(dimension: &str, observation: &str, location: Option<&str>) -> serde_json::Value {
+        let mut v = json!({
             "dimension": dimension,
             "severity": "medium",
             "observation": observation,
             "why_it_matters": "matters",
             "recommended_action": "fix it",
             "confidence": 0.9
-        })
+        });
+        if let Some(loc) = location {
+            v["location"] = json!({"file": loc});
+        }
+        v
     }
 
     #[tokio::test]
@@ -679,8 +693,8 @@ mod tests {
         let operator = ReconcileOperator::new(std::path::PathBuf::from("/tmp"), store.clone());
 
         let assessment = make_assessment(vec![
-            make_obs("tests", "Coverage is below threshold"),
-            make_obs("security", "Dependency has known CVE"),
+            make_obs("tests", "Coverage is below threshold", Some("src/main.rs")),
+            make_obs("security", "Dependency has known CVE", Some("Cargo.toml")),
         ]);
 
         let params = json!({
@@ -713,8 +727,8 @@ mod tests {
 
         // Second identical reconcile: creates 0 new, refreshes 2, resolves 0.
         let assessment2 = make_assessment(vec![
-            make_obs("tests", "Coverage is below threshold"),
-            make_obs("security", "Dependency has known CVE"),
+            make_obs("tests", "Coverage is below threshold", Some("src/main.rs")),
+            make_obs("security", "Dependency has known CVE", Some("Cargo.toml")),
         ]);
         let params2 = json!({
             "scope": "module",
@@ -741,7 +755,7 @@ mod tests {
             "scope": "module",
             "scope_id": "mod-002",
             "grader": "grader-a",
-            "assessment": make_assessment(vec![make_obs("tests", "No tests")]),
+            "assessment": make_assessment(vec![make_obs("tests", "No tests", Some("src/lib.rs"))]),
         });
         op.execute(params_a, make_ctx()).await.unwrap();
 
@@ -750,7 +764,7 @@ mod tests {
             "scope": "module",
             "scope_id": "mod-002",
             "grader": "grader-b",
-            "assessment": make_assessment(vec![make_obs("docs", "No docs")]),
+            "assessment": make_assessment(vec![make_obs("docs", "No docs", Some("README.md"))]),
         });
         let result_b = op.execute(params_b, make_ctx()).await.unwrap();
 
@@ -773,5 +787,54 @@ mod tests {
             findings.iter().filter(|f| f.source == "grader-a").collect();
         assert_eq!(grader_a_findings.len(), 1);
         assert_eq!(grader_a_findings[0].status, "awaiting_triage");
+    }
+
+    /// Two distinct observations with no location in the same dimension must produce
+    /// two separate findings, not one (fingerprint-collision bug fixed in spec 067).
+    #[tokio::test]
+    async fn no_location_observations_are_not_merged() {
+        let store: Arc<dyn BackendStore> =
+            Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
+        let op = ReconcileOperator::new(std::path::PathBuf::from("/tmp"), store.clone());
+
+        let assessment = make_assessment(vec![
+            make_obs(
+                "architecture",
+                "Circular dependency between layers A and B",
+                None,
+            ),
+            make_obs(
+                "architecture",
+                "Service boundary violation in module X",
+                None,
+            ),
+        ]);
+
+        let params = json!({
+            "scope": "module",
+            "scope_id": "mod-003",
+            "grader": "arch-grader",
+            "assessment": assessment,
+        });
+
+        let result = op.execute(params, make_ctx()).await.unwrap();
+        assert_eq!(
+            result["created"], 2,
+            "two distinct no-location observations must produce two findings, not one"
+        );
+
+        let findings = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-003".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            findings.len(),
+            2,
+            "both findings must be stored and retrievable"
+        );
     }
 }

--- a/crates/core/src/workflow/operators/reconcile.rs
+++ b/crates/core/src/workflow/operators/reconcile.rs
@@ -1,5 +1,5 @@
 //! ReconcileOperator — reads observations from Assessment output and reconciles with stored Findings.
-//! Spec 063.
+//! Spec 063 + 067.
 
 #![allow(clippy::result_large_err)]
 
@@ -8,25 +8,23 @@ use crate::core::types::ErrorCategory;
 use crate::workflow::operator::{ExecutionContext, Operator};
 use async_trait::async_trait;
 use chrono::Utc;
-use newton_backend::{BackendStore, CreateFindingBody, PatchFindingBody};
+use newton_backend::{BackendStore, CreateFindingBody, FindingItem, PatchFindingBody};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct ReconcileOperator {
-    _workspace_root: PathBuf,
+    workspace_root: PathBuf,
     store: Arc<dyn BackendStore>,
 }
 
 impl ReconcileOperator {
     pub fn new(workspace_root: PathBuf, store: Arc<dyn BackendStore>) -> Self {
         Self {
-            _workspace_root: workspace_root,
+            workspace_root,
             store,
         }
     }
@@ -34,17 +32,36 @@ impl ReconcileOperator {
 
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
 pub struct ReconcileParams {
+    /// Scope kind: product | component | repo | module.
+    pub scope: String,
     /// Scope entity ID to reconcile findings for.
     pub scope_id: String,
-    /// Grader name (used as source when creating new findings).
+    /// Grader name (used as source when creating/matching findings).
     #[serde(default = "default_grader")]
     pub grader: String,
     /// Assessment JSON passed inline (caller resolves from task output).
     pub assessment: Value,
+    /// Engine to use for LLM adjudication (default: "claude").
+    #[serde(default = "default_engine")]
+    pub engine: String,
+    /// Model for LLM adjudication (optional).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Timeout for LLM adjudication in seconds (default: 60).
+    #[serde(default = "default_adjudication_timeout")]
+    pub adjudication_timeout_seconds: u64,
 }
 
 fn default_grader() -> String {
     "unknown".to_string()
+}
+
+fn default_engine() -> String {
+    "claude".to_string()
+}
+
+fn default_adjudication_timeout() -> u64 {
+    60
 }
 
 #[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
@@ -67,12 +84,42 @@ struct Observation {
     evidence: Option<Vec<String>>,
 }
 
-fn fingerprint(scope_id: &str, dimension: &str, observation_text: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    scope_id.hash(&mut hasher);
-    dimension.hash(&mut hasher);
-    observation_text.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+/// Stable natural key: scope + dimension + normalized_location.
+/// Does NOT use the free observation text so that rewording by a
+/// non-deterministic grader produces the same fingerprint.
+fn stable_fingerprint(
+    scope: &str,
+    scope_id: &str,
+    dimension: &str,
+    location: Option<&Value>,
+) -> String {
+    let loc_key = match location {
+        Some(v) => {
+            // Normalize: sort object keys, strip whitespace.
+            normalize_location(v)
+        }
+        None => String::new(),
+    };
+    format!("{}:{}:{}:{}", scope, scope_id, dimension, loc_key)
+}
+
+fn normalize_location(v: &Value) -> String {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&str> = map.keys().map(|k| k.as_str()).collect();
+            keys.sort();
+            let parts: Vec<String> = keys
+                .iter()
+                .filter_map(|k| {
+                    map.get(*k)
+                        .map(|val| format!("{}={}", k, val.to_string().replace(' ', "")))
+                })
+                .collect();
+            parts.join(",")
+        }
+        Value::String(s) => s.clone(),
+        other => other.to_string().replace(' ', ""),
+    }
 }
 
 fn parse_observations(assessment: &Value) -> Vec<Observation> {
@@ -110,12 +157,58 @@ fn parse_observations(assessment: &Value) -> Vec<Observation> {
         .collect()
 }
 
-/// Determine if a finding status is "open" for the purposes of auto-resolution.
 fn is_open_status(status: &str) -> bool {
     matches!(
         status,
         "awaiting_triage" | "triaged" | "approved_for_planning"
     )
+}
+
+/// Adjudication result from the LLM.
+#[derive(Debug, Deserialize)]
+struct AdjudicationPlan {
+    /// Each entry: (observation_index, finding_id) — LLM says these match.
+    matched: Vec<AdjudicationMatch>,
+    /// Finding IDs the LLM says are resolved (not seen in this run at all).
+    resolved: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdjudicationMatch {
+    observation_index: usize,
+    finding_id: String,
+}
+
+const RECONCILE_ADJUDICATION_SCHEMA: &str = r#"{
+  "type": "object",
+  "properties": {
+    "matched": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "observation_index": {"type": "integer"},
+          "finding_id": {"type": "string"}
+        },
+        "required": ["observation_index", "finding_id"]
+      }
+    },
+    "resolved": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "required": ["matched", "resolved"]
+}"#;
+
+/// Populate the correct scope column on a CreateFindingBody based on scope kind.
+fn apply_scope(body: &mut CreateFindingBody, scope: &str, scope_id: &str) {
+    match scope {
+        "component" => body.component_id = Some(scope_id.to_string()),
+        "repo" => body.repo_id = Some(scope_id.to_string()),
+        "module" => body.module = Some(scope_id.to_string()),
+        _ => {}
+    }
 }
 
 #[async_trait]
@@ -160,16 +253,17 @@ impl Operator for ReconcileOperator {
         })?;
 
         let now = Utc::now().to_rfc3339();
+        let scope = &parsed.scope;
         let scope_id = &parsed.scope_id;
         let grader = &parsed.grader;
 
-        // Parse observations from the assessment JSON
+        // Parse observations from the assessment JSON.
         let observations = parse_observations(&parsed.assessment);
 
-        // List all findings for this scope_id
-        let existing_findings = self
+        // R1 + R3: list only this grader's findings for this scope.
+        let all_scope_findings = self
             .store
-            .list_findings(None, Some(scope_id.clone()))
+            .list_findings(None, Some(scope.clone()), Some(scope_id.clone()))
             .await
             .map_err(|e| {
                 AppError::new(
@@ -179,27 +273,164 @@ impl Operator for ReconcileOperator {
                 .with_code("RECONCILE-010")
             })?;
 
-        // Build fingerprint index from existing findings
-        let mut fp_index: HashMap<String, &newton_backend::FindingItem> = HashMap::new();
+        // R3: restrict to this grader's source only.
+        let existing_findings: Vec<&FindingItem> = all_scope_findings
+            .iter()
+            .filter(|f| f.source == *grader)
+            .collect();
+
+        // Build stable-fingerprint index from existing findings.
+        let mut fp_index: HashMap<String, &FindingItem> = HashMap::new();
         for finding in &existing_findings {
             fp_index.insert(finding.fingerprint.clone(), finding);
+        }
+
+        // Compute stable fingerprint for each observation and partition into:
+        // - deterministically matched (fp hit)
+        // - unmatched (need LLM adjudication or create)
+        let mut matched_by_fp: Vec<(usize, String)> = vec![]; // (obs_idx, fp)
+        let mut unmatched: Vec<(usize, &Observation)> = vec![];
+
+        for (idx, obs) in observations.iter().enumerate() {
+            let fp = stable_fingerprint(scope, scope_id, &obs.dimension, obs.location.as_ref());
+            if fp_index.contains_key(&fp) {
+                matched_by_fp.push((idx, fp));
+            } else {
+                unmatched.push((idx, obs));
+            }
+        }
+
+        // Open candidates not yet matched — these are the LLM adjudication targets.
+        let matched_fps_set: std::collections::HashSet<&str> =
+            matched_by_fp.iter().map(|(_, fp)| fp.as_str()).collect();
+        let unmatched_candidates: Vec<&FindingItem> = existing_findings
+            .iter()
+            .filter(|f| {
+                is_open_status(&f.status) && !matched_fps_set.contains(f.fingerprint.as_str())
+            })
+            .copied()
+            .collect();
+
+        // Run LLM adjudication for unmatched observations (if any candidates exist).
+        let workspace_root = self.workspace_root.clone();
+        let engine = parsed.engine.clone();
+        let model = parsed.model.clone();
+        let timeout_secs = parsed.adjudication_timeout_seconds;
+
+        // Collect data needed for the spawn_blocking call (owned copies).
+        let unmatched_owned: Vec<(usize, String, String, Option<Value>)> = unmatched
+            .iter()
+            .map(|(idx, obs)| {
+                (
+                    *idx,
+                    obs.dimension.clone(),
+                    obs.observation.clone(),
+                    obs.location.clone(),
+                )
+            })
+            .collect();
+        let candidates_owned: Vec<(String, String, String, String, String)> = unmatched_candidates
+            .iter()
+            .map(|f| {
+                (
+                    f.id.clone(),
+                    f.dimension.clone(),
+                    f.title.clone(),
+                    f.fingerprint.clone(),
+                    f.status.clone(),
+                )
+            })
+            .collect();
+
+        let adj_plan: Option<AdjudicationPlan> = if !unmatched_owned.is_empty()
+            && !candidates_owned.is_empty()
+        {
+            let obs_json: Vec<serde_json::Value> = unmatched_owned
+                .iter()
+                .map(|(idx, dim, obs_text, loc)| {
+                    serde_json::json!({
+                        "index": idx,
+                        "dimension": dim,
+                        "observation": obs_text,
+                        "location": loc,
+                    })
+                })
+                .collect();
+            let findings_json: Vec<serde_json::Value> = candidates_owned
+                .iter()
+                .map(|(id, dim, title, fp, status)| {
+                    serde_json::json!({
+                        "id": id,
+                        "dimension": dim,
+                        "title": title,
+                        "fingerprint": fp,
+                        "status": status,
+                    })
+                })
+                .collect();
+            let obs_str = serde_json::to_string_pretty(&obs_json).unwrap_or_default();
+            let findings_str = serde_json::to_string_pretty(&findings_json).unwrap_or_default();
+
+            let result = tokio::task::spawn_blocking(move || {
+                let template = "You are a semantic matching agent. Your job is ONLY to judge whether observations from a grader run match existing findings by meaning — not to evaluate quality or add new analysis.\n\n## Unmatched observations (this run)\n{{observations}}\n\n## Candidate open findings (existing)\n{{findings}}\n\n## Task\nFor each observation, decide:\n- Does it semantically describe the same issue as an existing finding? If so, record the match.\n- Is it genuinely new? Record its index in `new`.\n- Are any candidate findings NOT covered by any observation (resolved)? Record their IDs in `resolved`.\n\nReturn a JSON object matching the schema. Keep temperature low — judge sameness strictly.";
+
+                let runner = aikit_sdk::AgentRunner::new()
+                    .agent(&engine)
+                    .working_dir(&workspace_root.to_string_lossy())
+                    .timeout(std::time::Duration::from_secs(timeout_secs));
+                let runner = if let Some(ref m) = model {
+                    runner.model(m)
+                } else {
+                    runner
+                };
+
+                let pipeline = aikit_sdk::pipeline::Pipeline::new(template, RECONCILE_ADJUDICATION_SCHEMA)
+                    .max_retries(1);
+
+                match pipeline.run(&[("observations", &obs_str), ("findings", &findings_str)], runner) {
+                    Ok(pr) => serde_json::from_value::<AdjudicationPlan>(pr.data).ok(),
+                    Err(e) => {
+                        tracing::warn!(
+                            "ReconcileOperator: LLM adjudication failed, treating unmatched as new: {e}"
+                        );
+                        None
+                    }
+                }
+            })
+            .await
+            .unwrap_or(None);
+            result
+        } else {
+            None
+        };
+
+        // Build sets of: llm-matched obs indices → finding_id, llm-resolved finding IDs.
+        let mut llm_matched: HashMap<usize, String> = HashMap::new(); // obs_idx → finding_id
+        let mut llm_resolved: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        if let Some(ref plan) = adj_plan {
+            for m in &plan.matched {
+                llm_matched.insert(m.observation_index, m.finding_id.clone());
+            }
+            for fid in &plan.resolved {
+                llm_resolved.insert(fid.clone());
+            }
         }
 
         let mut created = 0usize;
         let mut refreshed = 0usize;
         let mut reopened = 0usize;
 
-        // Track fingerprints seen in this run
-        let mut seen_fps: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Track finding IDs seen/touched in this run (for auto-resolve sweep).
+        let mut seen_finding_ids: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
-        for obs in &observations {
-            let fp = fingerprint(scope_id, &obs.dimension, &obs.observation);
-            seen_fps.insert(fp.clone());
-
-            if let Some(existing) = fp_index.get(&fp) {
-                let status = existing.status.as_str();
-                if status == "resolved" {
-                    // Reopen
+        // Phase 1: handle deterministically matched observations.
+        for (idx, fp) in &matched_by_fp {
+            let _ = idx; // used implicitly via fp
+            if let Some(existing) = fp_index.get(fp.as_str()) {
+                seen_finding_ids.insert(existing.id.clone());
+                if existing.status == "resolved" {
                     self.store
                         .patch_finding(
                             &existing.id,
@@ -221,7 +452,6 @@ impl Operator for ReconcileOperator {
                         })?;
                     reopened += 1;
                 } else {
-                    // Refresh (open or rejected/deferred — keep status, update last_seen_at)
                     self.store
                         .patch_finding(
                             &existing.id,
@@ -243,55 +473,90 @@ impl Operator for ReconcileOperator {
                         })?;
                     refreshed += 1;
                 }
-            } else {
-                // Create new finding
-                let id = Uuid::new_v4().to_string();
-                let title: String = obs.observation.chars().take(120).collect();
+            }
+        }
+
+        // Phase 2: handle unmatched observations (LLM-matched or create new).
+        for (idx, obs) in &unmatched {
+            if let Some(finding_id) = llm_matched.get(idx) {
+                // LLM says this matches an existing finding — refresh it.
+                seen_finding_ids.insert(finding_id.clone());
                 self.store
-                    .create_finding(CreateFindingBody {
-                        id,
-                        source: grader.clone(),
-                        origin: "system".to_string(),
-                        component_id: None,
-                        module: None,
-                        repo_id: None,
-                        kpi_id: None,
-                        dimension: obs.dimension.clone(),
-                        location: obs.location.clone(),
-                        fingerprint: fp.clone(),
-                        title,
-                        why_it_matters: obs.why_it_matters.clone().unwrap_or_default(),
-                        recommended_action: obs.recommended_action.clone().unwrap_or_default(),
-                        severity: obs.severity.clone().unwrap_or_else(|| "medium".to_string()),
-                        risk: obs.severity.clone().unwrap_or_else(|| "medium".to_string()),
-                        confidence: obs.confidence,
-                        evidence: obs
-                            .evidence
-                            .as_ref()
-                            .map(|e| serde_json::to_value(e).unwrap_or(Value::Null)),
-                        expected_value: None,
-                        effort: None,
-                        status: "awaiting_triage".to_string(),
-                        last_seen_at: Some(now.clone()),
-                        depends_on: vec![],
-                        blocks: vec![],
-                    })
+                    .patch_finding(
+                        finding_id,
+                        PatchFindingBody {
+                            status: None,
+                            last_seen_at: Some(now.clone()),
+                            expected_value: None,
+                            effort: None,
+                            risk: None,
+                        },
+                    )
                     .await
                     .map_err(|e| {
                         AppError::new(
                             ErrorCategory::ToolExecutionError,
-                            format!("ReconcileOperator: failed to create finding: {e:?}"),
+                            format!("ReconcileOperator: failed to patch finding: {e:?}"),
                         )
-                        .with_code("RECONCILE-012")
+                        .with_code("RECONCILE-011")
                     })?;
+                refreshed += 1;
+            } else {
+                // Genuinely new — create.
+                let id = Uuid::new_v4().to_string();
+                let fp = stable_fingerprint(scope, scope_id, &obs.dimension, obs.location.as_ref());
+                let title: String = obs.observation.chars().take(120).collect();
+                let mut body = CreateFindingBody {
+                    id: id.clone(),
+                    source: grader.clone(),
+                    origin: "system".to_string(),
+                    component_id: None,
+                    module: None,
+                    repo_id: None,
+                    kpi_id: None,
+                    dimension: obs.dimension.clone(),
+                    location: obs.location.clone(),
+                    fingerprint: fp,
+                    title,
+                    why_it_matters: obs.why_it_matters.clone().unwrap_or_default(),
+                    recommended_action: obs.recommended_action.clone().unwrap_or_default(),
+                    severity: obs.severity.clone().unwrap_or_else(|| "medium".to_string()),
+                    risk: obs.severity.clone().unwrap_or_else(|| "medium".to_string()),
+                    confidence: obs.confidence,
+                    evidence: obs
+                        .evidence
+                        .as_ref()
+                        .map(|e| serde_json::to_value(e).unwrap_or(Value::Null)),
+                    expected_value: None,
+                    effort: None,
+                    status: "awaiting_triage".to_string(),
+                    last_seen_at: Some(now.clone()),
+                    depends_on: vec![],
+                    blocks: vec![],
+                };
+                // R1: populate correct scope column.
+                apply_scope(&mut body, scope, scope_id);
+
+                self.store.create_finding(body).await.map_err(|e| {
+                    AppError::new(
+                        ErrorCategory::ToolExecutionError,
+                        format!("ReconcileOperator: failed to create finding: {e:?}"),
+                    )
+                    .with_code("RECONCILE-012")
+                })?;
+                seen_finding_ids.insert(id);
                 created += 1;
             }
         }
 
-        // Resolve open findings not seen in this run
+        // Phase 3: R3-scoped resolution — only resolve this grader's open findings
+        // not seen in this run (and not LLM-resolved, which is handled here too).
         let mut resolved = 0usize;
         for finding in &existing_findings {
-            if is_open_status(&finding.status) && !seen_fps.contains(&finding.fingerprint) {
+            if is_open_status(&finding.status)
+                && !seen_finding_ids.contains(&finding.id)
+                && !llm_resolved.contains(&finding.id)
+            {
                 self.store
                     .patch_finding(
                         &finding.id,
@@ -315,11 +580,198 @@ impl Operator for ReconcileOperator {
             }
         }
 
+        // Also resolve findings explicitly flagged by LLM as resolved.
+        for fid in &llm_resolved {
+            if let Some(finding) = existing_findings.iter().find(|f| &f.id == fid) {
+                if is_open_status(&finding.status) && !seen_finding_ids.contains(fid) {
+                    self.store
+                        .patch_finding(
+                            fid,
+                            PatchFindingBody {
+                                status: Some("resolved".to_string()),
+                                last_seen_at: Some(now.clone()),
+                                expected_value: None,
+                                effort: None,
+                                risk: None,
+                            },
+                        )
+                        .await
+                        .map_err(|e| {
+                            AppError::new(
+                                ErrorCategory::ToolExecutionError,
+                                format!("ReconcileOperator: failed to resolve finding: {e:?}"),
+                            )
+                            .with_code("RECONCILE-013")
+                        })?;
+                    resolved += 1;
+                }
+            }
+        }
+
         Ok(serde_json::json!({
             "created": created,
             "refreshed": refreshed,
             "reopened": reopened,
             "resolved": resolved,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::executor::{ExecutionOverrides, GraphHandle};
+    use crate::workflow::operator::{OperatorRegistry, StateView};
+    use newton_backend::{BackendStore, SqliteBackendStore};
+    use serde_json::json;
+
+    fn make_ctx() -> crate::workflow::operator::ExecutionContext {
+        crate::workflow::operator::ExecutionContext {
+            workspace_path: std::path::PathBuf::from("/tmp"),
+            execution_id: "test-exec".to_string(),
+            task_id: "test-task".to_string(),
+            iteration: 1,
+            state_view: StateView::new(json!({}), json!({}), json!({})),
+            graph: GraphHandle::new(std::collections::HashMap::new()),
+            workflow_file: std::path::PathBuf::from("/tmp/test.yaml"),
+            nesting_depth: 0,
+            execution_overrides: ExecutionOverrides {
+                parallel_limit: None,
+                max_time_seconds: None,
+                checkpoint_base_path: None,
+                artifact_base_path: None,
+                max_nesting_depth: None,
+                verbose: false,
+                sink: None,
+                pre_seed_nodes: true,
+            },
+            operator_registry: OperatorRegistry::new(),
+        }
+    }
+
+    fn make_assessment(observations: Vec<serde_json::Value>) -> Value {
+        json!({
+            "overall_score": 75.0,
+            "verdict": "needs_improvement",
+            "summary": "test",
+            "scores": [{"dimension": "tests", "score": 75.0, "rationale": "ok"}],
+            "observations": observations
+        })
+    }
+
+    fn make_obs(dimension: &str, observation: &str) -> serde_json::Value {
+        json!({
+            "dimension": dimension,
+            "severity": "medium",
+            "observation": observation,
+            "why_it_matters": "matters",
+            "recommended_action": "fix it",
+            "confidence": 0.9
+        })
+    }
+
+    #[tokio::test]
+    async fn r1_round_trip_grade_reconcile_list_findings() {
+        let store: Arc<dyn BackendStore> =
+            Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
+
+        // Uses module scope to avoid FK constraints on component/repo.
+        let operator = ReconcileOperator::new(std::path::PathBuf::from("/tmp"), store.clone());
+
+        let assessment = make_assessment(vec![
+            make_obs("tests", "Coverage is below threshold"),
+            make_obs("security", "Dependency has known CVE"),
+        ]);
+
+        let params = json!({
+            "scope": "module",
+            "scope_id": "mod-001",
+            "grader": "test-grader",
+            "assessment": assessment,
+        });
+
+        let result = operator.execute(params, make_ctx()).await.unwrap();
+
+        assert_eq!(result["created"], 2, "should create 2 findings");
+        assert_eq!(result["refreshed"], 0);
+        assert_eq!(result["resolved"], 0);
+
+        // R1: list_findings must return both findings when scope is provided.
+        let findings = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-001".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            findings.len(),
+            2,
+            "list_findings must return both created findings"
+        );
+
+        // Second identical reconcile: creates 0 new, refreshes 2, resolves 0.
+        let assessment2 = make_assessment(vec![
+            make_obs("tests", "Coverage is below threshold"),
+            make_obs("security", "Dependency has known CVE"),
+        ]);
+        let params2 = json!({
+            "scope": "module",
+            "scope_id": "mod-001",
+            "grader": "test-grader",
+            "assessment": assessment2,
+        });
+        let result2 = operator.execute(params2, make_ctx()).await.unwrap();
+
+        assert_eq!(result2["created"], 0, "second identical run must create 0");
+        assert_eq!(result2["refreshed"], 2, "second run must refresh 2");
+        assert_eq!(result2["resolved"], 0, "second run must resolve 0");
+    }
+
+    #[tokio::test]
+    async fn r3_cross_grader_isolation() {
+        let store: Arc<dyn BackendStore> =
+            Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
+
+        let op = ReconcileOperator::new(std::path::PathBuf::from("/tmp"), store.clone());
+
+        // Grader A creates findings.
+        let params_a = json!({
+            "scope": "module",
+            "scope_id": "mod-002",
+            "grader": "grader-a",
+            "assessment": make_assessment(vec![make_obs("tests", "No tests")]),
+        });
+        op.execute(params_a, make_ctx()).await.unwrap();
+
+        // Grader B runs on same scope — must NOT resolve grader A's findings.
+        let params_b = json!({
+            "scope": "module",
+            "scope_id": "mod-002",
+            "grader": "grader-b",
+            "assessment": make_assessment(vec![make_obs("docs", "No docs")]),
+        });
+        let result_b = op.execute(params_b, make_ctx()).await.unwrap();
+
+        assert_eq!(result_b["created"], 1, "grader-b creates its own finding");
+        assert_eq!(
+            result_b["resolved"], 0,
+            "grader-b must not resolve grader-a findings"
+        );
+
+        // Grader A's finding must still be open.
+        let findings = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-002".to_string()),
+            )
+            .await
+            .unwrap();
+        let grader_a_findings: Vec<_> =
+            findings.iter().filter(|f| f.source == "grader-a").collect();
+        assert_eq!(grader_a_findings.len(), 1);
+        assert_eq!(grader_a_findings[0].status, "awaiting_triage");
     }
 }

--- a/openapi/newton-backend-parity.yaml
+++ b/openapi/newton-backend-parity.yaml
@@ -518,9 +518,15 @@ paths:
         required: false
         schema:
           type: string
+      - name: scope
+        in: query
+        description: 'Scope kind: component | repo | module'
+        required: false
+        schema:
+          type: string
       - name: scope_id
         in: query
-        description: Optional component or repo id filter
+        description: Optional scope entity id filter
         required: false
         schema:
           type: string


### PR DESCRIPTION
## Summary

Implements spec `specs/draft/067-grading-loop-remediation.md`, fixing defects across the three-operator grading loop (GraderAgent → Reconcile → ChangeRequest).

### R1 — BLOCKER: Findings unfindable by scope

- Extended `BackendStore::list_findings` with a `scope: Option<String>` parameter so the query filters the correct column (`componentId`, `repoId`, or `module`) rather than an `OR` across all three that always misses NULL rows.
- `ReconcileOperator` and `ChangeRequestOperator` now accept `scope` + `scope_id` params and pass them through to `create_finding` / `list_findings`.
- `apply_scope()` helper populates the correct DB column on finding creation.
- New test: `r1_round_trip_grade_reconcile_list_findings` — creates a finding then asserts `list_findings(scope, scope_id)` returns it.

### R2 — MAJOR: Agentic core missing — all three operators need aikit Pipeline

- **GraderAgentOperator**: replaced hand-rolled engine call with `aikit_sdk::pipeline::Pipeline` (schema-constrained, `max_retries(2)`, `spawn_blocking`). Exposes `timeout_seconds` param passed to `AgentRunner`.
- **ReconcileOperator**: fingerprint changed from observation-text hash to stable natural key `scope:scope_id:dimension:normalized_location`. Adds a Pipeline-based LLM adjudication pass for unmatched observations against open candidate findings; degrades gracefully on LLM error.
- **ChangeRequestOperator**: title/body synthesised via Pipeline (`CR_SYNTHESIS_SCHEMA`); falls back to deterministic concat when LLM is unavailable.

### R3 — MAJOR: Cross-grader resolution clobbering

- `ReconcileOperator` now filters `list_findings` results to `source == grader` before building the fingerprint index and running the resolve sweep.
- Grader A can no longer resolve findings created by grader B on the same scope.
- New test: `r3_cross_grader_isolation` — two graders on one scope, asserts neither resolves the other's findings.

### M1 — Envelope fields overwritten with `insert()`

Both `GraderCommandOperator` and `GraderAgentOperator` now use `obj.insert(...)` (not `entry(...).or_insert_with(...)`) for `grader`, `scope`, `scope_id`, `evaluated_at` — the operator is authoritative; the grader subprocess cannot override these.

### M2 — Timeout enforcement

- `GraderCommandOperator`: wraps `cmd.output()` in `tokio::time::timeout`; returns `GRADER-CMD-005` on elapse.
- `GraderAgentOperator`: `timeout_seconds` param forwarded to `AgentRunner::timeout()`.

### M3 — Counts zero-fill

`assessment::build_output` always emits all four severity buckets (`critical`, `high`, `medium`, `low`) + `total`, defaulting absent buckets to `0`. Gate expressions like `counts.critical == 0` can no longer panic on a missing key.

### M4 — Output schema declares all fields

`GraderCommandOutput` and `GraderAgentOutput` structs declare all five real fields: `overall_score`, `verdict`, `score_by_dimension`, `counts`, `assessment`.

### M5 — KPI linkage

`assessment::persist_assessment` resolves dimension → `kpi_id` via `store.list_kpis()` name match (case-insensitive). Grades are persisted with `kpi_id` set when a matching KPI exists.

## Test plan

- [x] `cargo test` — all suites green (pre-push hook)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — clean
- [x] `r1_round_trip_grade_reconcile_list_findings` — R1 acceptance criterion
- [x] `r3_cross_grader_isolation` — R3 acceptance criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)