### PR TITLE
feat(optimize): close the optimization loop — specs 069/070/071

### DIFF
--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -1,0 +1,464 @@
+#!/usr/bin/env bash
+# optimize.sh — Newton optimization loop driver (spec 069)
+# Usage: optimize.sh <project_id> [--once] [--max-cycles N] [--converge-rounds K]
+#        [--target-grade G] [--delivery local|pr] [--auto-approve] [-w <workspace>]
+set -euo pipefail
+
+# ── Arg parsing ─────────────────────────────────────────────────────────────
+PROJECT_ID=""
+WORKSPACE="${NEWTON_WORKSPACE:-$(pwd)}"
+ONCE=false
+MAX_CYCLES=""
+CONVERGE_ROUNDS=""
+TARGET_GRADE=""
+DELIVERY=""
+AUTO_APPROVE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once)            ONCE=true; shift ;;
+    --max-cycles)      MAX_CYCLES="$2"; shift 2 ;;
+    --converge-rounds) CONVERGE_ROUNDS="$2"; shift 2 ;;
+    --target-grade)    TARGET_GRADE="$2"; shift 2 ;;
+    --delivery)        DELIVERY="$2"; shift 2 ;;
+    --auto-approve)    AUTO_APPROVE=true; shift ;;
+    -w|--workspace)    WORKSPACE="$2"; shift 2 ;;
+    -*)                echo "Unknown option: $1" >&2; exit 1 ;;
+    *)
+      if [ -z "$PROJECT_ID" ]; then PROJECT_ID="$1"; else echo "Unexpected arg: $1" >&2; exit 1; fi
+      shift ;;
+  esac
+done
+
+if [ -z "$PROJECT_ID" ]; then
+  echo "Usage: optimize.sh <project_id> [options]" >&2
+  exit 1
+fi
+
+CONF="${WORKSPACE}/.newton/configs/${PROJECT_ID}.conf"
+if [ ! -f "$CONF" ]; then
+  echo "Config not found: $CONF" >&2
+  exit 1
+fi
+
+# ── Load config ──────────────────────────────────────────────────────────────
+# shellcheck source=/dev/null
+source "$CONF"
+
+REPO_ID="${optimize_repo_id:-}"
+REPO_PATH="${optimize_repo_path:-$(pwd)}"
+TEST_CMD="${optimize_test_cmd:-./scripts/run-tests.sh}"
+GRADERS="${optimize_graders:-}"
+: "${MAX_CYCLES:=${optimize_max_cycles:-8}}"
+: "${CONVERGE_ROUNDS:=${optimize_converge_rounds:-2}}"
+: "${TARGET_GRADE:=${optimize_target_grade:-}}"
+: "${DELIVERY:=${delivery:-local}}"
+: "${AUTO_APPROVE:=${optimize_auto_approve:-false}}"
+MAX_FAILED_ATTEMPTS="${optimize_max_failed_attempts:-2}"
+REGRESSION_TOLERANCE="${optimize_regression_tolerance:-3}"
+
+if [ -z "$REPO_ID" ]; then
+  echo "optimize_repo_id must be set in $CONF" >&2
+  exit 1
+fi
+
+# ── Trajectory file ──────────────────────────────────────────────────────────
+TRAJ_DIR="${WORKSPACE}/.newton/optimize/${PROJECT_ID}"
+mkdir -p "$TRAJ_DIR"
+TRAJ="${TRAJ_DIR}/trajectory.jsonl"
+
+newton() { command newton --workspace "$WORKSPACE" "$@"; }
+
+log() { echo "[optimize] $*" >&2; }
+traj_append() { echo "$1" >> "$TRAJ"; }
+
+# ── Helper: read trajectory into arrays ──────────────────────────────────────
+traj_grades() {
+  # Emit the last N grade values for a given grader dimension key
+  local grader="$1" n="${2:-9999}"
+  if [ ! -f "$TRAJ" ]; then echo; return; fi
+  grep '"grader":"'"$grader"'"' "$TRAJ" | tail -n "$n" \
+    | python3 -c "
+import sys, json
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+        print(d.get('grade', ''))
+    except: pass"
+}
+
+traj_last_decision() {
+  if [ ! -f "$TRAJ" ]; then echo ""; return; fi
+  tail -1 "$TRAJ" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('decision',''))" 2>/dev/null || echo ""
+}
+
+traj_consecutive_none() {
+  # Count trailing consecutive decision=none rounds
+  if [ ! -f "$TRAJ" ]; then echo 0; return; fi
+  python3 - "$TRAJ" <<'PY'
+import sys, json
+rows = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line: continue
+        try: rows.append(json.loads(line))
+        except: pass
+count = 0
+for r in reversed(rows):
+    if r.get('decision') == 'none':
+        count += 1
+    else:
+        break
+print(count)
+PY
+}
+
+traj_blocked_count() {
+  # Count Findings with status=blocked for this repo
+  newton data get findings 2>/dev/null \
+    | python3 -c "
+import sys, json, os
+repo_id = os.environ.get('REPO_ID','')
+data = json.load(sys.stdin)
+blocked = [f for f in data if f.get('status') == 'blocked' and (not repo_id or f.get('repoId') == repo_id)]
+print(len(blocked))" REPO_ID="$REPO_ID" 2>/dev/null || echo 0
+}
+
+traj_prev_grade() {
+  local grader="$1"
+  if [ ! -f "$TRAJ" ]; then echo ""; return; fi
+  grep '"grader":"'"$grader"'"' "$TRAJ" | tail -2 | head -1 \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('grade',''))" 2>/dev/null || echo ""
+}
+
+traj_no_progress_count() {
+  # Count cycles where grade AND open_findings unchanged for a grader
+  local grader="$1"
+  if [ ! -f "$TRAJ" ]; then echo 0; return; fi
+  python3 - "$TRAJ" "$grader" <<'PY'
+import sys, json
+path, grader = sys.argv[1], sys.argv[2]
+rows = []
+with open(path) as f:
+    for line in f:
+        line = line.strip()
+        if not line: continue
+        try: d = json.loads(line)
+        except: continue
+        if d.get('grader') == grader:
+            rows.append(d)
+count = 0
+for r in reversed(rows):
+    if rows.index(r) == 0:
+        break
+    prev = rows[rows.index(r) - 1]
+    if r.get('grade') == prev.get('grade') and r.get('open_findings') == prev.get('open_findings'):
+        count += 1
+    else:
+        break
+print(count)
+PY
+}
+
+# ── Single grader cycle: grade → reconcile → change-request ──────────────────
+run_grading() {
+  local grader="$1" scope="repo" scope_id="$REPO_ID"
+  local grader_script="${WORKSPACE}/.newton/grader/${grader}/generate.sh"
+  if [ ! -x "$grader_script" ]; then
+    log "WARNING: grader script not found or not executable: $grader_script"
+    echo "none"
+    return
+  fi
+  local grader_cmd="${grader_script} ${scope_id} ${REPO_PATH}"
+  newton run "${WORKSPACE}/.newton/workflows/grading.yaml" \
+    --arg "grader=${grader}" \
+    --arg "grader_cmd=${grader_cmd}" \
+    --arg "scope=${scope}" \
+    --arg "scope_id=${scope_id}" \
+    2>&1 | tee /dev/stderr | grep -E "^PROPOSED |^CONVERGED" | head -1 || echo "none"
+}
+
+# ── Approve CR ───────────────────────────────────────────────────────────────
+approve_cr() {
+  local cr_id="$1"
+  if [ "$AUTO_APPROVE" = "true" ] || [ "$AUTO_APPROVE" = "1" ]; then
+    newton data patch change-request "$cr_id" --body '{"status":"approved"}' > /dev/null
+    log "Auto-approved CR $cr_id"
+  else
+    log "HIL gate: approve Change Request $cr_id before continuing"
+    log "(Run: newton data patch change-request $cr_id --body '{\"status\":\"approved\"}')"
+    # Block on ailoop HIL gate
+    ailoop --workspace "$WORKSPACE" --channel "optimize-${PROJECT_ID}" \
+      --message "Approve Change Request $cr_id? (yes/no)" \
+      --expect yes || { log "CR rejected by human; halting."; return 1; }
+    newton data patch change-request "$cr_id" --body '{"status":"approved"}' > /dev/null
+  fi
+}
+
+# ── Run planner ──────────────────────────────────────────────────────────────
+run_planner() {
+  local cr_id="$1"
+  newton run "${WORKSPACE}/.newton/workflows/planner.yaml" \
+    --arg "change_request_id=${cr_id}" \
+    2>&1 | grep -oE '[0-9a-f-]{36}' | tail -1 || echo ""
+}
+
+# ── Run develop ──────────────────────────────────────────────────────────────
+run_develop() {
+  local plan_id="$1"
+  newton run "${WORKSPACE}/.newton/workflows/develop.yaml" \
+    --arg "plan_id=${plan_id}" \
+    --arg "delivery=${DELIVERY}" \
+    --arg "test_cmd=${TEST_CMD}"
+}
+
+# ── Break condition helpers ──────────────────────────────────────────────────
+check_regression() {
+  local grader="$1" current_grade="$2"
+  local prev
+  prev=$(traj_prev_grade "$grader")
+  if [ -z "$prev" ]; then return 0; fi
+  local tol
+  local tol_var="optimize_regression_tolerance_${grader}"
+  tol="${!tol_var:-$REGRESSION_TOLERANCE}"
+  python3 -c "
+import sys
+prev, curr, tol = float('$prev'), float('$current_grade'), float('$tol')
+sys.exit(0 if (prev - curr) <= tol else 1)
+" && return 0 || return 1
+}
+
+check_target_grade() {
+  local grader="$1" current_grade="$2"
+  local tgt_var="optimize_target_grade_${grader}"
+  local tgt="${!tgt_var:-$TARGET_GRADE}"
+  if [ -z "$tgt" ]; then return 1; fi  # no target = not met (skip check)
+  python3 -c "import sys; sys.exit(0 if float('$current_grade') >= float('$tgt') else 1)"
+}
+
+# ── UUID helper ─────────────────────────────────────────────────────────────
+new_uuid() { python3 -c "import uuid; print(uuid.uuid4())"; }
+
+# ── Trap: mark run as failed on unexpected exit ───────────────────────────────
+RUN_ID=""
+_on_exit() {
+  local code=$?
+  if [ -n "$RUN_ID" ] && [ "$code" -ne 0 ]; then
+    newton data patch optimize-run "$RUN_ID" --body '{"status":"failed"}' > /dev/null 2>&1 || true
+  fi
+}
+trap _on_exit EXIT
+
+# ── Main loop ────────────────────────────────────────────────────────────────
+CYCLE=0
+log "Starting optimize loop for project=${PROJECT_ID} repo=${REPO_ID} graders=${GRADERS}"
+log "max_cycles=${MAX_CYCLES} converge_rounds=${CONVERGE_ROUNDS} delivery=${DELIVERY} auto_approve=${AUTO_APPROVE}"
+
+GRADERS_LIST=()
+read -ra GRADERS_LIST <<< "$GRADERS"
+
+# ── Create OptimizeRun record ────────────────────────────────────────────────
+GRADERS_JSON=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${GRADERS_LIST[@]}")
+RUN_ID=$(new_uuid)
+newton data post optimize-run --body "$(python3 -c "import json,sys; print(json.dumps({'id':sys.argv[1],'projectId':sys.argv[2],'scope':'repo','scopeId':sys.argv[3],'maxCycles':int(sys.argv[4]),'graders':json.loads(sys.argv[5])}))" "$RUN_ID" "$PROJECT_ID" "$REPO_ID" "$MAX_CYCLES" "$GRADERS_JSON")" > /dev/null 2>&1 || true
+log "OptimizeRun created: $RUN_ID"
+
+while true; do
+  CYCLE=$((CYCLE + 1))
+  log "=== Cycle ${CYCLE}/${MAX_CYCLES} ==="
+
+  # Break: max cycles
+  if [ "$CYCLE" -gt "$MAX_CYCLES" ]; then
+    log "STOP: max_cycles (${MAX_CYCLES}) reached"
+    traj_append '{"cycle":'$CYCLE',"event":"stop","reason":"max_cycles"}'
+    break
+  fi
+
+  CR_ID=""
+  DECISION="none"
+  GRADER_GRADES=()
+
+  for grader in "${GRADERS_LIST[@]}"; do
+    log "Grading with: $grader"
+    GRADING_OUT=$(run_grading "$grader" || true)
+
+    # Extract grade from most recent EvalRun
+    CURRENT_GRADE=$(newton data get eval-runs --scope repo --scope-id "$REPO_ID" 2>/dev/null \
+      | python3 -c "
+import sys, json, os
+data = json.load(sys.stdin)
+grader = os.environ.get('GRADER','')
+# find most recent score for this grader
+for r in reversed(data):
+    if r.get('source','').startswith(grader):
+        score = r.get('score')
+        if score is not None:
+            print(score)
+            sys.exit(0)
+print(0)" GRADER="$grader" 2>/dev/null || echo "0")
+
+    OPEN_FINDINGS=$(newton data get findings 2>/dev/null \
+      | python3 -c "
+import sys, json, os
+data = json.load(sys.stdin)
+repo_id = os.environ.get('REPO_ID','')
+open_s = {'awaiting_triage','triaged','approved_for_planning'}
+open_f = [f for f in data if f.get('repoId') == repo_id and f.get('status') in open_s]
+print(len(open_f))" REPO_ID="$REPO_ID" 2>/dev/null || echo "0")
+
+    # Break: regression guard (per-grader disjunction)
+    if ! check_regression "$grader" "$CURRENT_GRADE"; then
+      log "STOP: regression detected for grader=${grader} (grade dropped beyond tolerance)"
+      traj_append '{"cycle":'$CYCLE',"grader":"'"$grader"'","grade":'$CURRENT_GRADE',"event":"stop","reason":"regression"}'
+      exit 1
+    fi
+
+    # Break: no-progress guard (per-grader)
+    NO_PROG=$(traj_no_progress_count "$grader")
+    if [ "$NO_PROG" -ge "$CONVERGE_ROUNDS" ] && [ "$CYCLE" -gt "$CONVERGE_ROUNDS" ]; then
+      log "STOP: no-progress for grader=${grader} for ${NO_PROG} consecutive cycles"
+      traj_append '{"cycle":'$CYCLE',"grader":"'"$grader"'","grade":'$CURRENT_GRADE',"event":"stop","reason":"no_progress"}'
+      exit 1
+    fi
+
+    # Break: grade target (per-grader conjunction — check all at end)
+    GRADER_GRADES+=("$grader:$CURRENT_GRADE")
+
+    # Extract decision and CR ID from grading output
+    if echo "$GRADING_OUT" | grep -q "^PROPOSED "; then
+      DECISION="propose"
+      CR_ID=$(echo "$GRADING_OUT" | grep "^PROPOSED " | awk '{print $2}')
+    fi
+
+    traj_append '{"cycle":'$CYCLE',"grader":"'"$grader"'","grade":'$CURRENT_GRADE',"open_findings":'$OPEN_FINDINGS',"decision":"'"$DECISION"'","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
+    log "grader=${grader} grade=${CURRENT_GRADE} open_findings=${OPEN_FINDINGS} decision=${DECISION}"
+  done
+
+  # ── Mirror cycle to store ─────────────────────────────────────────────────
+  BLOCKED_COUNT_NOW=$(traj_blocked_count)
+  GRADES_OBJ=$(python3 -c "
+import json, sys
+grades = {}
+for entry in sys.argv[1:]:
+    grader, grade = entry.rsplit(':', 1)
+    try: grades[grader] = float(grade)
+    except: grades[grader] = 0
+print(json.dumps(grades))" "${GRADER_GRADES[@]-}")
+  GRADE_MIN_VAL=$(python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+vals = list(d.values())
+print(min(vals) if vals else 0)" "$GRADES_OBJ")
+  CYCLE_ID=$(new_uuid)
+  newton data post optimize-cycle --body "$(python3 -c "
+import json,sys
+print(json.dumps({'id':sys.argv[1],'runId':sys.argv[2],'cycle':int(sys.argv[3]),'grades':json.loads(sys.argv[4]),'gradeMin':float(sys.argv[5]),'decision':sys.argv[6],'openFindings':int(sys.argv[7]),'resolvedThisCycle':0}))" "$CYCLE_ID" "$RUN_ID" "$CYCLE" "$GRADES_OBJ" "$GRADE_MIN_VAL" "$DECISION" "$OPEN_FINDINGS")" > /dev/null 2>&1 || true
+  newton data patch optimize-run "$RUN_ID" --body "$(python3 -c "
+import json,sys
+print(json.dumps({'cycle':int(sys.argv[1]),'latestGrades':json.loads(sys.argv[2]),'openFindings':int(sys.argv[3]),'blockedFindings':int(sys.argv[4])}))" "$CYCLE" "$GRADES_OBJ" "$OPEN_FINDINGS" "$BLOCKED_COUNT_NOW")" > /dev/null 2>&1 || true
+
+  # Break: grade target — conjunction (all graders clear their threshold)
+  if [ -n "$TARGET_GRADE" ]; then
+    ALL_TARGETS_MET=true
+    for entry in "${GRADER_GRADES[@]}"; do
+      grader="${entry%%:*}"
+      grade="${entry##*:}"
+      if ! check_target_grade "$grader" "$grade"; then
+        ALL_TARGETS_MET=false
+        break
+      fi
+    done
+    if [ "$ALL_TARGETS_MET" = "true" ]; then
+      log "STOP: all grade targets met"
+      traj_append '{"cycle":'$CYCLE',"event":"stop","reason":"target_grade"}'
+      break
+    fi
+  fi
+
+  # Break: converged (no actionable work AND no blocked Findings)
+  CONSECUTIVE_NONE=$(traj_consecutive_none)
+  BLOCKED_COUNT=$(traj_blocked_count)
+  if [ "$DECISION" = "none" ]; then
+    if [ "$BLOCKED_COUNT" -gt 0 ]; then
+      # No actionable work but blocked Findings remain → stalled_on_blocked
+      if [ "$CONSECUTIVE_NONE" -ge 1 ]; then
+        log "STOP: stalled_on_blocked — ${BLOCKED_COUNT} blocked Finding(s) remain, no actionable work"
+        traj_append '{"cycle":'$CYCLE',"event":"stop","reason":"stalled_on_blocked","blocked_findings":'$BLOCKED_COUNT'}'
+        break
+      fi
+    else
+      if [ "$CONSECUTIVE_NONE" -ge "$CONVERGE_ROUNDS" ]; then
+        log "STOP: converged — decision=none for ${CONSECUTIVE_NONE} consecutive rounds, zero blocked Findings"
+        traj_append '{"cycle":'$CYCLE',"event":"stop","reason":"converged"}'
+        break
+      fi
+    fi
+    log "No actionable findings this cycle (${CONSECUTIVE_NONE}/${CONVERGE_ROUNDS} none-rounds)"
+    if [ "$ONCE" = "true" ]; then break; fi
+    continue
+  fi
+
+  if [ -z "$CR_ID" ]; then
+    log "WARNING: decision=propose but no CR ID captured; skipping cycle"
+    if [ "$ONCE" = "true" ]; then break; fi
+    continue
+  fi
+
+  log "Change Request: $CR_ID"
+
+  # Step 3: Approve
+  if ! approve_cr "$CR_ID"; then
+    log "HALT: CR approval failed"
+    exit 1
+  fi
+
+  # Step 4: Plan
+  log "Running planner for CR $CR_ID"
+  PLAN_ID=$(run_planner "$CR_ID")
+  if [ -z "$PLAN_ID" ]; then
+    log "WARNING: planner did not return a plan_id; skipping cycle"
+    if [ "$ONCE" = "true" ]; then break; fi
+    continue
+  fi
+  log "Plan created: $PLAN_ID"
+  traj_append '{"cycle":'$CYCLE',"event":"plan","plan_id":"'"$PLAN_ID"'","change_request_id":"'"$CR_ID"'"}'
+
+  # Step 5: Develop (with failed-plan quarantine logic)
+  DEVELOP_STATUS="success"
+  if ! run_develop "$PLAN_ID"; then
+    DEVELOP_STATUS="failed"
+    log "Develop failed for plan $PLAN_ID"
+
+    # Increment attempts on Plan
+    CURRENT_ATTEMPTS=$(newton data get plan "$PLAN_ID" 2>/dev/null \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('attempts',0))" 2>/dev/null || echo 0)
+    NEW_ATTEMPTS=$((CURRENT_ATTEMPTS + 1))
+    newton data patch plan "$PLAN_ID" --body '{"status":"failed","attempts":'"$NEW_ATTEMPTS"',"lastError":"develop failed"}' > /dev/null || true
+
+    if [ "$NEW_ATTEMPTS" -ge "$MAX_FAILED_ATTEMPTS" ]; then
+      log "Plan $PLAN_ID reached max failed attempts (${MAX_FAILED_ATTEMPTS}); marking linked Findings as blocked"
+      # Get finding IDs from CR
+      FINDING_IDS=$(newton data get change-request "$CR_ID" 2>/dev/null \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(d.get('findingIds',[])))" 2>/dev/null || echo "")
+      for fid in $FINDING_IDS; do
+        newton data patch finding "$fid" --body '{"status":"blocked"}' > /dev/null || true
+        log "Finding $fid → blocked"
+      done
+      traj_append '{"cycle":'$CYCLE',"event":"quarantine","plan_id":"'"$PLAN_ID"'","change_request_id":"'"$CR_ID"'","blocked_findings":"'"$FINDING_IDS"'"}'
+    fi
+  else
+    newton data patch plan "$PLAN_ID" --body '{"status":"complete"}' > /dev/null || true
+    log "Plan $PLAN_ID → complete"
+  fi
+
+  traj_append '{"cycle":'$CYCLE',"event":"develop","plan_id":"'"$PLAN_ID"'","status":"'"$DEVELOP_STATUS"'"}'
+
+  if [ "$ONCE" = "true" ]; then
+    log "--once: stopping after one cycle"
+    break
+  fi
+done
+
+log "Optimize loop finished. Trajectory: $TRAJ"
+newton data patch optimize-run "$RUN_ID" --body '{"status":"complete"}' > /dev/null 2>&1 || true

--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -57,6 +57,9 @@ GRADERS="${optimize_graders:-}"
 MAX_FAILED_ATTEMPTS="${optimize_max_failed_attempts:-2}"
 REGRESSION_TOLERANCE="${optimize_regression_tolerance:-3}"
 
+GRADERS_LIST=()
+read -ra GRADERS_LIST <<< "$GRADERS"
+
 if [ -z "$REPO_ID" ]; then
   echo "optimize_repo_id must be set in $CONF" >&2
   exit 1
@@ -71,6 +74,22 @@ newton() { command newton --workspace "$WORKSPACE" "$@"; }
 
 log() { echo "[optimize] $*" >&2; }
 traj_append() { echo "$1" >> "$TRAJ"; }
+
+# ── Deterministic-grader K=1 forcing (§13.7) ──────────────────────────────────
+# If ALL active graders are marked deterministic in the conf, force CONVERGE_ROUNDS=1.
+# A deterministic grader's second identical round proves nothing.
+_all_deterministic=true
+for _g in "${GRADERS_LIST[@]:-}"; do
+  _det_var="optimize_grader_deterministic_${_g}"
+  if [ "${!_det_var:-false}" != "true" ]; then
+    _all_deterministic=false
+    break
+  fi
+done
+if [ "$_all_deterministic" = "true" ] && [ "${#GRADERS_LIST[@]}" -gt 0 ]; then
+  CONVERGE_ROUNDS=1
+  log "All graders are deterministic — forcing CONVERGE_ROUNDS=1 (§13.7)"
+fi
 
 # ── Helper: read trajectory into arrays ──────────────────────────────────────
 traj_grades() {
@@ -254,9 +273,6 @@ trap _on_exit EXIT
 CYCLE=0
 log "Starting optimize loop for project=${PROJECT_ID} repo=${REPO_ID} graders=${GRADERS}"
 log "max_cycles=${MAX_CYCLES} converge_rounds=${CONVERGE_ROUNDS} delivery=${DELIVERY} auto_approve=${AUTO_APPROVE}"
-
-GRADERS_LIST=()
-read -ra GRADERS_LIST <<< "$GRADERS"
 
 # ── Create OptimizeRun record ────────────────────────────────────────────────
 GRADERS_JSON=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${GRADERS_LIST[@]}")

--- a/.newton/workflows/develop.yaml
+++ b/.newton/workflows/develop.yaml
@@ -1,17 +1,16 @@
 version: '2.0'
 mode: workflow_graph
 metadata:
-  name: rust-workflow
-  description: Implement from a repo-local spec path. Prefer raw_spec_path + board_issue_number + board_item_title (develop.sh); workflow copies into tmp/<issue>-<slug>.md before git work.
+  name: develop-workflow
+  description: 'Implement from a Plan id or raw_spec_path. Pluggable delivery: local (ff-merge) or pr.'
 triggers:
   type: manual
   schema_version: '1.0'
   payload:
-    prompt: ''
+    plan_id: ''
     raw_spec_path: ''
-    board_item_id: ''
-    board_issue_number: ''
-    board_item_title: ''
+    delivery: 'local'
+    test_cmd: './scripts/run-tests.sh'
     skip_gh_pr_approve: 'true'
 workflow:
   settings:
@@ -34,11 +33,11 @@ workflow:
   context:
     preamble: |-
       Implement the following spec in the target source code target.
-      After you have applied the changes and ./scripts/run-tests.sh completes with no errors, print exactly <status>COMPLETED</status> in your final output.
-    codescene_preamble: Fix code health issues reported by CodeScene. Work in the target source code base; run ./scripts/run-tests.sh to verify. Do not require a COMPLETED marker.
+      After you have applied the changes and the test command completes with no errors, print exactly <status>COMPLETED</status> in your final output.
+    codescene_preamble: Fix code health issues reported by CodeScene. Work in the target source code base; run the configured test command to verify. Do not require a COMPLETED marker.
     precommit_fix_preamble: |-
       The pre-commit hook rejected a commit. The full hook output is below.
-      Fix all reported issues in the codebase. Run ./scripts/run-tests.sh to verify.
+      Fix all reported issues in the codebase. Run the configured test command to verify.
       Do not attempt to commit; only fix the code.
     validation_preamble: |-
       You are a reviewer. You will be given the spec path (read the spec file in the workspace) and a bounded diff vs main (stat plus truncated patch).
@@ -72,69 +71,38 @@ workflow:
       params:
         operation: sync_main
       transitions:
-        - to: resolve_board_ids
-      name: Sync main branch
-    - id: resolve_board_ids
-      operator: GhOperator
-      params:
-        operation: project_resolve_board
-        owner:
-          $expr: env("GH_PROJECT_OWNER")
-        project_number:
-          $expr: env("GH_PROJECT_NUMBER")
-      transitions:
-        - to: move_to_in_progress
-      name: Pick next Issue
-    - id: move_to_in_progress
-      operator: GhOperator
-      params:
-        operation: project_item_set_status
-        item_id:
-          $expr: triggers.board_item_id
-        board:
-          $expr: tasks.resolve_board_ids.output
-        status: In progress
-        on_error: warn
-      transitions:
         - to: prepare_spec_paths
-      name: Move Issue to In Progress
+      name: Sync main branch
     - id: prepare_spec_paths
       operator: CommandOperator
       params:
         shell: true
         capture_stdout: true
         env:
-          ISSUE:
-            $expr: triggers.board_issue_number
-          TITLE:
-            $expr: triggers.board_item_title
+          PLAN_ID:
+            $expr: triggers.plan_id
           RAW_SPEC:
             $expr: triggers.raw_spec_path
-          LEGACY_PROMPT:
-            $expr: triggers.prompt
+          WORKSPACE:
+            $expr: 'triggers.workspace'
         cmd: |
           set -eo pipefail
           mkdir -p .newton/plan tmp
-          slugify() {
-            s=$(printf '%s' "${TITLE:-}" | iconv -f utf-8 -t ascii//TRANSLIT 2>/dev/null || printf '%s' "${TITLE:-}")
-            s=$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
-            [ -z "$s" ] && s="spec"
-            printf '%s' "$s" | cut -c1-60 | sed -E 's/-+$//'
-          }
-          if [ -n "$RAW_SPEC" ] && [ -f "$RAW_SPEC" ]; then
-            slug=$(slugify)
-            OUT="tmp/${ISSUE}-${slug}.md"
-            if [ "$RAW_SPEC" != "$OUT" ]; then
-              cp "$RAW_SPEC" "$OUT"
-            fi
+          if [ -n "$PLAN_ID" ]; then
+            OUT="tmp/plan-${PLAN_ID}.md"
+            newton --workspace "${WORKSPACE:-.}" data get plan "$PLAN_ID" \
+              | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('body',''))" > "$OUT"
+            BRANCH="feature/plan-${PLAN_ID}"
+          elif [ -n "$RAW_SPEC" ] && [ -f "$RAW_SPEC" ]; then
+            OUT="$RAW_SPEC"
+            SLUG=$(basename "$RAW_SPEC" .md | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//')
+            BRANCH="feature/${SLUG}"
           else
-            OUT="$LEGACY_PROMPT"
-            if [ -z "$OUT" ] || [ ! -f "$OUT" ]; then
-              echo "prepare_spec_paths: set raw_spec_path to an existing file or pass prompt with a readable path"
-              exit 1
-            fi
+            echo "prepare_spec_paths: set plan_id or raw_spec_path to an existing file" >&2
+            exit 1
           fi
           printf '%s\n' "$OUT" > .newton/plan/.develop-prompt-path
+          printf '%s\n' "$BRANCH" > .newton/plan/.develop-branch
           echo "spec_path=$OUT"
       transitions:
         - to: read_develop_spec_path
@@ -153,7 +121,7 @@ workflow:
       params:
         operation: create_branch
         name:
-          $expr: '"feature/" + file_stem(tasks.read_develop_spec_path.output.stdout)'
+          $expr: '"feature/plan-" + triggers.plan_id'
       transitions:
         - to: load_spec
       name: Create Branch
@@ -195,7 +163,8 @@ workflow:
       operator: CommandOperator
       params:
         shell: true
-        cmd: ./scripts/run-tests.sh
+        cmd:
+          $expr: triggers.test_cmd
         capture_stdout: true
         capture_stderr: true
       transitions:
@@ -214,7 +183,7 @@ workflow:
         model:
           $expr: develop_secondary_model
         prompt:
-          $expr: 'context.preamble + "\n\nSpec path: " + tasks.read_develop_spec_path.output.stdout + "\n\nSpec content:\n" + tasks.load_spec.output.stdout + "\n\nTests failed. Fix the issues and re-run ./scripts/run-tests.sh:\n" + tasks.run_tests.output.stdout'
+          $expr: 'context.preamble + "\n\nSpec path: " + tasks.read_develop_spec_path.output.stdout + "\n\nSpec content:\n" + tasks.load_spec.output.stdout + "\n\nTests failed. Fix the issues and re-run the test command:\n" + tasks.run_tests.output.stdout'
       transitions:
         - to: run_tests
     - id: snapshot_commit
@@ -223,7 +192,7 @@ workflow:
       params:
         operation: commit
         message:
-          $expr: '"chore(develop): " + file_stem(tasks.read_develop_spec_path.output.stdout)'
+          $expr: '"chore(develop): snapshot " + triggers.plan_id'
         allow_empty: false
       transitions:
         - to: get_diff
@@ -245,7 +214,7 @@ workflow:
         model:
           $expr: develop_secondary_model
         prompt:
-          $expr: context.precommit_fix_preamble + "\n\nPre-commit hook rejected the snapshot commit. Run ./scripts/run-tests.sh to verify fixes."
+          $expr: context.precommit_fix_preamble + "\n\nPre-commit hook rejected the snapshot commit. Run the configured test command to verify fixes."
       transitions:
         - to: snapshot_commit
     - id: get_diff
@@ -291,7 +260,6 @@ workflow:
         shell: true
         cmd: |
           echo "develop: validation preflight failed — spec+diff exceeds safe prompt budget." >&2
-          echo "See validation_preflight output for byte counts. Split the change or spec before re-running." >&2
           exit 1
         capture_stdout: false
       terminal: failure
@@ -386,7 +354,7 @@ workflow:
       operator: CommandOperator
       params:
         shell: true
-        cmd: echo "No changes to commit; skipping PR."
+        cmd: echo "No changes to commit; skipping delivery."
         capture_stdout: false
       terminal: success
     - id: git_commit
@@ -394,10 +362,10 @@ workflow:
       params:
         operation: commit
         message:
-          $expr: '"feat: implement " + file_stem(tasks.read_develop_spec_path.output.stdout)'
+          $expr: '"feat: implement plan " + triggers.plan_id'
         allow_empty: false
       transitions:
-        - to: git_push
+        - to: route_delivery
           priority: 0
           when:
             $expr: tasks.git_commit.output.committed == true || tasks.git_commit.output.skipped == true
@@ -416,9 +384,55 @@ workflow:
         model:
           $expr: develop_secondary_model
         prompt:
-          $expr: context.precommit_fix_preamble + "\n\nPre-commit hook rejected the final commit. Run ./scripts/run-tests.sh to verify fixes."
+          $expr: context.precommit_fix_preamble + "\n\nPre-commit hook rejected the final commit. Run the configured test command to verify fixes."
       transitions:
         - to: git_commit
+
+    # ── Delivery routing ────────────────────────────────────────────────────────
+    - id: route_delivery
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "routing delivery: ${DELIVERY}"'
+        capture_stdout: false
+        env:
+          DELIVERY:
+            $expr: triggers.delivery
+      transitions:
+        - to: local_merge
+          priority: 0
+          when:
+            $expr: triggers.delivery == "local"
+        - to: git_push
+          priority: 10
+
+    # ── Local delivery ──────────────────────────────────────────────────────────
+    - id: local_merge
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          BRANCH:
+            $expr: '"feature/plan-" + triggers.plan_id'
+          PLAN_ID:
+            $expr: triggers.plan_id
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          set -eo pipefail
+          git checkout main
+          git merge --ff-only "$BRANCH" || git merge --no-edit "$BRANCH"
+          echo "local_merge: merged $BRANCH into main"
+          # Update Plan status to complete
+          if [ -n "$PLAN_ID" ]; then
+            newton --workspace "${WORKSPACE:-.}" data patch plan "$PLAN_ID" \
+              --body '{"status":"complete"}' || true
+          fi
+      transitions:
+        - to: success
+
+    # ── PR delivery ─────────────────────────────────────────────────────────────
     - id: git_push
       operator: GitOperator
       params:
@@ -435,22 +449,10 @@ workflow:
         operation: pr_create
         base: main
         title:
-          $expr: '"feat: implement " + file_stem(tasks.read_develop_spec_path.output.stdout)'
-        body: Implements spec. Merge with squash.
+          $expr: '"feat: implement plan " + triggers.plan_id'
+        body: Implements plan. Merge with squash.
         retry_count: 3
         retry_delay_ms: 5000
-      transitions:
-        - to: move_to_in_review
-    - id: move_to_in_review
-      operator: GhOperator
-      params:
-        operation: project_item_set_status
-        item_id:
-          $expr: triggers.board_item_id
-        board:
-          $expr: tasks.resolve_board_ids.output
-        status: In review
-        on_error: warn
       transitions:
         - to: poll_pr
           priority: 0
@@ -481,7 +483,7 @@ workflow:
           priority: 0
           when:
             $expr: tasks.poll_pr.output.state == "MERGED"
-        - to: move_to_ready_on_close
+        - to: fail_pr_closed
           priority: 1
           when:
             $expr: tasks.poll_pr.output.state == "CLOSED"
@@ -491,8 +493,6 @@ workflow:
             $expr: tasks.poll_pr.output.state == "OPEN"
         - to: sleep_merge_unknown
           priority: 10
-          when:
-            $expr: tasks.poll_pr.output.state != "OPEN" && tasks.poll_pr.output.state != "MERGED" && tasks.poll_pr.output.state != "CLOSED"
       name: Wait for PR Acceptance
     - id: sleep_merge_wait
       operator: CommandOperator
@@ -512,18 +512,6 @@ workflow:
         capture_stdout: false
       transitions:
         - to: poll_pr
-    - id: move_to_ready_on_close
-      operator: GhOperator
-      params:
-        operation: project_item_set_status
-        item_id:
-          $expr: triggers.board_item_id
-        board:
-          $expr: tasks.resolve_board_ids.output
-        status: Ready
-        on_error: warn
-      transitions:
-        - to: fail_pr_closed
     - id: fail_pr_closed
       operator: CommandOperator
       params:
@@ -537,25 +525,35 @@ workflow:
       params:
         operation: cleanup_merge
       transitions:
-        - to: move_to_done
-    - id: move_to_done
-      operator: GhOperator
+        - to: mark_plan_complete_pr
+
+    - id: mark_plan_complete_pr
+      operator: CommandOperator
       params:
-        operation: project_item_set_status
-        item_id:
-          $expr: triggers.board_item_id
-        board:
-          $expr: tasks.resolve_board_ids.output
-        status: Done
-        on_error: warn
+        shell: true
+        capture_stdout: false
+        env:
+          PLAN_ID:
+            $expr: triggers.plan_id
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          if [ -n "$PLAN_ID" ]; then
+            newton --workspace "${WORKSPACE:-.}" data patch plan "$PLAN_ID" \
+              --body '{"status":"complete"}' || true
+          fi
       transitions:
         - to: success
+
     - id: success
       operator: CommandOperator
       params:
         shell: true
-        cmd: echo "Job is completed based on opencode output" | tee /dev/tty
+        cmd: echo "develop: completed plan ${PLAN_ID}"
         capture_stdout: false
+        env:
+          PLAN_ID:
+            $expr: triggers.plan_id
       terminal: success
     - id: retry_implementation
       operator: CommandOperator

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,7 +41,7 @@ The `change-request` phase is the loop's *optimizer step*: it reads the standing
 `grade (→ Assessment) → reconcile (→ Findings) → change-request (→ Change Request)
 → plan → implement → grade`.
 (As of this writing the edge is **designed but not yet wired** in code; the
-vocabulary and ADR 0005 describe the target.)
+vocabulary and ADR 0009 describe the target.)
 
 ### Objective
 The project-defined goal the optimization loop drives toward — *what progress
@@ -153,7 +153,18 @@ reconciliation metadata (`fingerprint`, `last_seen_at`). Lifecycle:
 deferred | rejected`, plus **`resolved`** — set *automatically* by
 **Reconciliation** when the issue vanishes (the per-Finding convergence signal),
 firmly distinct from the human `rejected`/`deferred` (Reconciliation never
-resurrects a human-closed Finding; it reopens a `resolved` one if it recurs). A Finding's identity is
+resurrects a human-closed Finding; it reopens a `resolved` one if it recurs) —
+and **`blocked`** — set *automatically* by the loop when the **Plan** implementing
+this Finding **fails** develop after the configured retry budget. A `blocked`
+Finding is **fenced from the work pipeline** (the `change-request` synthesis skips
+it, so it never re-enters Plan/develop) yet stays open and keeps being refreshed
+by Reconciliation (the problem is still in the code); it is **cleared only by a
+human** (un-block to retry, or fix it directly so it auto-`resolved`s). Distinct
+from `deferred`/`rejected` (human-closed) and `resolved` (auto-closed): `blocked`
+means "the loop tried and could not, a human must act." A loop run that reaches
+no-more-actionable-work with `blocked` Findings still open ends in
+**`stalled_on_blocked`** (needs-human), *not* the clean **`converged`** success
+endpoint. A Finding's identity is
 **assigned and maintained by Newton via Reconciliation — never taken from a
 Grader** (Graders are non-deterministic and cannot supply stable ids). Findings
 are the standing text-gradient that the loop synthesizes (Score-prioritized) into
@@ -174,6 +185,18 @@ cannot be matched by equality. Reconciliation is what gives Findings stable
 identity and yields per-Finding resolution tracking, a richer convergence signal
 than the scalar Grade delta.
 
+**Resolution tracking is best-effort, not exact — by design.** With
+non-deterministic graders (different wording each run) and location-less findings
+(no natural key), perfectly accounting for every Finding's open/resolved transition
+is **not achievable in principle**, only approximated. The loop is therefore a
+**fuzzy optimizer** (closer to a genetic/stochastic search than a crisp state
+machine): it tolerates imperfect matching and converges through **re-grading plus
+the break conditions** (a still-present problem is simply re-reported next run and
+re-matched), never relying on exact per-Finding bookkeeping. Mis-matches degrade
+*quality and efficiency* (blurry tracking, an occasional merged/muddled Change
+Request), not *correctness* — the loop does not declare victory while a problem is
+still detectable.
+
 ### Plan
 A unit of queued work a project's optimization loop consumes — the spec for one
 Step. This is the canonical noun; "work item", "task", and "batch item" are
@@ -181,8 +204,26 @@ deprecated synonyms to be removed.
 
 ### Plan queue
 The per-project backlog of Plans and their lifecycle:
-`todo → completed | failed` (with `draft`, `abandoned` as holding states). The
-queue is the only durable state the loop owns between Steps.
+`draft → ready → running → complete | failed`, plus **`abandoned`** as a holding
+state (a human shelved or rejected the Plan, distinct from `failed` which is a
+develop/test failure). `draft` = planner emitted, not yet approved; `ready` =
+approved, queued for develop; `running` = develop executing; `complete` = develop
+succeeded and merged; `failed` = develop/tests failed after retries. The queue is
+the only durable state the loop owns between Steps.
+
+### Trajectory
+The **Optimization loop**'s flight recorder: the ordered, per-cycle record of the
+path a scope takes toward its **Objective** — one entry per cycle capturing that
+cycle's `Grade`(s), `decision` (`propose | none`), the `Plan`/`Execution` it ran,
+`develop` outcome, and open/resolved **Finding** counts. Written by the loop driver
+(as `.newton/optimize/<scope>/trajectory.jsonl`). It has two jobs: the **audit
+trail** ("what did the loop do, and why did it stop?") and the **input to the break
+conditions** — regression, no-progress, max-cycles, and convergence are all judged
+over the Trajectory, never from a single moment. Borrowed from optimization: the
+sequence of states a system traces through its state-space over time.
+_Avoid_: "history"/"log" (too generic — it is the structured per-cycle series the
+break conditions read), confusing it with an **Execution** (one develop run *within*
+a cycle; the Trajectory spans *all* cycles).
 
 ### Driver
 A way to set Steps running over the one execution engine. Newton has exactly
@@ -193,6 +234,18 @@ these drivers, distinguished only by what originates the work:
 
 External HTTP *ingress* (an outside system POSTing to start a Step) is **out of
 scope**: Newton's optimizer is self-driving, not event-driven. See ADR 0004.
+
+### Projection
+A representation of Newton-owned state in an external work surface, such as a
+project board or issue tracker. A Projection may help humans discover or trigger
+work, but it is never the source of truth for the loop. The durable entity remains
+in Newton — for example, a **Change Request** may be projected as an external
+issue, but the issue is not the Change Request, the **Finding**, or the **Plan**.
+External status is a mirror of Newton lifecycle state; in the ideal loop Newton
+drives Projection state changes rather than inferring domain truth from the
+external surface.
+_Avoid_: treating external issue status as the durable Plan queue or using
+"issue" as a synonym for any Newton entity.
 
 ### ailoop (not a Driver)
 Outbound, WebSocket-only human-in-the-loop: mid-Step, Newton reaches *out* to a
@@ -205,6 +258,26 @@ is unrelated.
 The portfolio model is the cross-scope view that *consumes* loop outputs for
 human resourcing decisions. It does not drive any single loop's steps.
 
+### Scope hierarchy (read this first)
+The four scopes nest **Product → Component → Repo → Module**, largest to smallest:
+
+```
+Product        e.g. "Newton"              (business product)
+└─ Component   e.g. "newton-engine"       (team-owned system; a microservice/platform)
+   └─ Repo     e.g. github.com/org/newton (one git repository)
+      └─ Module e.g. crate `newton-core`  (one crate/package inside the repo)
+```
+
+**The ordering is counterintuitive on purpose — guard against it.** A *Component*
+is **larger** than a *Repo* (it can own several), even though "component" colloquially
+sounds like a small part; and a *Module* is **smaller** than a Repo (a Repo holds
+many), even though a Repo may have exactly one. A **Component can contain multiple
+Repos; a Repo can contain multiple Modules.** Graders target a **Repo** by default;
+a **Plan** may narrow to a single **Module** within that Repo (e.g. "refactor crate
+`newton-core`") when work is crate-scoped. When in doubt: Module = the publishable
+unit (a crate/npm package), Repo = the git boundary, Component = the ownership/
+deployment boundary, Product = the business boundary.
+
 ### Product
 The top of the portfolio hierarchy: a business-level product or service that
 groups **Components** under a common ownership boundary.
@@ -212,9 +285,12 @@ _Avoid_: "service", "project".
 
 ### Component
 A bounded technical system owned by one team, belonging to one **Product**;
-roughly a microservice or platform. Carries `owner`, **Criticality**, and
+roughly a microservice or platform. **It is larger than a Repo and may own several
+Repos** — not a part *of* a Repo. Carries `owner`, **Criticality**, and
 **Autonomy**.
-_Avoid_: "service", "domain".
+_Avoid_: "service", "domain"; **and do not read it as a *code* component** (a UI
+widget, a Rust crate, a software sub-module) — those are **Modules**, the smallest
+scope, the opposite end of the hierarchy.
 
 ### Repo
 A git repository belonging to a **Component**, and the scope most Graders target
@@ -222,10 +298,13 @@ directly. Carries quality **Scores** (e.g. qualityScore, coverage, secScore) and
 execution state.
 
 ### Module
-A package or library inside a **Repo** (Rust crate, npm/pip package, gem, jar).
-The lowest-granularity portfolio unit; the unit of reasoning for **Dependency
-mapping**.
-_Avoid_: "package"/"library" except in language-specific contexts.
+A package or library inside a **Repo** (Rust crate, npm/pip package, gem, jar) —
+a **whole publishable unit**, the lowest-granularity portfolio scope and the unit
+of reasoning for **Dependency mapping**. A Repo holds **one or many** Modules.
+_Avoid_: "package"/"library" except in language-specific contexts; **and do not
+read it as a *language-level* module** (a Rust `mod`, a Python `.py` file) — those
+are intra-crate, far below this scope. In Rust terms a Module here is a **crate/
+package**, never a `mod`.
 
 ### Portfolio
 An aggregated view linking a **Product** to its active **Plans** and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -225,6 +225,27 @@ _Avoid_: "history"/"log" (too generic — it is the structured per-cycle series 
 break conditions read), confusing it with an **Execution** (one develop run *within*
 a cycle; the Trajectory spans *all* cycles).
 
+### Optimize Run
+One invocation of the **Optimization loop** over a scope — the durable, addressable
+record of "this project being driven toward its Objective from start to stop." It
+owns a `status` (`running | converged | stalled_on_blocked | max_cycles | regressed
+| no_progress`), the configured graders, and an ordered set of **Cycles**; its
+**Trajectory** is the per-cycle series within it. A Run is the **top of the nesting**
+— one Run contains many Cycles; each Cycle fires several **Steps** and produces one
+**Execution**. This is the proper-noun entity behind the `optimize` driver.
+_Avoid_: bare "run" (ambiguous — a **Step** is also "a workflow run" and an
+**Execution** is colloquially "this run"); say **Optimize Run** for the loop
+invocation, **Step** for one workflow run, **Execution** for one develop run.
+
+### Cycle
+One iteration of an **Optimize Run**: a single pass of `grade → reconcile →
+change-request → (approve) → plan → develop → re-grade`. A Cycle contains several
+**Steps** (the grading / planner / develop workflow runs) and at most one develop
+**Execution**; it is the unit recorded as one row of the **Trajectory**. Many Cycles
+make one **Optimize Run**.
+_Avoid_: "iteration"/"round" (informal), "Step" (a Step is *one workflow run within*
+a Cycle, not the Cycle itself).
+
 ### Driver
 A way to set Steps running over the one execution engine. Newton has exactly
 these drivers, distinguished only by what originates the work:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Newton
 
-**Newton** is a workflow-first CLI for deterministic automation and orchestration. You define steps in YAML (shell commands, agents, human approvals, branching, nested workflows), and Newton runs them with explicit completion rules, checkpoints, and artifacts. It fits agent-assisted coding, release checklists, and batch plan queues where you want a defined graph instead of ad hoc scripts.
+**Newton** is a workflow-first CLI for deterministic automation and orchestration — **and an autonomous optimizer**. You define steps in YAML (shell commands, agents, human approvals, branching, nested workflows), and Newton runs them with explicit completion rules, checkpoints, and artifacts. On top of that, Newton drives an **optimization loop** that grades a project and improves it toward a target Grade. It fits agent-assisted coding, release checklists, and self-improving optimization loops where you want a defined graph instead of ad hoc scripts.
 
-Version: **0.5.109** · Repository: [github.com/gonewton/newton](https://github.com/gonewton/newton)
+Version: **0.5.117** · Repository: [github.com/gonewton/newton](https://github.com/gonewton/newton)
 
 ## Installation
 
@@ -25,7 +25,7 @@ Verify: `newton --version` and `newton --help`.
 ## Prerequisites
 
 - The **Newton CLI** (installed above).
-- **Optional**: Git for version control, hooks, and batch workflows.
+- **Optional**: Git for version control, hooks, and the optimization loop's local-merge delivery.
 
 `newton init .` scaffolds a workspace and installs the default template via the bundled **aikit-sdk** (statically linked). You do **not** need the `aikit` binary on your `PATH` for init.
 
@@ -44,7 +44,7 @@ Verify: `newton --version` and `newton --help`.
    newton workflow run path/to/workflow.yaml --workspace .
    ```
 
-For an existing repository, run `newton init .` at the repo root. Edit `.newton/configs/default.conf` to set `workflow_file` when using batch mode (see [Batch mode](#batch-mode) below).
+For an existing repository, run `newton init .` at the repo root. Edit `.newton/configs/default.conf` to set `workflow_file`, or add an `optimize_*` block to drive the [optimization loop](#optimization-loop).
 
 ## What you get
 
@@ -69,10 +69,13 @@ For operator reference, see [docs/operators/](docs/operators/) and the [Newton s
 | `newton workflow runs list\|show` | Inspect past executions |
 | `newton workflow checkpoint\|artifact` | Manage checkpoints and artifacts |
 | `newton init [path]` | Scaffold `.newton/` and install template |
-| `newton batch <project_id>` | Process queued plan files |
-| `newton serve` | HTTP/WebSocket API for workflow state and integrations |
-| `newton webhook serve\|status` | Trigger workflows from external HTTP events |
+| `newton optimize <project_id>` | Drive the optimization loop / drain the Plan queue (renamed from `batch`) |
+| `newton serve` | HTTP/WebSocket API for workflow state, loop observation, and integrations |
+| `newton data <verb> <entity>` | Catalog CRUD (`finding`, `change-request`, `plan`, `optimize-run`, …) |
+| `newton doctor` | Environment readiness diagnostics |
 | `newton schema export` | Emit the workflow IR JSON Schema (operator-discriminated) |
+
+> `webhook` (external HTTP ingress) and `health` were removed: the optimizer is self-driving (ADR 0004), and `health` folded into `doctor`.
 
 Run `newton <command> --help` for flags and examples. The top-level `newton run` command is deprecated; use `newton workflow run`.
 
@@ -86,21 +89,25 @@ newton workflow run workflow.yaml --timeout 3600 --parallel-limit 4 --verbose
 
 Trigger payload merge order: `--parameters-json` (base object), then each `--trigger KEY=VAL` in order. Values prefixed with `@` load file contents.
 
-### Batch mode
+### Optimization loop
 
-Batch mode processes markdown plan files from `.newton/plan/<project_id>/todo/` using the workflow named in `.newton/configs/<project_id>.conf`:
+Newton's autonomous loop improves a project toward a **Grade**:
 
-```conf
-project_root=/path/to/project
-workflow_file=path/to/workflow.yaml
 ```
+grade ─→ reconcile ─→ change-request ─→ plan ─→ develop ─→ merge ─→ re-grade
+(Assessment) (Findings)  (Change Request)  (HOW)  (tests)   (local git)
+```
+
+The durable work spine — `Finding → Change Request → Plan → Execution` — lives in Newton's store (never a board). It runs **GitHub-free** and terminates on a break condition (converged / max-cycles / per-grader target / regression / no-progress / `stalled_on_blocked`).
 
 ```bash
-newton batch default          # poll and process plans
-newton batch default --once     # process one plan then exit
+# Closed loop (interim driver; reads the optimize_* block in .newton/configs/<id>.conf)
+.newton/scripts/optimize.sh my-project --once
+# Rust command (currently drains the Plan queue under .newton/plan/<id>/todo/)
+newton optimize my-project --once
 ```
 
-Plans move to `completed/` on success or `failed/` on error. See [skill/newton/references/batch.md](skill/newton/references/batch.md) for plan file format and lifecycle.
+Observe runs over `serve`: `GET /api/v1/optimize-runs[/{id}/trajectory]`, `GET /api/v1/findings?status=blocked`, `POST /api/v1/findings/{id}/unblock`. See [skill/newton/references/optimize.md](skill/newton/references/optimize.md) and [CONTEXT.md](CONTEXT.md).
 
 ### HTTP serve API
 
@@ -178,8 +185,10 @@ After `newton init`, Newton expects:
 workspace/
 ├── .newton/
 │   ├── workflows/       # Workflow YAML (from template)
-│   ├── configs/         # Batch and integration config (*.conf)
-│   ├── plan/            # Batch plan queues by project_id
+│   ├── grader/          # Command-Graders: <name>/generate.sh (prints an Assessment)
+│   ├── configs/         # Workflow, optimize, and integration config (*.conf)
+│   ├── plan/            # Plan queues by project_id
+│   ├── optimize/        # Per-project loop trajectory.jsonl (audit trail)
 │   ├── tasks/           # Per-plan execution state
 │   ├── state/           # Workflow run records
 │   ├── checkpoints/     # Resume checkpoints

--- a/crates/backend/migrations/005_plan_optimize.sql
+++ b/crates/backend/migrations/005_plan_optimize.sql
@@ -1,0 +1,16 @@
+-- 005: extend Plan for the optimize loop; add risk/confidence to ChangeRequest
+
+PRAGMA foreign_keys = OFF;
+
+-- Plan: add body, executionId, attempts, lastError, module
+ALTER TABLE Plan ADD COLUMN body TEXT NULL;
+ALTER TABLE Plan ADD COLUMN executionId TEXT NULL;
+ALTER TABLE Plan ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE Plan ADD COLUMN lastError TEXT NULL;
+ALTER TABLE Plan ADD COLUMN module TEXT NULL;
+
+-- ChangeRequest: add risk/confidence so Plan can copy them
+ALTER TABLE ChangeRequest ADD COLUMN risk TEXT NOT NULL DEFAULT 'medium';
+ALTER TABLE ChangeRequest ADD COLUMN confidence REAL NULL;
+
+PRAGMA foreign_keys = ON;

--- a/crates/backend/migrations/006_optimize_run.sql
+++ b/crates/backend/migrations/006_optimize_run.sql
@@ -1,0 +1,39 @@
+-- 006: OptimizeRun + OptimizeCycle tables; blocked_by_plan_id on Finding
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS OptimizeRun (
+  id            TEXT PRIMARY KEY,
+  projectId     TEXT NOT NULL,
+  scope         TEXT NOT NULL DEFAULT 'repo',
+  scopeId       TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'running',
+  cycle         INTEGER NOT NULL DEFAULT 0,
+  maxCycles     INTEGER NOT NULL DEFAULT 8,
+  graders       TEXT NOT NULL DEFAULT '[]',
+  latestGrades  TEXT NOT NULL DEFAULT '{}',
+  openFindings  INTEGER NOT NULL DEFAULT 0,
+  blockedFindings INTEGER NOT NULL DEFAULT 0,
+  outcomeReason TEXT NULL,
+  startedAt     TEXT NOT NULL,
+  updatedAt     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS OptimizeCycle (
+  id                TEXT PRIMARY KEY,
+  runId             TEXT NOT NULL,
+  cycle             INTEGER NOT NULL,
+  grades            TEXT NOT NULL DEFAULT '{}',
+  gradeMin          REAL NULL,
+  decision          TEXT NOT NULL DEFAULT 'none',
+  changeRequestId   TEXT NULL,
+  planId            TEXT NULL,
+  executionId       TEXT NULL,
+  developStatus     TEXT NULL,
+  openFindings      INTEGER NOT NULL DEFAULT 0,
+  resolvedThisCycle INTEGER NOT NULL DEFAULT 0,
+  createdAt         TEXT NOT NULL,
+  FOREIGN KEY(runId) REFERENCES OptimizeRun(id)
+);
+
+PRAGMA foreign_keys = ON;

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -100,10 +100,36 @@ pub trait BackendStore: Send + Sync {
         body: PatchChangeRequestBody,
     ) -> Result<ChangeRequestItem, ApiError>;
 
-    async fn list_plans(&self) -> Result<Vec<PlanItem>, ApiError>;
+    async fn list_plans(
+        &self,
+        status: Option<String>,
+        scope: Option<String>,
+        scope_id: Option<String>,
+    ) -> Result<Vec<PlanItem>, ApiError>;
     async fn get_plan(&self, id: &str) -> Result<PlanDetail, ApiError>;
+    async fn create_plan(&self, body: CreatePlanBody) -> Result<PlanItem, ApiError>;
+    async fn patch_plan(&self, id: &str, body: PatchPlanBody) -> Result<PlanItem, ApiError>;
     async fn approve_plan(&self, id: &str) -> Result<ApprovedPlan, ApiError>;
     async fn reject_plan(&self, id: &str) -> Result<PlanItem, ApiError>;
+
+    async fn unblock_finding(&self, id: &str) -> Result<FindingItem, ApiError>;
+
+    async fn list_optimize_runs(&self) -> Result<Vec<OptimizeRunItem>, ApiError>;
+    async fn get_optimize_run(&self, id: &str) -> Result<OptimizeRunDetail, ApiError>;
+    async fn create_optimize_run(
+        &self,
+        body: CreateOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError>;
+    async fn patch_optimize_run(
+        &self,
+        id: &str,
+        body: PatchOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError>;
+    async fn create_optimize_cycle(
+        &self,
+        body: CreateOptimizeCycleBody,
+    ) -> Result<OptimizeCycleItem, ApiError>;
+    async fn list_optimize_cycles(&self, run_id: &str) -> Result<Vec<OptimizeCycleItem>, ApiError>;
 
     async fn list_executions(
         &self,

--- a/crates/backend/src/models.rs
+++ b/crates/backend/src/models.rs
@@ -270,6 +270,14 @@ pub struct FindingItem {
     pub last_seen_at: String,
     pub depends_on: Vec<String>,
     pub blocks: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_by_plan_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_plan_attempts: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_change_request_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -316,7 +324,7 @@ pub struct CreateFindingBody {
     pub blocks: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchFindingBody {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -329,10 +337,141 @@ pub struct PatchFindingBody {
     pub risk: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_seen_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_by_plan_id: Option<String>,
+}
+
+// ── OptimizeRun ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimizeRunItem {
+    pub id: String,
+    pub project_id: String,
+    pub scope: String,
+    pub scope_id: String,
+    pub status: String,
+    pub cycle: i64,
+    pub max_cycles: i64,
+    pub graders: Vec<String>,
+    pub latest_grades: serde_json::Value,
+    pub open_findings: i64,
+    pub blocked_findings: i64,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimizeRunDetail {
+    #[serde(flatten)]
+    pub run: OptimizeRunItem,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome_reason: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimizeCycleItem {
+    pub id: String,
+    pub run_id: String,
+    pub cycle: i64,
+    pub grades: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grade_min: Option<f64>,
+    pub decision: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub develop_status: Option<String>,
+    pub open_findings: i64,
+    pub resolved_this_cycle: i64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimizeRunTrajectory {
+    #[serde(flatten)]
+    pub detail: OptimizeRunDetail,
+    pub cycles: Vec<OptimizeCycleItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateOptimizeRunBody {
+    pub id: String,
+    pub project_id: String,
+    #[serde(default = "default_run_scope")]
+    pub scope: String,
+    pub scope_id: String,
+    #[serde(default = "default_max_cycles")]
+    pub max_cycles: i64,
+    #[serde(default)]
+    pub graders: Vec<String>,
+}
+
+fn default_run_scope() -> String {
+    "repo".to_string()
+}
+
+fn default_max_cycles() -> i64 {
+    8
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchOptimizeRunBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cycle: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_grades: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_findings: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_findings: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome_reason: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateOptimizeCycleBody {
+    pub id: String,
+    pub run_id: String,
+    pub cycle: i64,
+    pub grades: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grade_min: Option<f64>,
+    pub decision: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub develop_status: Option<String>,
+    pub open_findings: i64,
+    pub resolved_this_cycle: i64,
 }
 
 fn default_cr_origin() -> String {
     "system".to_string()
+}
+
+fn default_cr_risk() -> String {
+    "medium".to_string()
+}
+
+fn default_plan_status() -> String {
+    "draft".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -351,6 +490,9 @@ pub struct ChangeRequestItem {
     pub repo_id: Option<String>,
     pub status: String,
     pub finding_ids: Vec<String>,
+    pub risk: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -372,6 +514,10 @@ pub struct CreateChangeRequestBody {
     pub repo_id: Option<String>,
     #[serde(default)]
     pub finding_ids: Vec<String>,
+    #[serde(default = "default_cr_risk")]
+    pub risk: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -399,7 +545,55 @@ pub struct PlanItem {
     pub agent_generated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub waiting_since: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<String>,
+    pub attempts: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePlanBody {
+    pub id: String,
+    pub title: String,
+    pub linked_change_request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(default = "default_plan_status")]
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    pub confidence: i64,
+    pub risk: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_delta: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchPlanBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempts: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/backend/src/store/catalog.rs
+++ b/crates/backend/src/store/catalog.rs
@@ -1,5 +1,4 @@
 use super::helpers::{query_err, unique_err};
-use super::plan::PLAN_SELECT;
 use super::rows::*;
 use crate::err_conflict;
 use crate::err_internal;
@@ -159,41 +158,6 @@ impl super::SqliteBackendStore {
             }
         }
         Ok(false)
-    }
-
-    pub(super) async fn fetch_plan_item(&self, id: &str) -> Result<PlanItem, ApiError> {
-        let row: Option<PlanRow> =
-            sqlx::query_as::<_, PlanRow>(&format!("{PLAN_SELECT} WHERE p.id = ?"))
-                .bind(id)
-                .fetch_optional(&self.pool)
-                .await
-                .map_err(query_err)?;
-
-        let row = row.ok_or_else(|| err_not_found("Plan not found"))?;
-
-        let exec_ids: Vec<IdRow> = sqlx::query_as::<_, IdRow>(
-            "SELECT id FROM ExecutionRecord WHERE planId = ? ORDER BY id ASC",
-        )
-        .bind(id)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(query_err)?;
-
-        Ok(PlanItem {
-            id: row.id,
-            title: row.title,
-            component: row.component_name.unwrap_or_default(),
-            repo: row.repo_name.unwrap_or_default(),
-            status: row.status,
-            linked_change_request_id: row.linked_change_request_id,
-            execution_ids: exec_ids.into_iter().map(|e| e.id).collect(),
-            confidence: row.confidence,
-            risk: row.risk,
-            expected_value: row.expected_value,
-            agent_generated: row.agent_generated,
-            waiting_since: row.waiting_since,
-            created_at: row.created_at,
-        })
     }
 }
 

--- a/crates/backend/src/store/finding.rs
+++ b/crates/backend/src/store/finding.rs
@@ -5,6 +5,26 @@ use crate::err_not_found;
 use crate::models::*;
 use newton_types::ApiError;
 
+const FINDING_STATUSES: &[&str] = &[
+    "awaiting_triage",
+    "triaged",
+    "approved_for_planning",
+    "blocked",
+    "resolved",
+];
+
+fn validate_finding_status(status: &str) -> Result<(), ApiError> {
+    if FINDING_STATUSES.contains(&status) {
+        Ok(())
+    } else {
+        Err(crate::err_validation(&format!(
+            "invalid Finding status '{}'; must be one of: {}",
+            status,
+            FINDING_STATUSES.join(", ")
+        )))
+    }
+}
+
 const FINDING_SELECT: &str =
     "SELECT f.id, f.source, f.origin, f.componentId as component_id, c.name as component_name, \
      f.module, f.repoId as repo_id, r.name as repo_name, f.kpiId as kpi_id, \
@@ -162,6 +182,7 @@ impl super::SqliteBackendStore {
         &self,
         body: CreateFindingBody,
     ) -> Result<FindingItem, ApiError> {
+        validate_finding_status(&body.status)?;
         let now = Self::now_iso();
         let last_seen_at = body.last_seen_at.unwrap_or_else(|| now.clone());
         let depends_on_json =
@@ -252,6 +273,7 @@ impl super::SqliteBackendStore {
         let now = Self::now_iso();
 
         if let Some(ref status) = body.status {
+            validate_finding_status(status)?;
             sqlx::query("UPDATE Finding SET status = ?, updatedAt = ? WHERE id = ?")
                 .bind(status)
                 .bind(&now)

--- a/crates/backend/src/store/finding.rs
+++ b/crates/backend/src/store/finding.rs
@@ -12,16 +12,21 @@ const FINDING_SELECT: &str =
      f.whyItMatters as why_it_matters, f.recommendedAction as recommended_action, \
      f.severity, f.risk, f.confidence, f.evidence, f.expectedValue as expected_value, \
      f.effort, f.status, f.lastSeenAt as last_seen_at, \
-     f.dependsOn as depends_on, f.blocks, f.createdAt as created_at, f.updatedAt as updated_at \
+     f.dependsOn as depends_on, f.blocks, f.blockedByPlanId as blocked_by_plan_id, \
+     p.attempts as blocked_plan_attempts, p.lastError as blocked_last_error, \
+     p.linkedChangeRequestId as blocked_change_request_id, \
+     f.createdAt as created_at, f.updatedAt as updated_at \
      FROM Finding f \
      LEFT JOIN Component c ON f.componentId = c.id \
-     LEFT JOIN Repo r ON f.repoId = r.id";
+     LEFT JOIN Repo r ON f.repoId = r.id \
+     LEFT JOIN Plan p ON f.blockedByPlanId = p.id";
 
-const CR_SELECT: &str =
-    "SELECT cr.id, cr.title, cr.body, cr.origin, cr.author, \
+const CR_SELECT: &str = "SELECT cr.id, cr.title, cr.body, cr.origin, cr.author, \
      cr.componentId as component_id, c.name as component_name, \
      cr.repoId as repo_id, r.name as repo_name, \
-     cr.status, cr.findingIds as finding_ids, cr.createdAt as created_at, cr.updatedAt as updated_at \
+     cr.status, cr.findingIds as finding_ids, \
+     cr.risk, cr.confidence, \
+     cr.createdAt as created_at, cr.updatedAt as updated_at \
      FROM ChangeRequest cr \
      LEFT JOIN Component c ON cr.componentId = c.id \
      LEFT JOIN Repo r ON cr.repoId = r.id";
@@ -60,6 +65,10 @@ fn finding_row_to_item(row: FindingRow) -> FindingItem {
         last_seen_at: row.last_seen_at,
         depends_on,
         blocks,
+        blocked_by_plan_id: row.blocked_by_plan_id,
+        blocked_plan_attempts: row.blocked_plan_attempts,
+        blocked_last_error: row.blocked_last_error,
+        blocked_change_request_id: row.blocked_change_request_id,
         created_at: row.created_at,
         updated_at: row.updated_at,
     }
@@ -81,6 +90,8 @@ fn cr_row_to_item(row: ChangeRequestRow) -> ChangeRequestItem {
         repo_id: row.repo_id,
         status: row.status,
         finding_ids,
+        risk: row.risk,
+        confidence: row.confidence,
         created_at: row.created_at,
         updated_at: row.updated_at,
     }
@@ -285,7 +296,33 @@ impl super::SqliteBackendStore {
                 .await
                 .map_err(|e| err_internal(&format!("update Finding lastSeenAt error: {e}")))?;
         }
+        if let Some(ref plan_id) = body.blocked_by_plan_id {
+            sqlx::query("UPDATE Finding SET blockedByPlanId = ?, updatedAt = ? WHERE id = ?")
+                .bind(plan_id)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Finding blockedByPlanId error: {e}")))?;
+        }
 
+        self.get_finding_db(id).await
+    }
+
+    pub(super) async fn unblock_finding_db(&self, id: &str) -> Result<FindingItem, ApiError> {
+        let finding = self.get_finding_db(id).await?;
+        if finding.status != "blocked" {
+            return Err(crate::err_conflict("finding is not blocked"));
+        }
+        let now = Self::now_iso();
+        sqlx::query(
+            "UPDATE Finding SET status = 'awaiting_triage', blockedByPlanId = NULL, updatedAt = ? WHERE id = ?",
+        )
+        .bind(&now)
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| err_internal(&format!("unblock Finding error: {e}")))?;
         self.get_finding_db(id).await
     }
 
@@ -334,8 +371,8 @@ impl super::SqliteBackendStore {
         sqlx::query(
             "INSERT INTO ChangeRequest (
                 id, title, body, origin, author, componentId, repoId,
-                status, findingIds, createdAt, updatedAt
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'proposed', ?, ?, ?)
+                status, findingIds, risk, confidence, createdAt, updatedAt
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'proposed', ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 title       = excluded.title,
                 body        = excluded.body,
@@ -344,6 +381,8 @@ impl super::SqliteBackendStore {
                 componentId = excluded.componentId,
                 repoId      = excluded.repoId,
                 findingIds  = excluded.findingIds,
+                risk        = excluded.risk,
+                confidence  = excluded.confidence,
                 updatedAt   = excluded.updatedAt",
         )
         .bind(&body.id)
@@ -354,6 +393,8 @@ impl super::SqliteBackendStore {
         .bind(&body.component_id)
         .bind(&body.repo_id)
         .bind(&finding_ids_json)
+        .bind(&body.risk)
+        .bind(body.confidence)
         .bind(&now)
         .bind(&now)
         .execute(&self.pool)
@@ -443,6 +484,8 @@ mod finding_tests {
             component_id: None,
             repo_id: None,
             finding_ids: vec![],
+            risk: "medium".to_string(),
+            confidence: None,
         };
         let item = store.create_change_request_db(body).await.unwrap();
         assert_eq!(item.id, "cr-001");

--- a/crates/backend/src/store/migration.rs
+++ b/crates/backend/src/store/migration.rs
@@ -436,3 +436,156 @@ pub(super) async fn upgrade_legacy_repo_schema(pool: &SqlitePool) -> Result<(), 
 
     Ok(())
 }
+
+pub(super) async fn upgrade_optimize_run(pool: &SqlitePool) -> Result<(), ApiError> {
+    let has_table: bool = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='OptimizeRun'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|n| n > 0)
+    .unwrap_or(false);
+
+    if !has_table {
+        sqlx::query(
+            "CREATE TABLE OptimizeRun (\
+              id TEXT PRIMARY KEY,\
+              projectId TEXT NOT NULL,\
+              scope TEXT NOT NULL DEFAULT 'repo',\
+              scopeId TEXT NOT NULL,\
+              status TEXT NOT NULL DEFAULT 'running',\
+              cycle INTEGER NOT NULL DEFAULT 0,\
+              maxCycles INTEGER NOT NULL DEFAULT 8,\
+              graders TEXT NOT NULL DEFAULT '[]',\
+              latestGrades TEXT NOT NULL DEFAULT '{}',\
+              openFindings INTEGER NOT NULL DEFAULT 0,\
+              blockedFindings INTEGER NOT NULL DEFAULT 0,\
+              outcomeReason TEXT NULL,\
+              startedAt TEXT NOT NULL,\
+              updatedAt TEXT NOT NULL\
+            )",
+        )
+        .execute(pool)
+        .await
+        .map_err(|e| err_internal(&format!("create OptimizeRun failed: {e}")))?;
+    }
+
+    let has_cycle_table: bool = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='OptimizeCycle'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|n| n > 0)
+    .unwrap_or(false);
+
+    if !has_cycle_table {
+        sqlx::query(
+            "CREATE TABLE OptimizeCycle (\
+              id TEXT PRIMARY KEY,\
+              runId TEXT NOT NULL,\
+              cycle INTEGER NOT NULL,\
+              grades TEXT NOT NULL DEFAULT '{}',\
+              gradeMin REAL NULL,\
+              decision TEXT NOT NULL DEFAULT 'none',\
+              changeRequestId TEXT NULL,\
+              planId TEXT NULL,\
+              executionId TEXT NULL,\
+              developStatus TEXT NULL,\
+              openFindings INTEGER NOT NULL DEFAULT 0,\
+              resolvedThisCycle INTEGER NOT NULL DEFAULT 0,\
+              createdAt TEXT NOT NULL,\
+              FOREIGN KEY(runId) REFERENCES OptimizeRun(id)\
+            )",
+        )
+        .execute(pool)
+        .await
+        .map_err(|e| err_internal(&format!("create OptimizeCycle failed: {e}")))?;
+    }
+
+    Ok(())
+}
+
+pub(super) async fn upgrade_finding_blocked_by_plan(pool: &SqlitePool) -> Result<(), ApiError> {
+    let has_col: bool = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM pragma_table_info('Finding') WHERE name='blockedByPlanId'",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|n| n > 0)
+    .unwrap_or(false);
+
+    if !has_col {
+        sqlx::query("ALTER TABLE Finding ADD COLUMN blockedByPlanId TEXT NULL")
+            .execute(pool)
+            .await
+            .map_err(|e| err_internal(&format!("add blockedByPlanId column: {e}")))?;
+    }
+    Ok(())
+}
+
+pub(super) async fn upgrade_plan_optimize(pool: &SqlitePool) -> Result<(), ApiError> {
+    #[derive(Debug, FromRow)]
+    struct ColRow {
+        name: String,
+    }
+
+    let plan_cols: Vec<ColRow> = sqlx::query_as::<_, ColRow>("PRAGMA table_info(Plan)")
+        .fetch_all(pool)
+        .await
+        .map_err(|e| err_internal(&format!("schema check Plan failed: {e}")))?;
+
+    let plan_col_names: std::collections::HashSet<String> =
+        plan_cols.into_iter().map(|r| r.name).collect();
+
+    for (col, ddl) in [
+        ("body", "ALTER TABLE Plan ADD COLUMN body TEXT NULL"),
+        (
+            "executionId",
+            "ALTER TABLE Plan ADD COLUMN executionId TEXT NULL",
+        ),
+        (
+            "attempts",
+            "ALTER TABLE Plan ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0",
+        ),
+        (
+            "lastError",
+            "ALTER TABLE Plan ADD COLUMN lastError TEXT NULL",
+        ),
+        ("module", "ALTER TABLE Plan ADD COLUMN module TEXT NULL"),
+    ] {
+        if !plan_col_names.contains(col) {
+            sqlx::query(ddl)
+                .execute(pool)
+                .await
+                .map_err(|e| err_internal(&format!("add Plan.{col} failed: {e}")))?;
+        }
+    }
+
+    let cr_cols: Vec<ColRow> = sqlx::query_as::<_, ColRow>("PRAGMA table_info(ChangeRequest)")
+        .fetch_all(pool)
+        .await
+        .map_err(|e| err_internal(&format!("schema check ChangeRequest failed: {e}")))?;
+
+    let cr_col_names: std::collections::HashSet<String> =
+        cr_cols.into_iter().map(|r| r.name).collect();
+
+    for (col, ddl) in [
+        (
+            "risk",
+            "ALTER TABLE ChangeRequest ADD COLUMN risk TEXT NOT NULL DEFAULT 'medium'",
+        ),
+        (
+            "confidence",
+            "ALTER TABLE ChangeRequest ADD COLUMN confidence REAL NULL",
+        ),
+    ] {
+        if !cr_col_names.contains(col) {
+            sqlx::query(ddl)
+                .execute(pool)
+                .await
+                .map_err(|e| err_internal(&format!("add ChangeRequest.{col} failed: {e}")))?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/backend/src/store/mod.rs
+++ b/crates/backend/src/store/mod.rs
@@ -3,6 +3,7 @@ mod eval;
 mod finding;
 mod helpers;
 mod migration;
+mod optimize_run;
 mod plan;
 mod rows;
 mod workflow_runtime;
@@ -66,6 +67,10 @@ impl SqliteBackendStore {
         migration::upgrade_legacy_indicator_schema(&pool).await?;
         migration::upgrade_legacy_component_schema(&pool).await?;
         migration::upgrade_legacy_repo_schema(&pool).await?;
+
+        migration::upgrade_plan_optimize(&pool).await?;
+        migration::upgrade_optimize_run(&pool).await?;
+        migration::upgrade_finding_blocked_by_plan(&pool).await?;
 
         Ok(Self { pool })
     }
@@ -182,17 +187,59 @@ impl BackendStore for SqliteBackendStore {
     ) -> Result<ChangeRequestItem, ApiError> {
         self.patch_change_request_db(id, body).await
     }
-    async fn list_plans(&self) -> Result<Vec<PlanItem>, ApiError> {
-        self.list_plans_db().await
+    async fn list_plans(
+        &self,
+        status: Option<String>,
+        scope: Option<String>,
+        scope_id: Option<String>,
+    ) -> Result<Vec<PlanItem>, ApiError> {
+        self.list_plans_db(status, scope, scope_id).await
     }
     async fn get_plan(&self, id: &str) -> Result<PlanDetail, ApiError> {
         self.get_plan_db(id).await
+    }
+    async fn create_plan(&self, body: CreatePlanBody) -> Result<PlanItem, ApiError> {
+        self.create_plan_db(body).await
+    }
+    async fn patch_plan(&self, id: &str, body: PatchPlanBody) -> Result<PlanItem, ApiError> {
+        self.patch_plan_db(id, body).await
     }
     async fn approve_plan(&self, id: &str) -> Result<ApprovedPlan, ApiError> {
         self.approve_plan_db(id).await
     }
     async fn reject_plan(&self, id: &str) -> Result<PlanItem, ApiError> {
         self.reject_plan_db(id).await
+    }
+    async fn unblock_finding(&self, id: &str) -> Result<FindingItem, ApiError> {
+        self.unblock_finding_db(id).await
+    }
+    async fn list_optimize_runs(&self) -> Result<Vec<OptimizeRunItem>, ApiError> {
+        self.list_optimize_runs_db().await
+    }
+    async fn get_optimize_run(&self, id: &str) -> Result<OptimizeRunDetail, ApiError> {
+        self.get_optimize_run_db(id).await
+    }
+    async fn create_optimize_run(
+        &self,
+        body: CreateOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError> {
+        self.create_optimize_run_db(body).await
+    }
+    async fn patch_optimize_run(
+        &self,
+        id: &str,
+        body: PatchOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError> {
+        self.patch_optimize_run_db(id, body).await
+    }
+    async fn create_optimize_cycle(
+        &self,
+        body: CreateOptimizeCycleBody,
+    ) -> Result<OptimizeCycleItem, ApiError> {
+        self.create_optimize_cycle_db(body).await
+    }
+    async fn list_optimize_cycles(&self, run_id: &str) -> Result<Vec<OptimizeCycleItem>, ApiError> {
+        self.list_optimize_cycles_db(run_id).await
     }
     async fn list_executions(
         &self,

--- a/crates/backend/src/store/optimize_run.rs
+++ b/crates/backend/src/store/optimize_run.rs
@@ -1,0 +1,255 @@
+use super::helpers::query_err;
+use super::rows::{OptimizeCycleRow, OptimizeRunRow};
+use crate::err_internal;
+use crate::err_not_found;
+use crate::models::*;
+use newton_types::ApiError;
+
+const RUN_SELECT: &str =
+    "SELECT id, projectId as project_id, scope, scopeId as scope_id, status, cycle, \
+     maxCycles as max_cycles, graders, latestGrades as latest_grades, \
+     openFindings as open_findings, blockedFindings as blocked_findings, \
+     outcomeReason as outcome_reason, startedAt as started_at, updatedAt as updated_at \
+     FROM OptimizeRun";
+
+const CYCLE_SELECT: &str =
+    "SELECT id, runId as run_id, cycle, grades, gradeMin as grade_min, decision, \
+     changeRequestId as change_request_id, planId as plan_id, executionId as execution_id, \
+     developStatus as develop_status, openFindings as open_findings, \
+     resolvedThisCycle as resolved_this_cycle, createdAt as created_at \
+     FROM OptimizeCycle";
+
+fn run_row_to_item(row: OptimizeRunRow) -> OptimizeRunItem {
+    OptimizeRunItem {
+        id: row.id,
+        project_id: row.project_id,
+        scope: row.scope,
+        scope_id: row.scope_id,
+        status: row.status,
+        cycle: row.cycle,
+        max_cycles: row.max_cycles,
+        graders: serde_json::from_str(&row.graders).unwrap_or_default(),
+        latest_grades: serde_json::from_str(&row.latest_grades)
+            .unwrap_or(serde_json::Value::Object(Default::default())),
+        open_findings: row.open_findings,
+        blocked_findings: row.blocked_findings,
+        started_at: row.started_at,
+        updated_at: row.updated_at,
+    }
+}
+
+fn cycle_row_to_item(row: OptimizeCycleRow) -> OptimizeCycleItem {
+    OptimizeCycleItem {
+        id: row.id,
+        run_id: row.run_id,
+        cycle: row.cycle,
+        grades: serde_json::from_str(&row.grades)
+            .unwrap_or(serde_json::Value::Object(Default::default())),
+        grade_min: row.grade_min,
+        decision: row.decision,
+        change_request_id: row.change_request_id,
+        plan_id: row.plan_id,
+        execution_id: row.execution_id,
+        develop_status: row.develop_status,
+        open_findings: row.open_findings,
+        resolved_this_cycle: row.resolved_this_cycle,
+        created_at: row.created_at,
+    }
+}
+
+impl super::SqliteBackendStore {
+    pub(super) async fn list_optimize_runs_db(&self) -> Result<Vec<OptimizeRunItem>, ApiError> {
+        let rows =
+            sqlx::query_as::<_, OptimizeRunRow>(&format!("{RUN_SELECT} ORDER BY startedAt DESC"))
+                .fetch_all(&self.pool)
+                .await
+                .map_err(query_err)?;
+        Ok(rows.into_iter().map(run_row_to_item).collect())
+    }
+
+    pub(super) async fn get_optimize_run_db(
+        &self,
+        id: &str,
+    ) -> Result<OptimizeRunDetail, ApiError> {
+        let row = sqlx::query_as::<_, OptimizeRunRow>(&format!("{RUN_SELECT} WHERE id = ?"))
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(query_err)?
+            .ok_or_else(|| err_not_found("OptimizeRun not found"))?;
+
+        let outcome_reason = row
+            .outcome_reason
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok());
+        let run = run_row_to_item(row);
+        Ok(OptimizeRunDetail {
+            run,
+            outcome_reason,
+        })
+    }
+
+    pub(super) async fn create_optimize_run_db(
+        &self,
+        body: CreateOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError> {
+        let now = Self::now_iso();
+        let graders_json =
+            serde_json::to_string(&body.graders).unwrap_or_else(|_| "[]".to_string());
+        sqlx::query(
+            "INSERT INTO OptimizeRun \
+             (id, projectId, scope, scopeId, status, cycle, maxCycles, graders, \
+              latestGrades, openFindings, blockedFindings, outcomeReason, startedAt, updatedAt) \
+             VALUES (?, ?, ?, ?, 'running', 0, ?, ?, '{}', 0, 0, NULL, ?, ?)",
+        )
+        .bind(&body.id)
+        .bind(&body.project_id)
+        .bind(&body.scope)
+        .bind(&body.scope_id)
+        .bind(body.max_cycles)
+        .bind(&graders_json)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| err_internal(&format!("insert OptimizeRun error: {e}")))?;
+
+        let row = sqlx::query_as::<_, OptimizeRunRow>(&format!("{RUN_SELECT} WHERE id = ?"))
+            .bind(&body.id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(query_err)?;
+        Ok(run_row_to_item(row))
+    }
+
+    pub(super) async fn patch_optimize_run_db(
+        &self,
+        id: &str,
+        body: PatchOptimizeRunBody,
+    ) -> Result<OptimizeRunItem, ApiError> {
+        let row = sqlx::query_as::<_, OptimizeRunRow>(&format!("{RUN_SELECT} WHERE id = ?"))
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(query_err)?
+            .ok_or_else(|| err_not_found("OptimizeRun not found"))?;
+        let _ = row;
+
+        let now = Self::now_iso();
+
+        if let Some(ref status) = body.status {
+            sqlx::query("UPDATE OptimizeRun SET status = ?, updatedAt = ? WHERE id = ?")
+                .bind(status)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run status: {e}")))?;
+        }
+        if let Some(cycle) = body.cycle {
+            sqlx::query("UPDATE OptimizeRun SET cycle = ?, updatedAt = ? WHERE id = ?")
+                .bind(cycle)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run cycle: {e}")))?;
+        }
+        if let Some(ref grades) = body.latest_grades {
+            let grades_json = serde_json::to_string(grades).unwrap_or_else(|_| "{}".to_string());
+            sqlx::query("UPDATE OptimizeRun SET latestGrades = ?, updatedAt = ? WHERE id = ?")
+                .bind(&grades_json)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run latestGrades: {e}")))?;
+        }
+        if let Some(of) = body.open_findings {
+            sqlx::query("UPDATE OptimizeRun SET openFindings = ?, updatedAt = ? WHERE id = ?")
+                .bind(of)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run openFindings: {e}")))?;
+        }
+        if let Some(bf) = body.blocked_findings {
+            sqlx::query("UPDATE OptimizeRun SET blockedFindings = ?, updatedAt = ? WHERE id = ?")
+                .bind(bf)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run blockedFindings: {e}")))?;
+        }
+        if let Some(ref reason) = body.outcome_reason {
+            let reason_json = serde_json::to_string(reason).unwrap_or_else(|_| "null".to_string());
+            sqlx::query("UPDATE OptimizeRun SET outcomeReason = ?, updatedAt = ? WHERE id = ?")
+                .bind(&reason_json)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update run outcomeReason: {e}")))?;
+        }
+
+        let updated = sqlx::query_as::<_, OptimizeRunRow>(&format!("{RUN_SELECT} WHERE id = ?"))
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(query_err)?;
+        Ok(run_row_to_item(updated))
+    }
+
+    pub(super) async fn create_optimize_cycle_db(
+        &self,
+        body: CreateOptimizeCycleBody,
+    ) -> Result<OptimizeCycleItem, ApiError> {
+        let now = Self::now_iso();
+        let grades_json = serde_json::to_string(&body.grades).unwrap_or_else(|_| "{}".to_string());
+        sqlx::query(
+            "INSERT INTO OptimizeCycle \
+             (id, runId, cycle, grades, gradeMin, decision, changeRequestId, planId, \
+              executionId, developStatus, openFindings, resolvedThisCycle, createdAt) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&body.id)
+        .bind(&body.run_id)
+        .bind(body.cycle)
+        .bind(&grades_json)
+        .bind(body.grade_min)
+        .bind(&body.decision)
+        .bind(&body.change_request_id)
+        .bind(&body.plan_id)
+        .bind(&body.execution_id)
+        .bind(&body.develop_status)
+        .bind(body.open_findings)
+        .bind(body.resolved_this_cycle)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| err_internal(&format!("insert OptimizeCycle error: {e}")))?;
+
+        let row = sqlx::query_as::<_, OptimizeCycleRow>(&format!("{CYCLE_SELECT} WHERE id = ?"))
+            .bind(&body.id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(query_err)?;
+        Ok(cycle_row_to_item(row))
+    }
+
+    pub(super) async fn list_optimize_cycles_db(
+        &self,
+        run_id: &str,
+    ) -> Result<Vec<OptimizeCycleItem>, ApiError> {
+        let rows = sqlx::query_as::<_, OptimizeCycleRow>(&format!(
+            "{CYCLE_SELECT} WHERE runId = ? ORDER BY cycle ASC"
+        ))
+        .bind(run_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(query_err)?;
+        Ok(rows.into_iter().map(cycle_row_to_item).collect())
+    }
+}

--- a/crates/backend/src/store/plan.rs
+++ b/crates/backend/src/store/plan.rs
@@ -1,5 +1,26 @@
 use super::helpers::{query_err, tx_err};
 
+const PLAN_STATUSES: &[&str] = &[
+    "draft",
+    "ready",
+    "running",
+    "complete",
+    "failed",
+    "abandoned",
+];
+
+fn validate_plan_status(status: &str) -> Result<(), newton_types::ApiError> {
+    if PLAN_STATUSES.contains(&status) {
+        Ok(())
+    } else {
+        Err(crate::err_validation(&format!(
+            "invalid Plan status '{}'; must be one of: {}",
+            status,
+            PLAN_STATUSES.join(", ")
+        )))
+    }
+}
+
 pub(super) const PLAN_SELECT: &str =
     "SELECT p.id, p.title, p.componentId as component_id, c.name as component_name, \
      p.repoId as repo_id, r.name as repo_name, p.status, p.linkedChangeRequestId as linked_change_request_id, \
@@ -242,6 +263,7 @@ impl super::SqliteBackendStore {
         } else {
             body.status.clone()
         };
+        validate_plan_status(&status)?;
         sqlx::query(
             "INSERT INTO Plan (
                 id, title, linkedChangeRequestId, body, status,
@@ -287,6 +309,7 @@ impl super::SqliteBackendStore {
         }
         let now = Self::now_iso();
         if let Some(ref s) = body.status {
+            validate_plan_status(s)?;
             sqlx::query("UPDATE Plan SET status = ?, updatedAt = ? WHERE id = ?")
                 .bind(s)
                 .bind(&now)

--- a/crates/backend/src/store/plan.rs
+++ b/crates/backend/src/store/plan.rs
@@ -4,7 +4,8 @@ pub(super) const PLAN_SELECT: &str =
     "SELECT p.id, p.title, p.componentId as component_id, c.name as component_name, \
      p.repoId as repo_id, r.name as repo_name, p.status, p.linkedChangeRequestId as linked_change_request_id, \
      p.confidence, p.risk, p.expectedValue as expected_value, p.agentGenerated as agent_generated, \
-     p.waitingSince as waiting_since, p.createdAt as created_at \
+     p.waitingSince as waiting_since, p.body, p.executionId as execution_id, \
+     COALESCE(p.attempts, 0) as attempts, p.lastError as last_error, p.module, p.createdAt as created_at \
      FROM Plan p LEFT JOIN Component c ON p.componentId = c.id LEFT JOIN Repo r ON p.repoId = r.id";
 use super::rows::*;
 use crate::err_conflict;
@@ -141,11 +142,81 @@ impl super::SqliteBackendStore {
         }
     }
 
-    pub(super) async fn list_plans_db(&self) -> Result<Vec<PlanItem>, ApiError> {
-        let rows = sqlx::query_as::<_, PlanRow>(&format!("{PLAN_SELECT} ORDER BY p.id ASC"))
-            .fetch_all(&self.pool)
-            .await
-            .map_err(query_err)?;
+    pub(super) fn plan_row_to_item(row: PlanRow, exec_ids: Vec<String>) -> PlanItem {
+        PlanItem {
+            id: row.id,
+            title: row.title,
+            component: row.component_name.unwrap_or_default(),
+            repo: row.repo_name.unwrap_or_default(),
+            status: row.status,
+            linked_change_request_id: row.linked_change_request_id,
+            execution_ids: exec_ids,
+            confidence: row.confidence,
+            risk: row.risk,
+            expected_value: row.expected_value,
+            agent_generated: row.agent_generated,
+            waiting_since: row.waiting_since,
+            body: row.body,
+            execution_id: row.execution_id,
+            attempts: row.attempts,
+            last_error: row.last_error,
+            module: row.module,
+            created_at: row.created_at,
+        }
+    }
+
+    pub(super) async fn fetch_plan_item(&self, id: &str) -> Result<PlanItem, ApiError> {
+        let row: Option<PlanRow> =
+            sqlx::query_as::<_, PlanRow>(&format!("{PLAN_SELECT} WHERE p.id = ?"))
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(query_err)?;
+        let row = row.ok_or_else(|| err_not_found("Plan not found"))?;
+        let exec_ids: Vec<IdRow> = sqlx::query_as::<_, IdRow>(
+            "SELECT id FROM ExecutionRecord WHERE planId = ? ORDER BY id ASC",
+        )
+        .bind(id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(query_err)?;
+        Ok(Self::plan_row_to_item(
+            row,
+            exec_ids.into_iter().map(|e| e.id).collect(),
+        ))
+    }
+
+    pub(super) async fn list_plans_db(
+        &self,
+        status: Option<String>,
+        scope: Option<String>,
+        scope_id: Option<String>,
+    ) -> Result<Vec<PlanItem>, ApiError> {
+        let mut conditions: Vec<String> = Vec::new();
+        if status.is_some() {
+            conditions.push("p.status = ?".to_string());
+        }
+        if scope_id.is_some() {
+            let col = match scope.as_deref() {
+                Some("component") => "p.componentId",
+                _ => "p.repoId",
+            };
+            conditions.push(format!("{col} = ?"));
+        }
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!(" WHERE {}", conditions.join(" AND "))
+        };
+        let sql = format!("{PLAN_SELECT}{where_clause} ORDER BY p.createdAt DESC");
+        let mut q = sqlx::query_as::<_, PlanRow>(&sql);
+        if let Some(ref s) = status {
+            q = q.bind(s);
+        }
+        if let Some(ref sid) = scope_id {
+            q = q.bind(sid);
+        }
+        let rows = q.fetch_all(&self.pool).await.map_err(query_err)?;
 
         let mut result = Vec::new();
         for row in rows {
@@ -156,33 +227,115 @@ impl super::SqliteBackendStore {
             .fetch_all(&self.pool)
             .await
             .map_err(query_err)?;
-
-            result.push(PlanItem {
-                id: row.id,
-                title: row.title,
-                component: row.component_name.unwrap_or_default(),
-                repo: row.repo_name.unwrap_or_default(),
-                status: row.status,
-                linked_change_request_id: row.linked_change_request_id,
-                execution_ids: exec_ids.into_iter().map(|e| e.id).collect(),
-                confidence: row.confidence,
-                risk: row.risk,
-                expected_value: row.expected_value,
-                agent_generated: row.agent_generated,
-                waiting_since: row.waiting_since,
-                created_at: row.created_at,
-            });
+            result.push(Self::plan_row_to_item(
+                row,
+                exec_ids.into_iter().map(|e| e.id).collect(),
+            ));
         }
         Ok(result)
     }
 
+    pub(super) async fn create_plan_db(&self, body: CreatePlanBody) -> Result<PlanItem, ApiError> {
+        let now = Self::now_iso();
+        let status = if body.status.is_empty() {
+            "draft".to_string()
+        } else {
+            body.status.clone()
+        };
+        sqlx::query(
+            "INSERT INTO Plan (
+                id, title, linkedChangeRequestId, body, status,
+                componentId, repoId, module, confidence, risk,
+                expectedValue, expectedDelta,
+                agentGenerated, createdAt, updatedAt
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)",
+        )
+        .bind(&body.id)
+        .bind(&body.title)
+        .bind(&body.linked_change_request_id)
+        .bind(&body.body)
+        .bind(&status)
+        .bind(&body.component_id)
+        .bind(&body.repo_id)
+        .bind(&body.module)
+        .bind(body.confidence)
+        .bind(&body.risk)
+        .bind(&body.expected_value)
+        .bind(&body.expected_delta)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("UNIQUE") {
+                err_conflict("Plan id already exists")
+            } else {
+                err_internal(&format!("insert Plan error: {e}"))
+            }
+        })?;
+
+        self.fetch_plan_item(&body.id).await
+    }
+
+    pub(super) async fn patch_plan_db(
+        &self,
+        id: &str,
+        body: PatchPlanBody,
+    ) -> Result<PlanItem, ApiError> {
+        if !self.row_exists("Plan", id).await? {
+            return Err(err_not_found("Plan not found"));
+        }
+        let now = Self::now_iso();
+        if let Some(ref s) = body.status {
+            sqlx::query("UPDATE Plan SET status = ?, updatedAt = ? WHERE id = ?")
+                .bind(s)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Plan status: {e}")))?;
+        }
+        if let Some(ref eid) = body.execution_id {
+            sqlx::query("UPDATE Plan SET executionId = ?, updatedAt = ? WHERE id = ?")
+                .bind(eid)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Plan executionId: {e}")))?;
+        }
+        if let Some(attempts) = body.attempts {
+            sqlx::query("UPDATE Plan SET attempts = ?, updatedAt = ? WHERE id = ?")
+                .bind(attempts)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Plan attempts: {e}")))?;
+        }
+        if let Some(ref le) = body.last_error {
+            sqlx::query("UPDATE Plan SET lastError = ?, updatedAt = ? WHERE id = ?")
+                .bind(le)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Plan lastError: {e}")))?;
+        }
+        if let Some(ref b) = body.body {
+            sqlx::query("UPDATE Plan SET body = ?, updatedAt = ? WHERE id = ?")
+                .bind(b)
+                .bind(&now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| err_internal(&format!("update Plan body: {e}")))?;
+        }
+        self.fetch_plan_item(id).await
+    }
+
     pub(super) async fn get_plan_db(&self, id: &str) -> Result<PlanDetail, ApiError> {
-        let plan = self
-            .list_plans_db()
-            .await?
-            .into_iter()
-            .find(|p| p.id == id)
-            .ok_or_else(|| err_not_found("Plan not found"))?;
+        let plan = self.fetch_plan_item(id).await?;
 
         let delta: Option<ExpectedDeltaRow> = sqlx::query_as::<_, ExpectedDeltaRow>(
             "SELECT expectedDelta as expected_delta FROM Plan WHERE id = ?",

--- a/crates/backend/src/store/rows.rs
+++ b/crates/backend/src/store/rows.rs
@@ -252,6 +252,10 @@ pub(super) struct FindingRow {
     pub last_seen_at: String,
     pub depends_on: Option<String>,
     pub blocks: Option<String>,
+    pub blocked_by_plan_id: Option<String>,
+    pub blocked_plan_attempts: Option<i64>,
+    pub blocked_last_error: Option<String>,
+    pub blocked_change_request_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -270,6 +274,8 @@ pub(super) struct ChangeRequestRow {
     pub repo_name: Option<String>,
     pub status: String,
     pub finding_ids: Option<String>,
+    pub risk: String,
+    pub confidence: Option<f64>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -289,6 +295,11 @@ pub(super) struct PlanRow {
     pub expected_value: Option<String>,
     pub agent_generated: bool,
     pub waiting_since: Option<String>,
+    pub body: Option<String>,
+    pub execution_id: Option<String>,
+    pub attempts: i64,
+    pub last_error: Option<String>,
+    pub module: Option<String>,
     pub created_at: String,
 }
 
@@ -443,4 +454,39 @@ pub(super) struct WorkflowLogRow {
 pub(super) struct InstanceIdRow {
     #[sqlx(rename = "instanceId")]
     pub instance_id: String,
+}
+
+#[derive(Debug, FromRow)]
+pub(super) struct OptimizeRunRow {
+    pub id: String,
+    pub project_id: String,
+    pub scope: String,
+    pub scope_id: String,
+    pub status: String,
+    pub cycle: i64,
+    pub max_cycles: i64,
+    pub graders: String,
+    pub latest_grades: String,
+    pub open_findings: i64,
+    pub blocked_findings: i64,
+    pub outcome_reason: Option<String>,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, FromRow)]
+pub(super) struct OptimizeCycleRow {
+    pub id: String,
+    pub run_id: String,
+    pub cycle: i64,
+    pub grades: String,
+    pub grade_min: Option<f64>,
+    pub decision: String,
+    pub change_request_id: Option<String>,
+    pub plan_id: Option<String>,
+    pub execution_id: Option<String>,
+    pub develop_status: Option<String>,
+    pub open_findings: i64,
+    pub resolved_this_cycle: i64,
+    pub created_at: String,
 }

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -53,8 +53,13 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
 
     let resource = args.resource.as_str();
 
-    if (args.run_id.is_some() || args.kpi_id.is_some()) && resource != "grades" {
-        eprintln!("DATA-006: --run-id/--kpi-id are only supported with: resource=grades");
+    if (args.run_id.is_some() || args.kpi_id.is_some())
+        && resource != "grades"
+        && resource != "optimize-cycles"
+    {
+        eprintln!(
+            "DATA-006: --run-id/--kpi-id are only supported with: resource=grades, optimize-cycles"
+        );
         std::process::exit(1);
     }
     if (args.scope.is_some()
@@ -90,9 +95,15 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         "findings",
         "change-request",
         "change-requests",
+        "plan",
+        "plans",
+        "optimize-run",
+        "optimize-runs",
+        "optimize-cycle",
+        "optimize-cycles",
     ];
     if !valid_resources.contains(&resource) {
-        eprintln!("DATA-003: unknown resource '{resource}'; must be one of: product, products, component, components, repo, repos, module, modules, module-dependency, module-dependencies, kpi, kpis, eval-run, eval-runs, grade, grades, finding, findings, change-request, change-requests");
+        eprintln!("DATA-003: unknown resource '{resource}'; must be one of: product, products, component, components, repo, repos, module, modules, module-dependency, module-dependencies, kpi, kpis, eval-run, eval-runs, grade, grades, finding, findings, change-request, change-requests, plan, plans, optimize-run, optimize-runs, optimize-cycle, optimize-cycles");
         std::process::exit(1);
     }
 
@@ -115,6 +126,9 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
                 | "grades"
                 | "findings"
                 | "change-requests"
+                | "plans"
+                | "optimize-runs"
+                | "optimize-cycles"
         ),
         DataVerb::Post => false,
         DataVerb::Put | DataVerb::Patch | DataVerb::Delete => true,
@@ -535,6 +549,74 @@ async fn dispatch_data(
             let b = parse_body::<newton_backend::PatchChangeRequestBody>(body)?;
             store
                 .patch_change_request(id, b)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Get, "plans") => store
+            .list_plans(None, None, None)
+            .await
+            .map_err(api_err)
+            .and_then(to_json),
+        (DataVerb::Get, "plan") => store.get_plan(id).await.map_err(api_err).and_then(to_json),
+        (DataVerb::Post, "plan" | "plans") => {
+            let b = parse_body::<newton_backend::CreatePlanBody>(body)?;
+            store
+                .create_plan(b)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Patch, "plan" | "plans") => {
+            let b = parse_body::<newton_backend::PatchPlanBody>(body)?;
+            store
+                .patch_plan(id, b)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Get, "optimize-runs") => store
+            .list_optimize_runs()
+            .await
+            .map_err(api_err)
+            .and_then(to_json),
+        (DataVerb::Get, "optimize-run") => store
+            .get_optimize_run(id)
+            .await
+            .map_err(api_err)
+            .and_then(to_json),
+        (DataVerb::Post, "optimize-run" | "optimize-runs") => {
+            let b = parse_body::<newton_backend::CreateOptimizeRunBody>(body)?;
+            store
+                .create_optimize_run(b)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Patch, "optimize-run" | "optimize-runs") => {
+            let b = parse_body::<newton_backend::PatchOptimizeRunBody>(body)?;
+            store
+                .patch_optimize_run(id, b)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Get, "optimize-cycles") => {
+            let run_id = args.run_id.as_deref().unwrap_or(id);
+            store
+                .list_optimize_cycles(run_id)
+                .await
+                .map_err(api_err)
+                .and_then(to_json)
+        }
+        (DataVerb::Get, "optimize-cycle") => {
+            // For single cycle GET we reuse get_optimize_run by run_id + trajectory; use list and filter by id
+            Err("use 'optimize-cycles --run-id <run_id>' to list cycles; single cycle GET not supported".to_string())
+        }
+        (DataVerb::Post, "optimize-cycle" | "optimize-cycles") => {
+            let b = parse_body::<newton_backend::CreateOptimizeCycleBody>(body)?;
+            store
+                .create_optimize_cycle(b)
                 .await
                 .map_err(api_err)
                 .and_then(to_json)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -201,3 +201,7 @@ path = "tests/workflow_graph/test_schema_export.rs"
 [[test]]
 name = "test_git_operator"
 path = "tests/workflow_graph/test_git_operator.rs"
+
+[[test]]
+name = "test_optimize_loop"
+path = "tests/integration/test_optimize_loop.rs"

--- a/crates/core/src/api/findings.rs
+++ b/crates/core/src/api/findings.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::Json,
     extract::{Path, Query, State},
     response::Response,
-    routing::get,
+    routing::{get, post},
     Router,
 };
 use newton_backend::{CreateFindingBody, PatchFindingBody};
@@ -16,6 +16,7 @@ pub fn routes(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/findings", get(list_findings).post(create_finding))
         .route("/findings/{id}", get(get_finding).patch(patch_finding))
+        .route("/findings/{id}/unblock", post(unblock_finding))
         .with_state(state)
 }
 
@@ -107,4 +108,23 @@ pub(crate) async fn patch_finding(
     Json(body): Json<PatchFindingBody>,
 ) -> Response {
     ok_json(state.backend.patch_finding(&id, body).await)
+}
+
+#[utoipa::path(
+    post,
+    path = "/findings/{id}/unblock",
+    tag = "findings",
+    params(("id" = String, Path, description = "Finding id")),
+    responses(
+        (status = 200, description = "Unblocked finding", body = newton_backend::FindingItem),
+        (status = 404, description = "Finding not found", body = newton_types::ApiError),
+        (status = 409, description = "Finding is not blocked", body = newton_types::ApiError),
+        (status = 500, description = "Internal error", body = newton_types::ApiError)
+    )
+)]
+pub(crate) async fn unblock_finding(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    ok_json(state.backend.unblock_finding(&id).await)
 }

--- a/crates/core/src/api/mod.rs
+++ b/crates/core/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod hil;
 pub mod magic_tools;
 pub mod openapi;
 pub mod operators;
+pub mod optimize_run;
 pub mod persistence;
 pub mod plans;
 pub mod portfolio;
@@ -65,6 +66,7 @@ pub fn api_v1_router(state: AppState) -> Router {
         .merge(plans::routes(arc_state.clone()))
         .merge(persistence::routes(arc_state.clone()))
         .merge(catalog::routes(arc_state.clone()))
+        .merge(optimize_run::routes(arc_state.clone()))
         .merge(testing_reset::routes(arc_state.clone()))
         .merge(workflow_files::routes(arc_state.clone()))
         .merge(aikit_magictool::router(magic_tools::build_state()))

--- a/crates/core/src/api/openapi.rs
+++ b/crates/core/src/api/openapi.rs
@@ -18,6 +18,11 @@ use utoipa::OpenApi;
         crate::api::findings::create_finding,
         crate::api::findings::get_finding,
         crate::api::findings::patch_finding,
+        crate::api::findings::unblock_finding,
+        crate::api::optimize_run::list_optimize_runs,
+        crate::api::optimize_run::get_optimize_run,
+        crate::api::optimize_run::get_optimize_run_trajectory,
+        crate::api::optimize_run::list_optimize_cycles,
         crate::api::change_requests::list_change_requests,
         crate::api::change_requests::create_change_request,
         crate::api::change_requests::get_change_request,
@@ -127,6 +132,10 @@ use utoipa::OpenApi;
         newton_backend::CreateGradeBody,
         newton_backend::CreateKpiBody,
         newton_backend::CreateGradeInlineBody,
+        newton_backend::OptimizeRunItem,
+        newton_backend::OptimizeRunDetail,
+        newton_backend::OptimizeRunTrajectory,
+        newton_backend::OptimizeCycleItem,
         newton_types::WorkflowInstance,
         newton_types::WorkflowStatus,
         newton_types::NodeState,
@@ -158,7 +167,8 @@ use utoipa::OpenApi;
         (name = "persistence", description = "Key-value persistence endpoints"),
         (name = "catalog", description = "Catalog entity CRUD endpoints"),
         (name = "testing", description = "Test-only maintenance endpoints"),
-        (name = "workflow-files", description = "Workflow definition file CRUD endpoints")
+        (name = "workflow-files", description = "Workflow definition file CRUD endpoints"),
+        (name = "optimize", description = "Optimization loop run and cycle endpoints")
     ),
     servers((url = "/api/v1")),
     info(

--- a/crates/core/src/api/optimize_run.rs
+++ b/crates/core/src/api/optimize_run.rs
@@ -1,0 +1,97 @@
+use crate::api::ok_json;
+use crate::api::state::AppState;
+use axum::{
+    extract::{Path, State},
+    response::Response,
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/optimize-runs", get(list_optimize_runs))
+        .route("/optimize-runs/{id}", get(get_optimize_run))
+        .route(
+            "/optimize-runs/{id}/trajectory",
+            get(get_optimize_run_trajectory),
+        )
+        .route("/optimize-runs/{id}/cycles", get(list_optimize_cycles))
+        .with_state(state)
+}
+
+#[utoipa::path(
+    get,
+    path = "/optimize-runs",
+    tag = "optimize",
+    responses(
+        (status = 200, description = "List of optimize runs", body = [newton_backend::OptimizeRunItem]),
+        (status = 500, description = "Internal error", body = newton_types::ApiError)
+    )
+)]
+pub(crate) async fn list_optimize_runs(State(state): State<Arc<AppState>>) -> Response {
+    ok_json(state.backend.list_optimize_runs().await)
+}
+
+#[utoipa::path(
+    get,
+    path = "/optimize-runs/{id}",
+    tag = "optimize",
+    params(("id" = String, Path, description = "Optimize run id")),
+    responses(
+        (status = 200, description = "Optimize run detail", body = newton_backend::OptimizeRunDetail),
+        (status = 404, description = "Not found", body = newton_types::ApiError),
+        (status = 500, description = "Internal error", body = newton_types::ApiError)
+    )
+)]
+pub(crate) async fn get_optimize_run(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    ok_json(state.backend.get_optimize_run(&id).await)
+}
+
+#[utoipa::path(
+    get,
+    path = "/optimize-runs/{id}/trajectory",
+    tag = "optimize",
+    params(("id" = String, Path, description = "Optimize run id")),
+    responses(
+        (status = 200, description = "Run detail with cycles", body = newton_backend::OptimizeRunTrajectory),
+        (status = 404, description = "Not found", body = newton_types::ApiError),
+        (status = 500, description = "Internal error", body = newton_types::ApiError)
+    )
+)]
+pub(crate) async fn get_optimize_run_trajectory(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let detail = match state.backend.get_optimize_run(&id).await {
+        Ok(d) => d,
+        Err(e) => return ok_json::<()>(Err(e)),
+    };
+    let cycles = match state.backend.list_optimize_cycles(&id).await {
+        Ok(c) => c,
+        Err(e) => return ok_json::<()>(Err(e)),
+    };
+    ok_json(Ok::<_, newton_types::ApiError>(
+        newton_backend::OptimizeRunTrajectory { detail, cycles },
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/optimize-runs/{id}/cycles",
+    tag = "optimize",
+    params(("id" = String, Path, description = "Optimize run id")),
+    responses(
+        (status = 200, description = "Cycles for run", body = [newton_backend::OptimizeCycleItem]),
+        (status = 500, description = "Internal error", body = newton_types::ApiError)
+    )
+)]
+pub(crate) async fn list_optimize_cycles(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    ok_json(state.backend.list_optimize_cycles(&id).await)
+}

--- a/crates/core/src/api/plans.rs
+++ b/crates/core/src/api/plans.rs
@@ -30,7 +30,7 @@ pub fn routes(state: Arc<AppState>) -> Router {
     )
 )]
 pub(crate) async fn list_plans(State(state): State<Arc<AppState>>) -> Response {
-    match state.backend.list_plans().await {
+    match state.backend.list_plans(None, None, None).await {
         Ok(items) => (StatusCode::OK, Json(items)).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e)).into_response(),
     }

--- a/crates/core/src/workflow/operators/change_request_op.rs
+++ b/crates/core/src/workflow/operators/change_request_op.rs
@@ -79,6 +79,30 @@ fn severity_rank(s: &str) -> u8 {
     }
 }
 
+fn rollup_risk<'a>(risks: impl Iterator<Item = &'a str>) -> String {
+    let worst = risks.map(severity_rank).min().unwrap_or(2);
+    match worst {
+        0 => "critical".to_string(),
+        1 => "high".to_string(),
+        2 => "medium".to_string(),
+        _ => "low".to_string(),
+    }
+}
+
+fn rollup_confidence(confidences: impl Iterator<Item = f64>) -> Option<f64> {
+    let mut sum = 0.0_f64;
+    let mut count = 0usize;
+    for c in confidences {
+        sum += c;
+        count += 1;
+    }
+    if count == 0 {
+        None
+    } else {
+        Some(sum / count as f64)
+    }
+}
+
 fn is_open_status(status: &str) -> bool {
     matches!(
         status,
@@ -269,6 +293,10 @@ impl Operator for ChangeRequestOperator {
             _ => (None, None),
         };
 
+        // Roll up risk and confidence from the selected Findings.
+        let rolled_risk = rollup_risk(selected.iter().map(|f| f.risk.as_str()));
+        let rolled_confidence = rollup_confidence(selected.iter().filter_map(|f| f.confidence));
+
         self.store
             .create_change_request(CreateChangeRequestBody {
                 id: cr_id.clone(),
@@ -279,6 +307,8 @@ impl Operator for ChangeRequestOperator {
                 component_id: cr_component_id,
                 repo_id: cr_repo_id,
                 finding_ids,
+                risk: rolled_risk,
+                confidence: rolled_confidence,
             })
             .await
             .map_err(|e| {

--- a/crates/core/src/workflow/operators/reconcile.rs
+++ b/crates/core/src/workflow/operators/reconcile.rs
@@ -450,6 +450,7 @@ impl Operator for ReconcileOperator {
                                 expected_value: None,
                                 effort: None,
                                 risk: None,
+                                blocked_by_plan_id: None,
                             },
                         )
                         .await
@@ -471,6 +472,7 @@ impl Operator for ReconcileOperator {
                                 expected_value: None,
                                 effort: None,
                                 risk: None,
+                                blocked_by_plan_id: None,
                             },
                         )
                         .await
@@ -500,6 +502,7 @@ impl Operator for ReconcileOperator {
                             expected_value: None,
                             effort: None,
                             risk: None,
+                            blocked_by_plan_id: None,
                         },
                     )
                     .await
@@ -576,6 +579,7 @@ impl Operator for ReconcileOperator {
                             expected_value: None,
                             effort: None,
                             risk: None,
+                            blocked_by_plan_id: None,
                         },
                     )
                     .await
@@ -603,6 +607,7 @@ impl Operator for ReconcileOperator {
                                 expected_value: None,
                                 effort: None,
                                 risk: None,
+                                blocked_by_plan_id: None,
                             },
                         )
                         .await

--- a/crates/core/tests/integration/test_optimize_loop.rs
+++ b/crates/core/tests/integration/test_optimize_loop.rs
@@ -47,8 +47,25 @@ fn patches_dir() -> PathBuf {
     workspace_root().join("tests/fixtures/repos/widgets-cli.patches")
 }
 
+fn shim_path_with_failing_gh(shim_dir: &std::path::Path) -> String {
+    // Write a fake `gh` script that exits 1 with a clear error.
+    let gh_shim = shim_dir.join("gh");
+    std::fs::write(
+        &gh_shim,
+        "#!/bin/sh\necho 'gh invoked — zero-GitHub guard triggered' >&2\nexit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&gh_shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let orig = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", shim_dir.display(), orig)
+}
+
 /// Copy the fixture directory to a temp location and init a git repo.
-fn setup_repo(tmp: &Path) {
+fn setup_repo(tmp: &Path, env_path: &str) {
     let src = fixture_dir();
     copy_dir_all(&src, tmp).expect("copy fixture");
 
@@ -61,6 +78,7 @@ fn setup_repo(tmp: &Path) {
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.test")
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("PATH", env_path)
             .status()
             .expect("git");
         assert!(status.success(), "git {:?} failed", args);
@@ -128,12 +146,13 @@ async fn seed_repo_id(store: &SqliteBackendStore) -> String {
 }
 
 /// Run the seed grader and return the Assessment as a JSON value.
-fn run_seed_grader(repo_id: &str, repo_path: &Path) -> serde_json::Value {
+fn run_seed_grader(repo_id: &str, repo_path: &Path, env_path: &str) -> serde_json::Value {
     let script = grader_script();
     let out = Command::new("bash")
         .arg(script)
         .arg(repo_id)
         .arg(repo_path)
+        .env("PATH", env_path)
         .output()
         .expect("seed-grader.sh");
     assert!(
@@ -145,29 +164,31 @@ fn run_seed_grader(repo_id: &str, repo_path: &Path) -> serde_json::Value {
 }
 
 /// Run pytest in the repo dir; returns true if all tests passed.
-fn run_pytest(repo_path: &Path) -> bool {
+fn run_pytest(repo_path: &Path, env_path: &str) -> bool {
     Command::new("python3")
         .args(["-m", "pytest", "-q", "--tb=short"])
         .current_dir(repo_path)
         .env("PYTHONPATH", repo_path.join("src"))
+        .env("PATH", env_path)
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
 }
 
 /// Apply a patch file with `git apply`. Returns true on success.
-fn apply_patch(repo_path: &Path, patch_file: &Path) -> bool {
+fn apply_patch(repo_path: &Path, patch_file: &Path, env_path: &str) -> bool {
     Command::new("git")
         .args(["apply", patch_file.to_str().unwrap()])
         .current_dir(repo_path)
         .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("PATH", env_path)
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
 }
 
 /// Commit everything staged in the repo.
-fn git_commit(repo_path: &Path, message: &str) {
+fn git_commit(repo_path: &Path, message: &str, env_path: &str) {
     let git = |args: &[&str]| {
         let status = Command::new("git")
             .args(args)
@@ -177,6 +198,7 @@ fn git_commit(repo_path: &Path, message: &str) {
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.test")
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("PATH", env_path)
             .status()
             .expect("git");
         assert!(status.success(), "git {:?} failed", args);
@@ -192,6 +214,7 @@ struct CycleRecord {
     cycle: usize,
     score: f64,
     open_findings: usize,
+    resolved_count: usize,
     decision: String,
     targeted_dimension: Option<String>,
     resolved_dimension: Option<String>,
@@ -205,7 +228,9 @@ async fn test_optimize_loop_tier1_deterministic() {
     // ── Setup ────────────────────────────────────────────────────────────────
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo_path = tmp.path().to_path_buf();
-    setup_repo(&repo_path);
+    let shim_dir = tempfile::tempdir().expect("shim_dir");
+    let env_path = shim_path_with_failing_gh(shim_dir.path());
+    setup_repo(&repo_path, &env_path);
 
     let store = Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
 
@@ -224,7 +249,7 @@ async fn test_optimize_loop_tier1_deterministic() {
 
     for cycle in 1..=MAX_CYCLES {
         // ── Grade ─────────────────────────────────────────────────────────
-        let assessment = run_seed_grader(&repo_id, &repo_path);
+        let assessment = run_seed_grader(&repo_id, &repo_path, &env_path);
         let score = assessment["overall_score"].as_f64().unwrap_or(0.0);
         let observations: Vec<serde_json::Value> = assessment["observations"]
             .as_array()
@@ -279,16 +304,6 @@ async fn test_optimize_loop_tier1_deterministic() {
             .await
             .unwrap();
 
-        let open_count = all_findings
-            .iter()
-            .filter(|f| {
-                matches!(
-                    f.status.as_str(),
-                    "awaiting_triage" | "triaged" | "approved_for_planning"
-                )
-            })
-            .count();
-
         // Resolve findings no longer observed (dimension no longer reported)
         for f in &all_findings {
             if !open_dims.contains(&f.dimension)
@@ -308,6 +323,14 @@ async fn test_optimize_loop_tier1_deterministic() {
                     .await;
             }
         }
+
+        let resolved_count = {
+            let all = store
+                .list_findings(None, Some("repo".to_string()), Some(repo_id.clone()))
+                .await
+                .unwrap();
+            all.iter().filter(|f| f.status == "resolved").count()
+        };
 
         // ── Change Request synthesis ──────────────────────────────────────
         // Re-fetch after resolution so we see the updated statuses.
@@ -332,6 +355,7 @@ async fn test_optimize_loop_tier1_deterministic() {
                 cycle,
                 score,
                 open_findings: 0,
+                resolved_count,
                 decision: "none".to_string(),
                 targeted_dimension: None,
                 resolved_dimension: None,
@@ -383,7 +407,7 @@ async fn test_optimize_loop_tier1_deterministic() {
         // ── Deterministic develop: apply dimension-matched patch ───────────
         let patch_file = patches_dir().join(format!("{}.patch", target_dim));
         let patch_applied = if patch_file.exists() {
-            apply_patch(&repo_path, &patch_file)
+            apply_patch(&repo_path, &patch_file, &env_path)
         } else {
             false
         };
@@ -395,7 +419,7 @@ async fn test_optimize_loop_tier1_deterministic() {
         );
 
         // pytest gate: must pass after the patch
-        let pytest_ok = run_pytest(&repo_path);
+        let pytest_ok = run_pytest(&repo_path, &env_path);
         assert!(
             pytest_ok,
             "cycle {cycle}: pytest failed after applying '{target_dim}' patch — behaviour regression"
@@ -404,6 +428,7 @@ async fn test_optimize_loop_tier1_deterministic() {
         git_commit(
             &repo_path,
             &format!("fix({target_dim}): apply deterministic patch"),
+            &env_path,
         );
 
         // Mark Plan complete
@@ -419,7 +444,7 @@ async fn test_optimize_loop_tier1_deterministic() {
 
         // Content-coupling: re-grade to see which dimension actually resolved.
         // A "fixed the wrong thing" regression would leave target_dim still present.
-        let post_patch_assessment = run_seed_grader(&repo_id, &repo_path);
+        let post_patch_assessment = run_seed_grader(&repo_id, &repo_path, &env_path);
         let post_patch_dims: std::collections::HashSet<String> = post_patch_assessment
             ["observations"]
             .as_array()
@@ -437,7 +462,8 @@ async fn test_optimize_loop_tier1_deterministic() {
         trajectory.push(CycleRecord {
             cycle,
             score,
-            open_findings: open_count,
+            open_findings: open_findings.len(),
+            resolved_count,
             decision: "propose".to_string(),
             targeted_dimension: Some(target_dim),
             resolved_dimension,
@@ -452,7 +478,7 @@ async fn test_optimize_loop_tier1_deterministic() {
     // Last cycle must have converged (decision=none) or we ran out of issues
     let last = trajectory.last().unwrap();
     let final_score = {
-        let assessment = run_seed_grader(&repo_id, &repo_path);
+        let assessment = run_seed_grader(&repo_id, &repo_path, &env_path);
         assessment["overall_score"].as_f64().unwrap_or(0.0)
     };
     assert!(
@@ -468,8 +494,8 @@ async fn test_optimize_loop_tier1_deterministic() {
     for window in propose_cycles.windows(2) {
         let (a, b) = (window[0], window[1]);
         assert!(
-            b.score >= a.score,
-            "score regression: cycle {} score={} → cycle {} score={}",
+            b.score > a.score,
+            "score did not strictly increase: cycle {} score={} → cycle {} score={}",
             a.cycle,
             a.score,
             b.cycle,
@@ -485,12 +511,29 @@ async fn test_optimize_loop_tier1_deterministic() {
     for window in propose_with_open.windows(2) {
         let (a, b) = (window[0], window[1]);
         assert!(
-            b.open_findings <= a.open_findings,
-            "open findings increased: cycle {} had {} → cycle {} had {}",
+            b.open_findings < a.open_findings,
+            "open findings did not strictly decrease: cycle {} had {} → cycle {} had {}",
             a.cycle,
             a.open_findings,
             b.cycle,
             b.open_findings
+        );
+    }
+
+    // resolved_count must strictly increase across propose cycles
+    let propose_resolved: Vec<&CycleRecord> = trajectory
+        .iter()
+        .filter(|r| r.decision == "propose")
+        .collect();
+    for window in propose_resolved.windows(2) {
+        let (a, b) = (window[0], window[1]);
+        assert!(
+            b.resolved_count > a.resolved_count,
+            "resolved count did not strictly increase: cycle {} had {} → cycle {} had {}",
+            a.cycle,
+            a.resolved_count,
+            b.cycle,
+            b.resolved_count
         );
     }
 

--- a/crates/core/tests/integration/test_optimize_loop.rs
+++ b/crates/core/tests/integration/test_optimize_loop.rs
@@ -1,0 +1,547 @@
+//! Tier-1 deterministic optimization loop test (spec 069 §11.2).
+//!
+//! Drives: seed-grader.sh → store entities → deterministic CR synthesis →
+//! dimension-matched patch → pytest → git commit → re-grade until convergence.
+//!
+//! Asserts (oracle from SEED.md):
+//!   - Each cycle: open Findings strictly decrease, score strictly increases
+//!   - content-coupling: dimension resolved == dimension CR targeted
+//!   - Converges (decision: none) within max_cycles
+//!   - pytest stays green every cycle
+//!   - Zero GhOperator / no `gh` binary invoked
+
+use newton_backend::{
+    BackendStore, CreateChangeRequestBody, CreateComponentBody, CreateFindingBody, CreatePlanBody,
+    CreateProductBody, CreateRepoBody, SqliteBackendStore,
+};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Arc,
+};
+use uuid::Uuid;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = crates/core  →  go up twice to repo root
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    Path::new(manifest)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixture_dir() -> PathBuf {
+    workspace_root().join("tests/fixtures/repos/widgets-cli")
+}
+
+fn grader_script() -> PathBuf {
+    workspace_root().join("tests/fixtures/graders/seed-grader.sh")
+}
+
+fn patches_dir() -> PathBuf {
+    workspace_root().join("tests/fixtures/repos/widgets-cli.patches")
+}
+
+/// Copy the fixture directory to a temp location and init a git repo.
+fn setup_repo(tmp: &Path) {
+    let src = fixture_dir();
+    copy_dir_all(&src, tmp).expect("copy fixture");
+
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(tmp)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.test")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.test")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .status()
+            .expect("git");
+        assert!(status.success(), "git {:?} failed", args);
+    };
+    git(&["init", "-b", "main"]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "initial: seeded fixture"]);
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        // Skip __pycache__ and .pyc files — they're stale bytecode from the dev machine
+        if name == "__pycache__" {
+            continue;
+        }
+        let ty = entry.file_type()?;
+        let dest = dst.join(&name);
+        if ty.is_dir() {
+            copy_dir_all(&entry.path(), &dest)?;
+        } else if entry.path().extension().is_none_or(|e| e != "pyc") {
+            fs::copy(entry.path(), dest)?;
+        }
+    }
+    Ok(())
+}
+
+/// Seed product → component → repo and return the repo id.
+async fn seed_repo_id(store: &SqliteBackendStore) -> String {
+    let now = "2026-01-01T00:00:00Z".to_string();
+    let product = store
+        .create_product(CreateProductBody {
+            name: "widgets-cli-product".to_string(),
+        })
+        .await
+        .unwrap();
+    let component = store
+        .create_component(CreateComponentBody {
+            name: "widgets-cli-component".to_string(),
+            product_id: product.id,
+            domain: "cli".to_string(),
+            owner: "test".to_string(),
+            criticality: "low".to_string(),
+            autonomy: "autonomous".to_string(),
+            trend: 0,
+            last_eval: now.clone(),
+        })
+        .await
+        .unwrap();
+    let repo = store
+        .create_repo(CreateRepoBody {
+            name: "widgets-cli".to_string(),
+            component_id: component.id,
+            owner: "test".to_string(),
+            criticality: "low".to_string(),
+            autonomy: "autonomous".to_string(),
+            exec_status: "idle".to_string(),
+            last_eval: now,
+        })
+        .await
+        .unwrap();
+    repo.id
+}
+
+/// Run the seed grader and return the Assessment as a JSON value.
+fn run_seed_grader(repo_id: &str, repo_path: &Path) -> serde_json::Value {
+    let script = grader_script();
+    let out = Command::new("bash")
+        .arg(script)
+        .arg(repo_id)
+        .arg(repo_path)
+        .output()
+        .expect("seed-grader.sh");
+    assert!(
+        out.status.success(),
+        "seed-grader.sh failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("Assessment JSON")
+}
+
+/// Run pytest in the repo dir; returns true if all tests passed.
+fn run_pytest(repo_path: &Path) -> bool {
+    Command::new("python3")
+        .args(["-m", "pytest", "-q", "--tb=short"])
+        .current_dir(repo_path)
+        .env("PYTHONPATH", repo_path.join("src"))
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Apply a patch file with `git apply`. Returns true on success.
+fn apply_patch(repo_path: &Path, patch_file: &Path) -> bool {
+    Command::new("git")
+        .args(["apply", patch_file.to_str().unwrap()])
+        .current_dir(repo_path)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Commit everything staged in the repo.
+fn git_commit(repo_path: &Path, message: &str) {
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo_path)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.test")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.test")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .status()
+            .expect("git");
+        assert!(status.success(), "git {:?} failed", args);
+    };
+    git(&["add", "."]);
+    git(&["commit", "-m", message, "--allow-empty"]);
+}
+
+// ── Per-cycle record ──────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct CycleRecord {
+    cycle: usize,
+    score: f64,
+    open_findings: usize,
+    decision: String,
+    targeted_dimension: Option<String>,
+    resolved_dimension: Option<String>,
+    pytest_passed: bool,
+}
+
+// ── Main test ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_optimize_loop_tier1_deterministic() {
+    // ── Setup ────────────────────────────────────────────────────────────────
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo_path = tmp.path().to_path_buf();
+    setup_repo(&repo_path);
+
+    let store = Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
+
+    let repo_id = seed_repo_id(&store).await;
+
+    const MAX_CYCLES: usize = 8;
+    let mut trajectory: Vec<CycleRecord> = Vec::new();
+
+    // Track which dimensions have been resolved to detect content-coupling.
+    let all_dimensions = [
+        "file_decomposition",
+        "canonical_placement",
+        "abstraction_economy",
+        "branching_discipline",
+    ];
+
+    for cycle in 1..=MAX_CYCLES {
+        // ── Grade ─────────────────────────────────────────────────────────
+        let assessment = run_seed_grader(&repo_id, &repo_path);
+        let score = assessment["overall_score"].as_f64().unwrap_or(0.0);
+        let observations: Vec<serde_json::Value> = assessment["observations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+
+        // ── Reconcile: upsert Findings from observations ────────────────
+        let now = chrono::Utc::now().to_rfc3339();
+        for obs in &observations {
+            let dim = obs["dimension"].as_str().unwrap_or("").to_string();
+            let fingerprint = format!("seed-grader:{}:{}", &repo_id, &dim);
+            let _ = store
+                .create_finding(CreateFindingBody {
+                    id: fingerprint.clone(),
+                    source: "seed-grader".to_string(),
+                    origin: "system".to_string(),
+                    component_id: None,
+                    module: None,
+                    repo_id: Some(repo_id.clone()),
+                    kpi_id: None,
+                    dimension: dim,
+                    location: obs.get("location").cloned(),
+                    fingerprint,
+                    title: obs["title"].as_str().unwrap_or("").to_string(),
+                    why_it_matters: "Reduces maintainability.".to_string(),
+                    recommended_action: obs["recommended_action"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string(),
+                    severity: obs["severity"].as_str().unwrap_or("medium").to_string(),
+                    risk: "medium".to_string(),
+                    confidence: obs["confidence"].as_f64(),
+                    evidence: None,
+                    expected_value: None,
+                    effort: None,
+                    status: "awaiting_triage".to_string(),
+                    last_seen_at: Some(now.clone()),
+                    depends_on: vec![],
+                    blocks: vec![],
+                })
+                .await;
+        }
+
+        // Resolve Findings whose dimensions are no longer in the Assessment
+        let open_dims: std::collections::HashSet<String> = observations
+            .iter()
+            .filter_map(|o| o["dimension"].as_str().map(|s| s.to_string()))
+            .collect();
+
+        let all_findings = store
+            .list_findings(None, Some("repo".to_string()), Some(repo_id.clone()))
+            .await
+            .unwrap();
+
+        let open_count = all_findings
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.status.as_str(),
+                    "awaiting_triage" | "triaged" | "approved_for_planning"
+                )
+            })
+            .count();
+
+        // Resolve findings no longer observed (dimension no longer reported)
+        for f in &all_findings {
+            if !open_dims.contains(&f.dimension)
+                && matches!(
+                    f.status.as_str(),
+                    "awaiting_triage" | "triaged" | "approved_for_planning"
+                )
+            {
+                let _ = store
+                    .patch_finding(
+                        &f.id,
+                        newton_backend::PatchFindingBody {
+                            status: Some("resolved".to_string()),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+            }
+        }
+
+        // ── Change Request synthesis ──────────────────────────────────────
+        // Re-fetch after resolution so we see the updated statuses.
+        let fresh_findings = store
+            .list_findings(None, Some("repo".to_string()), Some(repo_id.clone()))
+            .await
+            .unwrap();
+
+        let open_findings: Vec<_> = fresh_findings
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.status.as_str(),
+                    "awaiting_triage" | "triaged" | "approved_for_planning"
+                )
+            })
+            .collect();
+
+        if open_findings.is_empty() {
+            // No actionable findings → converged
+            trajectory.push(CycleRecord {
+                cycle,
+                score,
+                open_findings: 0,
+                decision: "none".to_string(),
+                targeted_dimension: None,
+                resolved_dimension: None,
+                pytest_passed: true,
+            });
+            break;
+        }
+
+        let target_finding = open_findings[0];
+        let target_dim = target_finding.dimension.clone();
+
+        let cr_id = Uuid::new_v4().to_string();
+        store
+            .create_change_request(CreateChangeRequestBody {
+                id: cr_id.clone(),
+                title: format!("Fix {} in widgets-cli", target_dim),
+                body: Some(target_finding.recommended_action.clone()),
+                origin: "system".to_string(),
+                author: None,
+                component_id: None,
+                repo_id: Some(repo_id.clone()),
+                finding_ids: vec![target_finding.id.clone()],
+                risk: target_finding.risk.clone(),
+                confidence: target_finding.confidence,
+            })
+            .await
+            .unwrap();
+
+        // Create a Plan for this CR
+        let plan_id = Uuid::new_v4().to_string();
+        store
+            .create_plan(CreatePlanBody {
+                id: plan_id.clone(),
+                title: format!("Plan: fix {}", target_dim),
+                linked_change_request_id: cr_id.clone(),
+                body: Some(target_finding.recommended_action.clone()),
+                status: "ready".to_string(),
+                component_id: None,
+                repo_id: Some(repo_id.clone()),
+                module: None,
+                confidence: (target_finding.confidence.unwrap_or(0.8) * 100.0) as i64,
+                risk: target_finding.risk.clone(),
+                expected_value: None,
+                expected_delta: None,
+            })
+            .await
+            .unwrap();
+
+        // ── Deterministic develop: apply dimension-matched patch ───────────
+        let patch_file = patches_dir().join(format!("{}.patch", target_dim));
+        let patch_applied = if patch_file.exists() {
+            apply_patch(&repo_path, &patch_file)
+        } else {
+            false
+        };
+
+        // Content-coupling assert: the patch file MUST exist for the targeted dimension.
+        assert!(
+            patch_applied,
+            "cycle {cycle}: no patch found for targeted dimension '{target_dim}' — content-coupling violated"
+        );
+
+        // pytest gate: must pass after the patch
+        let pytest_ok = run_pytest(&repo_path);
+        assert!(
+            pytest_ok,
+            "cycle {cycle}: pytest failed after applying '{target_dim}' patch — behaviour regression"
+        );
+
+        git_commit(
+            &repo_path,
+            &format!("fix({target_dim}): apply deterministic patch"),
+        );
+
+        // Mark Plan complete
+        let _ = store
+            .patch_plan(
+                &plan_id,
+                newton_backend::PatchPlanBody {
+                    status: Some("complete".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        // Content-coupling: re-grade to see which dimension actually resolved.
+        // A "fixed the wrong thing" regression would leave target_dim still present.
+        let post_patch_assessment = run_seed_grader(&repo_id, &repo_path);
+        let post_patch_dims: std::collections::HashSet<String> = post_patch_assessment
+            ["observations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|o| o["dimension"].as_str().map(|s| s.to_string()))
+            .collect();
+        // The dimension that was open before but absent after is the one resolved.
+        let resolved_dimension: Option<String> = open_findings
+            .iter()
+            .map(|f| f.dimension.clone())
+            .find(|d| !post_patch_dims.contains(d));
+
+        trajectory.push(CycleRecord {
+            cycle,
+            score,
+            open_findings: open_count,
+            decision: "propose".to_string(),
+            targeted_dimension: Some(target_dim),
+            resolved_dimension,
+            pytest_passed: pytest_ok,
+        });
+    }
+
+    // ── Oracle assertions ────────────────────────────────────────────────────
+
+    assert!(!trajectory.is_empty(), "trajectory must not be empty");
+
+    // Last cycle must have converged (decision=none) or we ran out of issues
+    let last = trajectory.last().unwrap();
+    let final_score = {
+        let assessment = run_seed_grader(&repo_id, &repo_path);
+        assessment["overall_score"].as_f64().unwrap_or(0.0)
+    };
+    assert!(
+        last.decision == "none" || final_score >= 95.0,
+        "loop did not converge within {MAX_CYCLES} cycles; final score={final_score}"
+    );
+
+    // Scores must be non-decreasing across propose cycles
+    let propose_cycles: Vec<&CycleRecord> = trajectory
+        .iter()
+        .filter(|r| r.decision == "propose")
+        .collect();
+    for window in propose_cycles.windows(2) {
+        let (a, b) = (window[0], window[1]);
+        assert!(
+            b.score >= a.score,
+            "score regression: cycle {} score={} → cycle {} score={}",
+            a.cycle,
+            a.score,
+            b.cycle,
+            b.score
+        );
+    }
+
+    // open_findings must be non-increasing across cycles
+    let propose_with_open: Vec<_> = trajectory
+        .iter()
+        .filter(|r| r.decision == "propose")
+        .collect();
+    for window in propose_with_open.windows(2) {
+        let (a, b) = (window[0], window[1]);
+        assert!(
+            b.open_findings <= a.open_findings,
+            "open findings increased: cycle {} had {} → cycle {} had {}",
+            a.cycle,
+            a.open_findings,
+            b.cycle,
+            b.open_findings
+        );
+    }
+
+    // pytest green every cycle
+    for rec in &trajectory {
+        assert!(
+            rec.pytest_passed,
+            "pytest failed on cycle {} — behaviour regression",
+            rec.cycle
+        );
+    }
+
+    // Content-coupling: every propose cycle must resolve exactly the targeted dimension.
+    // resolved_dimension=None means the patch didn't clear any dimension → regression.
+    for rec in &trajectory {
+        if rec.decision == "propose" {
+            let targeted = rec.targeted_dimension.as_deref().unwrap_or("<none>");
+            let resolved = rec
+                .resolved_dimension
+                .as_deref()
+                .unwrap_or("<nothing resolved>");
+            assert_eq!(
+                targeted, resolved,
+                "cycle {}: patch targeted '{}' but post-patch grader shows '{}' resolved",
+                rec.cycle, targeted, resolved
+            );
+        }
+    }
+
+    // Final score must be ≥ 95 (all 4 issues fixed)
+    assert!(
+        final_score >= 95.0,
+        "final score {final_score} < 95: not all issues fixed"
+    );
+
+    // All 4 dimensions must have been resolved at some point
+    let resolved_dims: std::collections::HashSet<&str> = trajectory
+        .iter()
+        .filter_map(|r| r.resolved_dimension.as_deref())
+        .collect();
+    for dim in &all_dimensions {
+        assert!(
+            resolved_dims.contains(*dim),
+            "dimension '{}' was never resolved",
+            dim
+        );
+    }
+
+    println!(
+        "Tier-1 optimize loop: {} cycles, final score={final_score}, dims resolved={:?}",
+        trajectory.len(),
+        resolved_dims
+    );
+}

--- a/docs/operators/change_request.md
+++ b/docs/operators/change_request.md
@@ -2,7 +2,7 @@
 
 > Status: **design** (not yet implemented). See [CONTEXT.md](../../CONTEXT.md)
 > (Change Request, Finding, Reconciliation) and
-> [ADR 0005](../adr/0005-grading-is-text-gradient-driven.md).
+> [ADR 0009](../adr/0009-grading-is-text-gradient-driven.md).
 
 The loop's **optimizer step**: reads the standing **Findings** (the aggregated
 text-gradient), synthesizes a coherent **Change Request**, and persists it. It is

--- a/docs/operators/grader_command.md
+++ b/docs/operators/grader_command.md
@@ -2,7 +2,7 @@
 
 > Status: **design** (not yet implemented). Settled via the grading design
 > sessions; see [CONTEXT.md](../../CONTEXT.md) (Grader, Assessment, …) and
-> [ADR 0005](../adr/0005-grading-is-text-gradient-driven.md).
+> [ADR 0009](../adr/0009-grading-is-text-gradient-driven.md).
 
 Runs a **command Grader** — an external program, in any language, that evaluates
 the project's current state and prints an **Assessment** — then validates it and

--- a/docs/operators/reconcile.md
+++ b/docs/operators/reconcile.md
@@ -2,7 +2,7 @@
 
 > Status: **design** (not yet implemented). See [CONTEXT.md](../../CONTEXT.md)
 > (Reconciliation, Observation, Finding) and
-> [ADR 0005](../adr/0005-grading-is-text-gradient-driven.md).
+> [ADR 0009](../adr/0009-grading-is-text-gradient-driven.md).
 
 Reconciles this run's transient **Observations** into the durable **Finding**
 set: it gives Findings stable identity across non-deterministic grading runs and

--- a/openapi/newton-backend-parity.yaml
+++ b/openapi/newton-backend-parity.yaml
@@ -647,6 +647,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+  /findings/{id}/unblock:
+    post:
+      tags:
+      - findings
+      operationId: unblock_finding
+      parameters:
+      - name: id
+        in: path
+        description: Finding id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Unblocked finding
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindingItem'
+        '404':
+          description: Finding not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Finding is not blocked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /grades:
     get:
       tags:
@@ -1272,6 +1309,115 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OperatorDescriptor'
+  /optimize-runs:
+    get:
+      tags:
+      - optimize
+      operationId: list_optimize_runs
+      responses:
+        '200':
+          description: List of optimize runs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OptimizeRunItem'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /optimize-runs/{id}:
+    get:
+      tags:
+      - optimize
+      operationId: get_optimize_run
+      parameters:
+      - name: id
+        in: path
+        description: Optimize run id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Optimize run detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeRunDetail'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /optimize-runs/{id}/cycles:
+    get:
+      tags:
+      - optimize
+      operationId: list_optimize_cycles
+      parameters:
+      - name: id
+        in: path
+        description: Optimize run id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Cycles for run
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OptimizeCycleItem'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+  /optimize-runs/{id}/trajectory:
+    get:
+      tags:
+      - optimize
+      operationId: get_optimize_run_trajectory
+      parameters:
+      - name: id
+        in: path
+        description: Optimize run id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Run detail with cycles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeRunTrajectory'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
   /pending-approvals:
     get:
       tags:
@@ -2385,6 +2531,7 @@ components:
       - origin
       - status
       - findingIds
+      - risk
       - createdAt
       - updatedAt
       properties:
@@ -2400,6 +2547,11 @@ components:
           type:
           - string
           - 'null'
+        confidence:
+          type:
+          - number
+          - 'null'
+          format: double
         createdAt:
           type: string
         findingIds:
@@ -2414,6 +2566,8 @@ components:
           type:
           - string
           - 'null'
+        risk:
+          type: string
         status:
           type: string
         title:
@@ -2489,6 +2643,11 @@ components:
           type:
           - string
           - 'null'
+        confidence:
+          type:
+          - number
+          - 'null'
+          format: double
         findingIds:
           type: array
           items:
@@ -2501,6 +2660,8 @@ components:
           type:
           - string
           - 'null'
+        risk:
+          type: string
         title:
           type: string
     CreateComponentBody:
@@ -2926,6 +3087,23 @@ components:
       - createdAt
       - updatedAt
       properties:
+        blockedByPlanId:
+          type:
+          - string
+          - 'null'
+        blockedChangeRequestId:
+          type:
+          - string
+          - 'null'
+        blockedLastError:
+          type:
+          - string
+          - 'null'
+        blockedPlanAttempts:
+          type:
+          - integer
+          - 'null'
+          format: int64
         blocks:
           type: array
           items:
@@ -3295,6 +3473,122 @@ components:
           - string
           - 'null'
         params_schema: {}
+    OptimizeCycleItem:
+      type: object
+      required:
+      - id
+      - runId
+      - cycle
+      - grades
+      - decision
+      - openFindings
+      - resolvedThisCycle
+      - createdAt
+      properties:
+        changeRequestId:
+          type:
+          - string
+          - 'null'
+        createdAt:
+          type: string
+        cycle:
+          type: integer
+          format: int64
+        decision:
+          type: string
+        developStatus:
+          type:
+          - string
+          - 'null'
+        executionId:
+          type:
+          - string
+          - 'null'
+        gradeMin:
+          type:
+          - number
+          - 'null'
+          format: double
+        grades: {}
+        id:
+          type: string
+        openFindings:
+          type: integer
+          format: int64
+        planId:
+          type:
+          - string
+          - 'null'
+        resolvedThisCycle:
+          type: integer
+          format: int64
+        runId:
+          type: string
+    OptimizeRunDetail:
+      allOf:
+      - $ref: '#/components/schemas/OptimizeRunItem'
+      - type: object
+        properties:
+          outcomeReason: {}
+    OptimizeRunItem:
+      type: object
+      required:
+      - id
+      - projectId
+      - scope
+      - scopeId
+      - status
+      - cycle
+      - maxCycles
+      - graders
+      - latestGrades
+      - openFindings
+      - blockedFindings
+      - startedAt
+      - updatedAt
+      properties:
+        blockedFindings:
+          type: integer
+          format: int64
+        cycle:
+          type: integer
+          format: int64
+        graders:
+          type: array
+          items:
+            type: string
+        id:
+          type: string
+        latestGrades: {}
+        maxCycles:
+          type: integer
+          format: int64
+        openFindings:
+          type: integer
+          format: int64
+        projectId:
+          type: string
+        scope:
+          type: string
+        scopeId:
+          type: string
+        startedAt:
+          type: string
+        status:
+          type: string
+        updatedAt:
+          type: string
+    OptimizeRunTrajectory:
+      allOf:
+      - $ref: '#/components/schemas/OptimizeRunDetail'
+      - type: object
+        required:
+        - cycles
+        properties:
+          cycles:
+            type: array
+            items:
+              $ref: '#/components/schemas/OptimizeCycleItem'
     PatchChangeRequestBody:
       type: object
       properties:
@@ -3341,6 +3635,10 @@ components:
     PatchFindingBody:
       type: object
       properties:
+        blockedByPlanId:
+          type:
+          - string
+          - 'null'
         effort:
           type:
           - string
@@ -3517,10 +3815,18 @@ components:
       - confidence
       - risk
       - agentGenerated
+      - attempts
       - createdAt
       properties:
         agentGenerated:
           type: boolean
+        attempts:
+          type: integer
+          format: int64
+        body:
+          type:
+          - string
+          - 'null'
         component:
           type: string
         confidence:
@@ -3528,6 +3834,10 @@ components:
           format: int64
         createdAt:
           type: string
+        executionId:
+          type:
+          - string
+          - 'null'
         executionIds:
           type: array
           items:
@@ -3538,7 +3848,15 @@ components:
           - 'null'
         id:
           type: string
+        lastError:
+          type:
+          - string
+          - 'null'
         linkedChangeRequestId:
+          type:
+          - string
+          - 'null'
+        module:
           type:
           - string
           - 'null'
@@ -3959,6 +4277,8 @@ tags:
   description: Test-only maintenance endpoints
 - name: workflow-files
   description: Workflow definition file CRUD endpoints
+- name: optimize
+  description: Optimization loop run and cycle endpoints
 externalDocs:
   url: ./newton-realtime.asyncapi.yaml
   description: Realtime (WebSocket + SSE) contract — AsyncAPI 3.0

--- a/skill/newton/SKILL.md
+++ b/skill/newton/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: newton
-description: Newton CLI for workflow YAML graphs (operators, checkpoints, goal gates), batch plan queues, ailoop human-in-the-loop via HumanApprovalOperator/HumanDecisionOperator, and HTTP APIs via serve. Use when running or resuming workflows, validating or linting workflow files, managing checkpoints or artifacts, configuring .newton/configs, or using `workflow validate`, `workflow lint`, `workflow preview`, `workflow graph`, `workflow resume`, `workflow runs`, `workflow checkpoint`, `workflow artifact`, webhook, or batch.
+description: Newton CLI for workflow YAML graphs (operators, checkpoints, goal gates), the autonomous optimization loop (grade → reconcile → change-request → plan → develop → re-grade) over the Finding → Change Request → Plan → Execution spine with Graders/Assessments, ailoop human-in-the-loop via HumanApprovalOperator/HumanDecisionOperator, and HTTP APIs via serve. Use when running or resuming workflows, driving or observing the optimization loop, validating or linting workflow files, managing checkpoints or artifacts, configuring .newton/configs, or using `optimize`, `workflow validate`, `workflow lint`, `workflow preview`, `workflow graph`, `workflow resume`, `workflow runs`, `workflow checkpoint`, `workflow artifact`.
 license: Apache-2.0
 compatibility: Requires the newton binary on PATH. newton init requires aikit on PATH for templates.
 ---
 
 # Newton
 
-Newton is a **workflow-first** CLI: YAML workflow graphs with operators, checkpoints, artifacts, and goal gates. Classic evaluator, advisor, and executor-only loops are expressed inside workflows now, not as separate top-level commands. **Sub-workflows** are supported: a task can invoke another workflow file with `WorkflowOperator` (`workflow_path`, optional `context` and `triggers` merges), subject to workspace path rules and a maximum nesting depth.
+Newton is a **workflow-first** CLI **and an autonomous optimizer**: it runs YAML workflow graphs (operators, checkpoints, artifacts, goal gates) and drives the **optimization loop** that improves a project toward a **Grade**. **Sub-workflows** are supported: a task can invoke another workflow file with `WorkflowOperator` (`workflow_path`, optional `context` and `triggers` merges), subject to workspace path rules and a maximum nesting depth.
+
+> **Vocabulary changes (pre-1.0):** `batch` was renamed to **`optimize`** (ADR 0003); the `webhook` command and `health` CLI command were **removed** (`webhook` per ADR 0004 — the optimizer is self-driving, no external ingress; `health` folded into `doctor`). The durable work entity `Opportunity` was renamed to **`Finding`** (061). See [Optimization loop](#optimization-loop) and `CONTEXT.md`.
 
 ## When to use
 
-- Running or resuming workflows (including graphs that call nested workflows via `WorkflowOperator`), batch plan queues, or webhook-driven runs.
+- Running or resuming workflows (including graphs that call nested workflows via `WorkflowOperator`).
+- Driving the **optimization loop** for a project (`newton optimize <project>` / the `.newton/scripts/optimize.sh` loop driver) or **observing** it over `serve`.
 - Initializing a workspace (`newton init`) and editing `.newton/configs/*.conf`.
 - Validating or explaining workflow YAML; cleaning checkpoints or artifacts.
-- Operating `newton serve` for HTTP or WebSocket APIs.
-- Creating or upserting opportunity records via `POST /api/v1/opportunities` or `newton data post opportunity`.
-- Ingesting `dk review` findings via `.newton/scripts/ingest-dk-review.sh --with-opportunities`.
+- Operating `newton serve` for HTTP or WebSocket APIs (incl. the optimize-run + grading read endpoints).
+- Working with loop entities — **Finding**, **Change Request**, **Plan**, **Assessment** — via `newton data` or `/api/v1` (e.g. `newton data post finding`, `POST /api/v1/findings/{id}/unblock`).
+- Wiring a **Grader** (`.newton/grader/<name>/generate.sh`) that prints an **Assessment** to stdout for the loop's grade phase.
 
 ## Installation
 
@@ -46,8 +49,10 @@ These subcommands match the current CLI (confirm with `newton --help` on your bu
 | --- | --- |
 | `run` | Execute a workflow graph from YAML |
 | `init` | Create `.newton/` and install the default template |
-| `batch` | Process queued plans under `.newton/plan/<project_id>/` |
-| `serve` | HTTP/WebSocket API for workflow state and streaming |
+| `optimize` | Drive the optimization loop for a project (renamed from `batch`, ADR 0003). The current Rust command drains the **Plan** queue under `.newton/plan/<project_id>/`; the **full closed loop** (grade → reconcile → change-request → plan → develop → re-grade) is driven by `.newton/scripts/optimize.sh` until the in-process driver lands (spec 073) |
+| `serve` | HTTP/WebSocket API for workflow state, streaming, and loop observation |
+| `data` | Catalog CRUD over HTTP-style verbs (`get`/`post`/`patch`/`put`/`delete`) for entities incl. `finding`, `change-request`, `plan`, `optimize-run`, `optimize-cycle`, `eval-run`, `grade` |
+| `doctor` | Environment readiness diagnostics (replaces the removed `health` command) |
 | `workflow validate` | Validate workflow YAML before run |
 | `workflow graph` | Emit Graphviz DOT for the workflow graph (`--format dot --output <PATH>`) |
 | `workflow lint` | Best-practice checks on a workflow file |
@@ -56,7 +61,8 @@ These subcommands match the current CLI (confirm with `newton --help` on your bu
 | `workflow runs` | `list` past runs / `show --run-id <RUN_ID>` task replay |
 | `workflow checkpoint` | `list` / `clean` checkpoint data |
 | `workflow artifact` | `clean` old execution artifacts |
-| `webhook` | `serve` or `status` for webhook-triggered runs (`--workflow <PATH>`) |
+
+> **Removed:** `webhook` (ADR 0004 — no external HTTP ingress; the optimizer is self-driving) and `health` (folded into `doctor`). Don't reference them.
 
 For commands without a dedicated reference file below, use `newton <cmd> --help` as the source of truth for flags and examples.
 
@@ -64,28 +70,68 @@ There is **no** `step`, `status`, `report`, or `error` subcommand in current rel
 
 ## Typical flows
 
-1. **New workspace**: `newton init .` then set `workflow_file` in `.newton/configs/default.conf` when using batch; run workflows with `newton run path/to/workflow.yaml --workspace .`.
-2. **Queue of plans**: Configure `.newton/configs/<project_id>.conf` with `project_root` and `workflow_file`; place plans in `.newton/plan/<project_id>/todo/`; run `newton batch <project_id>`.
+1. **New workspace**: `newton init .` then set `workflow_file` in `.newton/configs/default.conf`; run workflows with `newton workflow run path/to/workflow.yaml --workspace .`.
+2. **Optimization loop**: Configure `.newton/configs/<project_id>.conf` with the `optimize_*` block (repo, test cmd, graders, break-condition thresholds — see [Optimization loop](#optimization-loop)); run the closed loop with `.newton/scripts/optimize.sh <project_id> [--once]`. (The Rust `newton optimize <project_id>` currently drains the Plan queue.)
 3. **Live HIL**: Use `HumanApprovalOperator` or `HumanDecisionOperator` in your workflow YAML to pause for human input via [ailoop](https://github.com/goailoop/ailoop). Interact with ailoop channels using ailoop's own clients.
-4. **API / dashboards**: `newton serve` exposes REST, WebSocket, and SSE endpoints for workflow instances and streams (see `newton serve --help` and the Newton repository `README.md` when updated).
-5. **Opportunity ingest**: `POST /api/v1/opportunities` creates or upserts an opportunity record (idempotent by `id`). The companion script `.newton/scripts/ingest-dk-review.sh -s <scope-id> --with-opportunities` runs `dk review` and POSTs each finding to a live `newton serve` instance. Server URL defaults to `$NEWTON_SERVER_URL` or `http://localhost:8080`; override with `-u <url>`.
+4. **API / dashboards**: `newton serve` exposes REST, WebSocket, and SSE endpoints for workflow instances, streams, and the optimization loop (`/api/v1/optimize-runs`, trajectory, findings) — see `newton serve --help` and the Newton `README.md`.
+5. **Grade a project (Finding ingest)**: Write a **command-Grader** at `.newton/grader/<name>/generate.sh <repo_id> <repo_path>` that runs your analyzer (e.g. `dk review`) and **prints an Assessment JSON to stdout** (it must NOT self-persist). The loop's grade phase runs it via `GraderCommandOperator`, which validates and persists the Assessment; `ReconcileOperator` then turns its Observations into durable **Findings**.
 
 ## Usage notes
 
 - `newton init` requires `aikit` on `PATH` and refuses to run if `.newton` already exists (remove it or pick another directory).
 - `newton run` takes the workflow path as the required first positional argument; the legacy named flag is gone.
 - `--server <URL>` on `newton run` registers the run with a Newton API instance started via `newton serve` for lifecycle notifications.
-- Checkpoint and artifact layouts live under `.newton/` inside the workspace you pass with `--workspace` (or the discovered project root for batch).
+- Checkpoint and artifact layouts live under `.newton/` inside the workspace you pass with `--workspace` (or the discovered project root).
+
+## Optimization loop
+
+Newton's reason to exist is an **autonomous, GitHub-free loop** that improves a project toward a project-defined **Grade**. One pass:
+
+```
+grade ─→ reconcile ─→ change-request ─→ (approve) ─→ plan ─→ develop ─→ merge ─┐
+(Assessment)(Findings)(Change Request)   (HIL/auto)  (HOW)  (tests+commit) local│
+                            │ decision=none + nothing blocked → CONVERGED       │ re-grade
+                            └───────────────────────────────────────────────────┘
+```
+
+**Durable spine (lives in Newton's store, never a board):** `Finding → Change Request → Plan → Execution`.
+
+**Key concepts** (full glossary in `CONTEXT.md`):
+
+- **Grader / Assessment / Score / Observation** — a **Grader** (a command program, e.g. `generate.sh`, or a rubric agent) inspects the repo and emits an **Assessment**: an overall **Grade** (0–100), per-dimension **Scores**, and **Observations** (the text-gradient: problem + why + recommended action).
+- **Reconciliation → Finding** — `ReconcileOperator` matches an Assessment's Observations against open **Findings** (the durable, triageable records); match refreshes, no-match creates, open-with-no-match **resolves**. Identity is Newton's, never the grader's.
+- **Change Request** — the synthesized proposal (`ChangeRequestOperator`) over the standing Findings (the WHAT/WHY). `decision: propose | none`.
+- **Plan** — the enriched implementation spec (the HOW). Status: `draft → ready → running → complete | failed`, plus `abandoned`. Fields: `body`, `executionId`, `attempts`, `lastError`, `module`.
+- **Optimize Run / Cycle / Trajectory** — one loop invocation is an **Optimize Run**; each iteration is a **Cycle**; the per-cycle audit log (grades, decision, plan, develop status) is the **Trajectory**. A Run contains Cycles; each Cycle fires several **Steps** (workflow runs) and one develop **Execution**.
+- **Break conditions (the loop MUST terminate)** — `converged` (decision none for K rounds, zero blocked) · `stalled_on_blocked` · `max_cycles` · per-grader `target` (all clear) · per-grader `regression` (any drops) · `no_progress`.
+- **`blocked` Finding + un-block** — when a Plan fails develop after `optimize_max_failed_attempts`, its Findings are **quarantined** (`blocked`) and a human is escalated to; the loop keeps optimizing the rest. Clear with `POST /api/v1/findings/{id}/unblock`.
+- **Multi-grader** — `optimize_graders` is a space list; Findings pool into one Change Request per cycle; targets/regression are per-grader.
+
+**Drivers:** the **closed loop** runs via `.newton/scripts/optimize.sh <project_id> [--once] [--max-cycles N] [--delivery local|pr] [--auto-approve]` (interim; the in-process `newton optimize` is spec 073). It reads the `optimize_*` block in `.newton/configs/<project_id>.conf` (`optimize_repo_id`, `optimize_repo_path`, `optimize_test_cmd`, `optimize_graders`, `optimize_max_cycles`, `optimize_converge_rounds`, `optimize_target_grade[_<grader>]`, `optimize_regression_tolerance[_<grader>]`, `optimize_max_failed_attempts`, `optimize_auto_approve`, `delivery`).
+
+**Observe over `serve`** (read-only — the loop is self-driving, ADR 0004):
+
+```bash
+GET  /api/v1/optimize-runs                      # list runs (status, cycle, per-grader grades, open/blocked)
+GET  /api/v1/optimize-runs/{id}                 # one run + outcome reason
+GET  /api/v1/optimize-runs/{id}/trajectory      # per-cycle rows
+GET  /api/v1/findings?status=blocked            # blocked findings (inline plan/attempts/lastError/CR)
+POST /api/v1/findings/{id}/unblock              # return a blocked Finding to the actionable pool (409 if not blocked)
+```
+
+See [references/optimize.md](references/optimize.md).
 
 ## Quick reference
 
 ```bash
-newton run workflow.yaml --workspace . --verbose
-newton batch my-project --workspace ~/ws --once
+newton workflow run workflow.yaml --workspace . --verbose
+.newton/scripts/optimize.sh my-project --once          # drive one closed-loop cycle
+newton optimize my-project --workspace ~/ws --once     # Rust command: drain the Plan queue
 newton workflow validate workflow.yaml
 newton workflow lint workflow.yaml
 newton workflow preview workflow.yaml
 newton workflow resume --run-id <uuid> --workspace .
+curl -s localhost:8080/api/v1/optimize-runs            # observe loop runs
 ```
 
 ## MCP agent registration
@@ -222,10 +268,10 @@ A successful bind emits one structured `tracing::info!` event with fields `event
 
 ## References
 
-- [references/configuration.md](references/configuration.md) — `.newton/configs` keys read by Newton (`batch`, `init` stub)
+- [references/configuration.md](references/configuration.md) — `.newton/configs` keys read by Newton (`optimize_*` block, `init` stub)
 - [references/init.md](references/init.md)
 - [references/run.md](references/run.md)
-- [references/batch.md](references/batch.md)
+- [references/optimize.md](references/optimize.md) — the `optimize` command + the closed optimization loop, entities, break conditions, and `serve` endpoints (supersedes the old `batch.md`)
 
 **Canonical skill:** agent instructions for Newton CLI are maintained in [gonewton/skill](https://github.com/gonewton/skill) (`newton/`). Prefer `newton <cmd> --help` when behavior differs by version.
 

--- a/skill/newton/references/batch.md
+++ b/skill/newton/references/batch.md
@@ -1,5 +1,10 @@
 # newton batch
 
+> **DEPRECATED — renamed to `optimize` (ADR 0003).** This file describes the legacy
+> queue-runner behavior, which now lives under `newton optimize`. For the command
+> and the full optimization loop, see **[optimize.md](optimize.md)**. Kept only as a
+> migration aid.
+
 ## Purpose
 
 Headless **queue runner**: for each markdown plan in `.newton/plan/<project_id>/todo/`, copy it into the per-task layout under `project_root/.newton/tasks/<task_id>/` and execute the **configured workflow YAML** the same way as `newton run`, then move the plan to `completed/` or `failed/`.

--- a/skill/newton/references/optimize.md
+++ b/skill/newton/references/optimize.md
@@ -1,0 +1,86 @@
+# newton optimize / the optimization loop
+
+> Supersedes the old `batch.md`. `batch` was renamed to `optimize` (ADR 0003).
+
+## Two drivers
+
+| Driver | What it does today |
+| --- | --- |
+| `newton optimize <project_id>` | Rust command. **Currently drains the Plan queue** under `.newton/plan/<project_id>/todo/` (the renamed `batch`), running the configured workflow per Plan until the queue is empty. |
+| `.newton/scripts/optimize.sh <project_id>` | The **full closed loop** (grade → reconcile → change-request → plan → develop → re-grade) with break conditions — the interim driver until the in-process `newton optimize` lands (spec 073). |
+
+Both read `.newton/configs/<project_id>.conf`.
+
+## `optimize.sh` options
+
+```
+optimize.sh <project_id> [--once] [--max-cycles N] [--converge-rounds K]
+            [--target-grade G] [--delivery local|pr] [--auto-approve]
+```
+
+- `--once` — run a single cycle and exit.
+- `--max-cycles N` — hard cap (default 8).
+- `--converge-rounds K` — consecutive `decision: none` rounds to declare converged (default 2; forced to 1 for a deterministic grader).
+- `--delivery local|pr` — `local` merges to main with `git merge --ff-only` (zero GitHub); `pr` opens a PR.
+- `--auto-approve` — bypass HIL approval gates (loops/tests).
+
+## The loop, one cycle
+
+1. **Grade** — for each configured grader, run `.newton/grader/<name>/generate.sh <repo_id> <repo_path>`, which **prints an Assessment to stdout**. `GraderCommandOperator` validates + persists it. (The script must NOT self-persist.)
+2. **Reconcile** — `ReconcileOperator` matches Observations → durable **Findings** (refresh / create / resolve).
+3. **Change-request** — `ChangeRequestOperator` synthesizes one **Change Request** over the standing Findings (`decision: propose | none`).
+4. **Break check** — evaluate the conditions below against the Trajectory.
+5. **Approve** — auto (`optimize_auto_approve=true`) or an ailoop HIL gate.
+6. **Plan** — `planner.yaml` enriches the approved CR into a durable **Plan** (`status: ready`).
+7. **Develop** — `develop.yaml` renders `Plan.body` → implements → runs `optimize_test_cmd` (gate) → commits → merges (or PR). Success → `Plan: complete`; failure after retries → `Plan: failed`.
+8. **Re-grade** — record the cycle in the **Trajectory** and loop.
+
+## Break conditions
+
+| Condition | Fires when |
+| --- | --- |
+| `converged` *(success)* | `decision: none` for K rounds **and** zero `blocked` Findings |
+| `stalled_on_blocked` *(needs human)* | no actionable work left but ≥1 `blocked` Finding remains |
+| `max_cycles` | cycle count hits `optimize_max_cycles` |
+| `target` | **every** grader clears its own `optimize_target_grade[_<grader>]` (conjunction) |
+| `regressed` | **any** grader drops > its `optimize_regression_tolerance[_<grader>]` vs last cycle (disjunction) |
+| `no_progress` | grade + open-Finding count unchanged for K cycles (failed-develop cycles count) |
+
+## Failed Plans → `blocked` Findings
+
+When a Plan fails develop after `optimize_max_failed_attempts` (default 2), its linked Finding(s) become **`blocked`**: fenced from change-request synthesis (never re-planned), still open, **human-cleared only**. The loop keeps optimizing the rest. A human un-blocks via:
+
+```bash
+curl -X POST localhost:8080/api/v1/findings/<id>/unblock   # 409 if not blocked
+```
+
+## Observe over `serve` (read-only)
+
+```bash
+GET  /api/v1/optimize-runs                 # list runs
+GET  /api/v1/optimize-runs/{id}            # run + outcome reason
+GET  /api/v1/optimize-runs/{id}/trajectory # per-cycle rows
+GET  /api/v1/optimize-runs/{id}/cycles     # cycles
+GET  /api/v1/findings?status=blocked       # blocked findings (inline block context)
+POST /api/v1/findings/{id}/unblock         # un-block a Finding
+```
+
+The HTTP surface is **read-only + unblock** (the loop is self-driving; no HTTP route starts/stops/configures a run — ADR 0004). Run/cycle state is mirrored to the store by the driver via the local CLI (`newton data post optimize-run|optimize-cycle`).
+
+## Configuration (`.newton/configs/<project_id>.conf`)
+
+```sh
+optimize_repo_id="…"                 # Newton Repo UUID = grading scope_id
+optimize_repo_path="/abs/path/repo"  # filesystem path to grade + develop
+optimize_test_cmd="pytest -q"        # develop's run_tests gate
+optimize_graders="maintainability"   # space list; each → .newton/grader/<name>/generate.sh
+optimize_max_cycles=8
+optimize_converge_rounds=2
+optimize_target_grade=85             # + optimize_target_grade_<grader> overrides
+optimize_regression_tolerance=3      # + optimize_regression_tolerance_<grader> overrides
+optimize_max_failed_attempts=2       # same-CR develop failures → Findings blocked
+optimize_auto_approve=true           # false → ailoop approval gate
+delivery="local"                     # local | pr
+```
+
+See `CONTEXT.md` for the full glossary (Optimize Run, Cycle, Trajectory, Grader, Assessment, Finding, Change Request, Plan, Reconciliation).

--- a/tests/fixtures/graders/seed-grader.sh
+++ b/tests/fixtures/graders/seed-grader.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Deterministic structural grader for the widgets-cli fixture.
+# Contract: print a Newton Assessment JSON to stdout; do NOT self-persist.
+# Usage: seed-grader.sh <scope_id> <repo_path>
+set -euo pipefail
+
+SCOPE_ID="${1:-}"
+REPO_PATH="${2:-.}"
+
+if [ -z "$SCOPE_ID" ] || [ -z "$REPO_PATH" ]; then
+  echo "Usage: seed-grader.sh <scope_id> <repo_path>" >&2
+  exit 1
+fi
+
+INVENTORY="${REPO_PATH}/src/widgets/inventory.py"
+FORMATTING="${REPO_PATH}/src/widgets/formatting.py"
+REPORT="${REPO_PATH}/src/widgets/report.py"
+CLI="${REPO_PATH}/src/widgets/cli.py"
+
+# ── Detect issues ────────────────────────────────────────────────────────────
+issue_a=false  # god-function: process() line count > 60
+issue_b=false  # duplicate print_table in both formatting.py and report.py
+issue_c=false  # dead stub validate_unused
+issue_d=false  # substring dispatch cmd.find(
+
+if [ -f "$INVENTORY" ]; then
+  # Issue A: count non-blank lines inside the process() function body
+  process_lines=$(python3 - "$INVENTORY" <<'PY'
+import sys, re
+path = sys.argv[1]
+with open(path) as f:
+    lines = f.readlines()
+in_process = False
+count = 0
+indent_level = None
+for line in lines:
+    stripped = line.rstrip()
+    if re.match(r'^def process\(', stripped):
+        in_process = True
+        count = 0
+        continue
+    if in_process:
+        if stripped == '' or stripped.startswith('#'):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent_level is None and indent > 0:
+            indent_level = indent
+        if indent_level is not None and indent < indent_level and stripped.startswith('def '):
+            break
+        count += 1
+print(count)
+PY
+  )
+  if [ "$process_lines" -gt 40 ]; then
+    issue_a=true
+  fi
+
+  # Issue C: dead stub validate_unused
+  if grep -q "^def validate_unused" "$INVENTORY" 2>/dev/null; then
+    issue_c=true
+  fi
+fi
+
+# Issue B: duplicate print_table
+if [ -f "$FORMATTING" ] && [ -f "$REPORT" ]; then
+  fmt_has=$(grep -c "^def print_table" "$FORMATTING" 2>/dev/null || echo 0)
+  rpt_has=$(grep -c "^def print_table" "$REPORT" 2>/dev/null || echo 0)
+  if [ "$fmt_has" -gt 0 ] && [ "$rpt_has" -gt 0 ]; then
+    issue_b=true
+  fi
+fi
+
+# Issue D: substring dispatch
+if [ -f "$CLI" ]; then
+  if grep -q 'cmd\.find(' "$CLI" 2>/dev/null; then
+    issue_d=true
+  fi
+fi
+
+# ── Score computation ────────────────────────────────────────────────────────
+PENALTY=0
+[ "$issue_a" = "true" ] && PENALTY=$((PENALTY + 12))
+[ "$issue_b" = "true" ] && PENALTY=$((PENALTY + 10))
+[ "$issue_c" = "true" ] && PENALTY=$((PENALTY + 8))
+[ "$issue_d" = "true" ] && PENALTY=$((PENALTY + 10))
+SCORE=$((100 - PENALTY))
+
+# ── Build Assessment JSON ────────────────────────────────────────────────────
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+GRADER_ID="seed-grader"
+RUN_ID=$(python3 -c "import uuid; print(str(uuid.uuid4()))")
+
+build_observation() {
+  local id="$1" dimension="$2" title="$3" action="$4" severity="$5" location="$6"
+  printf '{"id":"%s","dimension":"%s","title":"%s","why_it_matters":"Reduces maintainability.","recommended_action":"%s","severity":"%s","confidence":0.95,"location":%s}' \
+    "$id" "$dimension" "$title" "$action" "$severity" "$location"
+}
+
+OBSERVATIONS="["
+SEP=""
+
+[ "$issue_a" = "true" ] && {
+  OBSERVATIONS="${OBSERVATIONS}${SEP}$(build_observation "obs-a" "file_decomposition" \
+    "process() is a god-function mixing validation, state, and hooks" \
+    "Split into focused helpers: _validate_add, _do_add, _validate_remove, _do_remove" \
+    "high" '{"file":"src/widgets/inventory.py","function":"process"}')"
+  SEP=","
+}
+
+[ "$issue_b" = "true" ] && {
+  OBSERVATIONS="${OBSERVATIONS}${SEP}$(build_observation "obs-b" "canonical_placement" \
+    "print_table duplicated verbatim in formatting.py and report.py" \
+    "Remove print_table from report.py; import from formatting.py (canonical location)" \
+    "medium" '{"file":"src/widgets/report.py","function":"print_table"}')"
+  SEP=","
+}
+
+[ "$issue_c" = "true" ] && {
+  OBSERVATIONS="${OBSERVATIONS}${SEP}$(build_observation "obs-c" "abstraction_economy" \
+    "validate_unused() is a dead stub never called anywhere" \
+    "Delete validate_unused from inventory.py" \
+    "low" '{"file":"src/widgets/inventory.py","function":"validate_unused"}')"
+  SEP=","
+}
+
+[ "$issue_d" = "true" ] && {
+  OBSERVATIONS="${OBSERVATIONS}${SEP}$(build_observation "obs-d" "branching_discipline" \
+    "Command dispatch uses substring matching (cmd.find) instead of exact-match dict" \
+    "Replace if/elif cmd.find chain with a dict-based dispatch table" \
+    "medium" '{"file":"src/widgets/cli.py","function":"main"}')"
+  SEP=","
+}
+
+OBSERVATIONS="${OBSERVATIONS}]"
+
+# Per-dimension scores
+DIM_SCORES="["
+DIM_SEP=""
+for dim in file_decomposition canonical_placement abstraction_economy branching_discipline; do
+  penalty=0
+  case "$dim" in
+    file_decomposition)  [ "$issue_a" = "true" ] && penalty=12 ;;
+    canonical_placement) [ "$issue_b" = "true" ] && penalty=10 ;;
+    abstraction_economy) [ "$issue_c" = "true" ] && penalty=8  ;;
+    branching_discipline)[ "$issue_d" = "true" ] && penalty=10 ;;
+  esac
+  dim_score=$((100 - penalty))
+  DIM_SCORES="${DIM_SCORES}${DIM_SEP}{\"dimension\":\"${dim}\",\"score\":${dim_score}}"
+  DIM_SEP=","
+done
+DIM_SCORES="${DIM_SCORES}]"
+
+python3 - <<PYEOF
+import json, sys
+assessment = {
+    "id": "$RUN_ID",
+    "source": "$GRADER_ID",
+    "scope": "repo",
+    "scope_id": "$SCOPE_ID",
+    "grader": "$GRADER_ID",
+    "overall_score": $SCORE,
+    "evaluated_at": "$NOW",
+    "observations": $OBSERVATIONS,
+    "dimension_scores": $DIM_SCORES,
+    "summary": f"widgets-cli maintainability score: {$SCORE}/100"
+}
+print(json.dumps(assessment, indent=2))
+PYEOF

--- a/tests/fixtures/repos/widgets-cli.patches/abstraction_economy.patch
+++ b/tests/fixtures/repos/widgets-cli.patches/abstraction_economy.patch
@@ -1,0 +1,12 @@
+diff --git a/src/widgets/inventory.py b/src/widgets/inventory.py
+index f2a8f0a..28b8a74 100644
+--- a/src/widgets/inventory.py
++++ b/src/widgets/inventory.py
+@@ -89,7 +89,3 @@ def _update_index(name: str) -> None:
+ def _update_index_remove(name: str) -> None:
+     pass  # stub: would remove from search index
+ 
+-
+-def validate_unused(name: str) -> bool:
+-    # ISSUE C: dead stub — abstraction_economy; never called
+-    return bool(name)

--- a/tests/fixtures/repos/widgets-cli.patches/branching_discipline.patch
+++ b/tests/fixtures/repos/widgets-cli.patches/branching_discipline.patch
@@ -1,0 +1,44 @@
+--- a/src/widgets/cli.py
++++ b/src/widgets/cli.py
+@@ -2,6 +2,15 @@
+ import sys
+ from widgets.inventory import process
+ from widgets.formatting import print_table
++from widgets.report import print_table as report_table
++
++
++_DISPATCH = {
++    "add": lambda args: process(("add", args[0] if args else "")),
++    "remove": lambda args: process(("remove", args[0] if args else "")),
++    "list": lambda args: print_table(process(("list",))),
++    "report": lambda args: report_table(process(("list",))),
++}
+
+
+ def main() -> None:
+@@ -11,21 +20,11 @@
+         sys.exit(1)
+
+     cmd = args[0]
++    rest = args[1:]
+
+-    # ISSUE D: substring-match dispatch — branching_discipline
+-    if cmd.find("add") != -1:
+-        name = args[1] if len(args) > 1 else ""
+-        process(("add", name))
+-    elif cmd.find("remove") != -1:
+-        name = args[1] if len(args) > 1 else ""
+-        process(("remove", name))
+-    elif cmd.find("list") != -1:
+-        items = process(("list",))
+-        print_table(items)
+-    elif cmd.find("report") != -1:
+-        items = process(("list",))
+-        from widgets.report import print_table as report_table
+-        report_table(items)
++    handler = _DISPATCH.get(cmd)
++    if handler is not None:
++        handler(rest)
+     else:
+         print(f"Unknown command: {cmd}")
+         sys.exit(1)

--- a/tests/fixtures/repos/widgets-cli.patches/canonical_placement.patch
+++ b/tests/fixtures/repos/widgets-cli.patches/canonical_placement.patch
@@ -1,0 +1,24 @@
+diff --git a/src/widgets/report.py b/src/widgets/report.py
+index 7c9eb43..3ef88e0 100644
+--- a/src/widgets/report.py
++++ b/src/widgets/report.py
+@@ -1,18 +1,6 @@
+ """Reporting utilities."""
+ from __future__ import annotations
+-
+-
+-# ISSUE B: print_table duplicated verbatim from formatting.py — canonical_placement
+-def print_table(items: list[str]) -> None:
+-    """Print items as a simple ASCII table."""
+-    if not items:
+-        print("(empty)")
+-        return
+-    width = max(len(i) for i in items) + 2
+-    print("+" + "-" * width + "+")
+-    for item in items:
+-        print("| " + item.ljust(width - 2) + " |")
+-    print("+" + "-" * width + "+")
++from widgets.formatting import print_table
+ 
+ 
+ def report_summary(items: list[str]) -> str:

--- a/tests/fixtures/repos/widgets-cli.patches/file_decomposition.patch
+++ b/tests/fixtures/repos/widgets-cli.patches/file_decomposition.patch
@@ -1,0 +1,109 @@
+diff --git a/src/widgets/inventory.py b/src/widgets/inventory.py
+index f2a8f0a..1c5a738 100644
+--- a/src/widgets/inventory.py
++++ b/src/widgets/inventory.py
+@@ -1,54 +1,23 @@
+-"""Inventory management — ISSUE A: god-function (file_decomposition)."""
++"""Inventory management."""
+ from __future__ import annotations
+ 
+ _STORE: list[str] = []
+ 
+ 
+-# ISSUE A: process() is a ~120-line god-function mixing validation,
+-# state mutation, logging, and error handling — file_decomposition
+ def process(command: tuple) -> list[str]:
+     """Process an inventory command. Returns current item list."""
+     action = command[0] if command else ""
+ 
+     if action == "add":
+         name = command[1] if len(command) > 1 else ""
+-        if not name:
+-            raise ValueError("add requires a name")
+-        # validation block
+-        if len(name) > 64:
+-            raise ValueError("name too long (max 64 chars)")
+-        if not name.replace("-", "").replace("_", "").isalnum():
+-            raise ValueError("name must be alphanumeric (hyphens/underscores allowed)")
+-        if name in _STORE:
+-            raise ValueError(f"item already exists: {name}")
+-        # normalise
+-        name = name.lower().strip()
+-        if name in _STORE:
+-            raise ValueError(f"normalised item already exists: {name}")
+-        # audit log
+-        _log_action("add", name)
+-        # persistence stub
+-        _persist_add(name)
+-        # state mutation
+-        _STORE.append(name)
+-        # post-add hook stubs
+-        _notify_add(name)
+-        _update_index(name)
+-        # return updated list
++        name = _validate_add(name)
++        _do_add(name)
+         return list(_STORE)
+ 
+     elif action == "remove":
+         name = command[1] if len(command) > 1 else ""
+-        if not name:
+-            raise ValueError("remove requires a name")
+-        name = name.lower().strip()
+-        if name not in _STORE:
+-            raise ValueError(f"item not found: {name}")
+-        _log_action("remove", name)
+-        _persist_remove(name)
+-        _STORE.remove(name)
+-        _notify_remove(name)
+-        _update_index_remove(name)
++        name = _validate_remove(name)
++        _do_remove(name)
+         return list(_STORE)
+ 
+     elif action == "list":
+@@ -62,6 +31,44 @@ def process(command: tuple) -> list[str]:
+         raise ValueError(f"unknown action: {action}")
+ 
+ 
++def _validate_add(name: str) -> str:
++    if not name:
++        raise ValueError("add requires a name")
++    if len(name) > 64:
++        raise ValueError("name too long (max 64 chars)")
++    if not name.replace("-", "").replace("_", "").isalnum():
++        raise ValueError("name must be alphanumeric (hyphens/underscores allowed)")
++    name = name.lower().strip()
++    if name in _STORE:
++        raise ValueError(f"item already exists: {name}")
++    return name
++
++
++def _do_add(name: str) -> None:
++    _log_action("add", name)
++    _persist_add(name)
++    _STORE.append(name)
++    _notify_add(name)
++    _update_index(name)
++
++
++def _validate_remove(name: str) -> str:
++    if not name:
++        raise ValueError("remove requires a name")
++    name = name.lower().strip()
++    if name not in _STORE:
++        raise ValueError(f"item not found: {name}")
++    return name
++
++
++def _do_remove(name: str) -> None:
++    _log_action("remove", name)
++    _persist_remove(name)
++    _STORE.remove(name)
++    _notify_remove(name)
++    _update_index_remove(name)
++
++
+ def _log_action(action: str, name: str) -> None:
+     pass  # stub: would write to audit log
+ 

--- a/tests/fixtures/repos/widgets-cli/.gitignore
+++ b/tests/fixtures/repos/widgets-cli/.gitignore
@@ -1,0 +1,6 @@
+# Python build/runtime artifacts generated when the Tier-1 optimize-loop test
+# runs pytest against this fixture — never commit them.
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/tests/fixtures/repos/widgets-cli/SEED.md
+++ b/tests/fixtures/repos/widgets-cli/SEED.md
@@ -1,0 +1,34 @@
+# widgets-cli — Seed Oracle
+
+## Starting state
+
+Four seeded maintainability issues are present in the initial codebase.
+The optimization loop should detect and fix all four, leaving only
+behaviour-neutral refactors with all pytest tests still green.
+
+## Seeded issues
+
+| # | File | Issue | Dimension | Fix |
+|---|------|-------|-----------|-----|
+| A | `src/widgets/inventory.py` | `process()` is a ~90-line god-function mixing validation, persistence stubs, event hooks, and index updates | `file_decomposition` | Split into focused helpers: `_validate_add`, `_do_add`, `_validate_remove`, `_do_remove` |
+| B | `src/widgets/formatting.py` + `src/widgets/report.py` | `print_table()` is copy-pasted verbatim in both files | `canonical_placement` | Extract to `formatting.py` (canonical), import in `report.py` |
+| C | `src/widgets/inventory.py` | `validate_unused()` stub is defined but never called anywhere | `abstraction_economy` | Delete the function |
+| D | `src/widgets/cli.py` | Command dispatch uses `cmd.find("add") != -1` substring matching | `branching_discipline` | Replace with exact-match dict dispatch |
+
+## Grading oracle
+
+Starting score band: 55–65 (all four issues present).
+Convergence target: Grade ≥ 85, zero high/medium open Findings.
+Each issue resolved adds ≈10 points to the overall score.
+
+## Deterministic grader contract
+
+The seed grader (`tests/fixtures/graders/seed-grader.sh`) detects issues
+by structural checks:
+- A: `process()` non-blank line count > 40
+- B: `def print_table` appears in both `formatting.py` AND `report.py`
+- C: `validate_unused` defined in `inventory.py`
+- D: `cmd.find(` appears in `cli.py`
+
+The grader emits a Newton Assessment JSON to stdout.
+Each resolved issue removes its Observation and improves its dimension Score.

--- a/tests/fixtures/repos/widgets-cli/pyproject.toml
+++ b/tests/fixtures/repos/widgets-cli/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "widgets-cli"
+version = "0.1.0"
+requires-python = ">=3.9"
+
+[project.scripts]
+widgets = "widgets.cli:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/fixtures/repos/widgets-cli/src/widgets/cli.py
+++ b/tests/fixtures/repos/widgets-cli/src/widgets/cli.py
@@ -1,0 +1,31 @@
+"""Entry point: parse args and dispatch to widget commands."""
+import sys
+from widgets.inventory import process
+from widgets.formatting import print_table
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: widgets <command> [options]")
+        sys.exit(1)
+
+    cmd = args[0]
+
+    # ISSUE D: substring-match dispatch — branching_discipline
+    if cmd.find("add") != -1:
+        name = args[1] if len(args) > 1 else ""
+        process(("add", name))
+    elif cmd.find("remove") != -1:
+        name = args[1] if len(args) > 1 else ""
+        process(("remove", name))
+    elif cmd.find("list") != -1:
+        items = process(("list",))
+        print_table(items)
+    elif cmd.find("report") != -1:
+        items = process(("list",))
+        from widgets.report import print_table as report_table
+        report_table(items)
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)

--- a/tests/fixtures/repos/widgets-cli/src/widgets/formatting.py
+++ b/tests/fixtures/repos/widgets-cli/src/widgets/formatting.py
@@ -1,0 +1,15 @@
+"""Formatting utilities."""
+from __future__ import annotations
+
+
+# ISSUE B: print_table duplicated verbatim in report.py — canonical_placement
+def print_table(items: list[str]) -> None:
+    """Print items as a simple ASCII table."""
+    if not items:
+        print("(empty)")
+        return
+    width = max(len(i) for i in items) + 2
+    print("+" + "-" * width + "+")
+    for item in items:
+        print("| " + item.ljust(width - 2) + " |")
+    print("+" + "-" * width + "+")

--- a/tests/fixtures/repos/widgets-cli/src/widgets/inventory.py
+++ b/tests/fixtures/repos/widgets-cli/src/widgets/inventory.py
@@ -1,0 +1,95 @@
+"""Inventory management — ISSUE A: god-function (file_decomposition)."""
+from __future__ import annotations
+
+_STORE: list[str] = []
+
+
+# ISSUE A: process() is a ~120-line god-function mixing validation,
+# state mutation, logging, and error handling — file_decomposition
+def process(command: tuple) -> list[str]:
+    """Process an inventory command. Returns current item list."""
+    action = command[0] if command else ""
+
+    if action == "add":
+        name = command[1] if len(command) > 1 else ""
+        if not name:
+            raise ValueError("add requires a name")
+        # validation block
+        if len(name) > 64:
+            raise ValueError("name too long (max 64 chars)")
+        if not name.replace("-", "").replace("_", "").isalnum():
+            raise ValueError("name must be alphanumeric (hyphens/underscores allowed)")
+        if name in _STORE:
+            raise ValueError(f"item already exists: {name}")
+        # normalise
+        name = name.lower().strip()
+        if name in _STORE:
+            raise ValueError(f"normalised item already exists: {name}")
+        # audit log
+        _log_action("add", name)
+        # persistence stub
+        _persist_add(name)
+        # state mutation
+        _STORE.append(name)
+        # post-add hook stubs
+        _notify_add(name)
+        _update_index(name)
+        # return updated list
+        return list(_STORE)
+
+    elif action == "remove":
+        name = command[1] if len(command) > 1 else ""
+        if not name:
+            raise ValueError("remove requires a name")
+        name = name.lower().strip()
+        if name not in _STORE:
+            raise ValueError(f"item not found: {name}")
+        _log_action("remove", name)
+        _persist_remove(name)
+        _STORE.remove(name)
+        _notify_remove(name)
+        _update_index_remove(name)
+        return list(_STORE)
+
+    elif action == "list":
+        return list(_STORE)
+
+    elif action == "clear":
+        _STORE.clear()
+        return []
+
+    else:
+        raise ValueError(f"unknown action: {action}")
+
+
+def _log_action(action: str, name: str) -> None:
+    pass  # stub: would write to audit log
+
+
+def _persist_add(name: str) -> None:
+    pass  # stub: would write to disk
+
+
+def _persist_remove(name: str) -> None:
+    pass  # stub: would delete from disk
+
+
+def _notify_add(name: str) -> None:
+    pass  # stub: would emit event
+
+
+def _notify_remove(name: str) -> None:
+    pass  # stub: would emit event
+
+
+def _update_index(name: str) -> None:
+    pass  # stub: would update search index
+
+
+def _update_index_remove(name: str) -> None:
+    pass  # stub: would remove from search index
+
+
+def validate_unused(name: str) -> bool:
+    # ISSUE C: dead stub — abstraction_economy; never called
+    return bool(name)

--- a/tests/fixtures/repos/widgets-cli/src/widgets/parsing.py
+++ b/tests/fixtures/repos/widgets-cli/src/widgets/parsing.py
@@ -1,0 +1,12 @@
+"""Command parsing helpers — currently unused (dispatch is in cli.py)."""
+from __future__ import annotations
+
+
+KNOWN_COMMANDS = {"add", "remove", "list", "report"}
+
+
+def parse_command(argv: list[str]) -> tuple[str, list[str]]:
+    """Parse argv into (command, remaining_args)."""
+    if not argv:
+        return "", []
+    return argv[0], argv[1:]

--- a/tests/fixtures/repos/widgets-cli/src/widgets/report.py
+++ b/tests/fixtures/repos/widgets-cli/src/widgets/report.py
@@ -1,0 +1,19 @@
+"""Reporting utilities."""
+from __future__ import annotations
+
+
+# ISSUE B: print_table duplicated verbatim from formatting.py — canonical_placement
+def print_table(items: list[str]) -> None:
+    """Print items as a simple ASCII table."""
+    if not items:
+        print("(empty)")
+        return
+    width = max(len(i) for i in items) + 2
+    print("+" + "-" * width + "+")
+    for item in items:
+        print("| " + item.ljust(width - 2) + " |")
+    print("+" + "-" * width + "+")
+
+
+def report_summary(items: list[str]) -> str:
+    return f"Total items: {len(items)}"

--- a/tests/fixtures/repos/widgets-cli/tests/test_cli.py
+++ b/tests/fixtures/repos/widgets-cli/tests/test_cli.py
@@ -1,0 +1,32 @@
+"""CLI smoke tests — behaviour lock."""
+import sys
+import pytest
+from unittest.mock import patch
+from widgets.inventory import _STORE
+from widgets import cli
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+def test_cli_add(capsys):
+    with patch.object(sys, "argv", ["widgets", "add", "foo"]):
+        cli.main()
+
+
+def test_cli_list(capsys):
+    _STORE.append("bar")
+    with patch.object(sys, "argv", ["widgets", "list"]):
+        cli.main()
+    out = capsys.readouterr().out
+    assert "bar" in out
+
+
+def test_cli_unknown_exits():
+    with patch.object(sys, "argv", ["widgets", "xyzzy"]):
+        with pytest.raises(SystemExit):
+            cli.main()

--- a/tests/fixtures/repos/widgets-cli/tests/test_inventory.py
+++ b/tests/fixtures/repos/widgets-cli/tests/test_inventory.py
@@ -1,0 +1,51 @@
+"""Behaviour lock for inventory — must stay green every cycle."""
+import pytest
+from widgets.inventory import process, _STORE
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+def test_add_item():
+    result = process(("add", "widget-a"))
+    assert "widget-a" in result
+
+
+def test_add_duplicate_raises():
+    process(("add", "widget-a"))
+    with pytest.raises(ValueError, match="already exists"):
+        process(("add", "widget-a"))
+
+
+def test_remove_item():
+    process(("add", "widget-b"))
+    result = process(("remove", "widget-b"))
+    assert "widget-b" not in result
+
+
+def test_remove_missing_raises():
+    with pytest.raises(ValueError, match="not found"):
+        process(("remove", "nonexistent"))
+
+
+def test_list_returns_all():
+    process(("add", "x"))
+    process(("add", "y"))
+    items = process(("list",))
+    assert "x" in items
+    assert "y" in items
+
+
+def test_add_validates_name():
+    with pytest.raises(ValueError):
+        process(("add", ""))
+
+
+def test_clear():
+    process(("add", "z"))
+    result = process(("clear",))
+    assert result == []


### PR DESCRIPTION
## Summary

Implements the autonomous, GitHub-free **optimization loop** (backend specs 069/070/071): grade → reconcile → change-request → plan → develop → merge → re-grade, with robust termination, proven by a deterministic CI test.

> Note: the spec drafts (`specs/draft/069–073`) and ADRs (`docs/adr/0011–0013`) are **gitignored by repo convention** (the whole `specs/` and `docs/adr/` trees are ignored, including historical ADRs), so they are not in this diff — they live locally for review. This PR is the **code + glossary + contract**.

## What's included

**069 — Close the loop** (`9e10936`):
- Durable `Plan` spine (`body`/`executionId`/`attempts`/`lastError`/`module`); `Finding` **`blocked`** state; CR `risk`/`confidence` roll-up.
- Board-stripped `grading.yaml`/`planner.yaml`/`develop.yaml`; `optimize.sh` driver; six break conditions incl. **failed-Plan quarantine** → `blocked` / `stalled_on_blocked`; multi-grader gates (per-grader target conjunction, regression disjunction).
- Tier-1 deterministic loop test (`widgets-cli` fixture) — content-coupled (patch-by-dimension), strict oracle asserts, zero-GitHub guard.

**070 — Read API** (`9e10936`): `GET /optimize-runs[/{id}/trajectory|/cycles]`, `POST /findings/{id}/unblock` (409-safe), blocked-context inline on findings, new Plan fields on `/plans`. Read-only over HTTP (ADR 0004); run/cycle state mirrored to the store via the local CLI.

**071 — Hardening** (`57a21b7`): strict Tier-1 asserts + zero-GitHub guard, deterministic `K=1` convergence forcing, `flow.yaml` removed, Plan/Finding status enum enforcement.

**This PR adds**:
- `docs(context)` — `CONTEXT.md` glossary: Optimize Run, Cycle, Trajectory, Plan-queue status machine, `blocked`/`stalled_on_blocked`, fuzzy-optimizer reconciliation, scope hierarchy + hardened Component/Module.
- `fix(openapi)` — regenerate `openapi/newton-backend-parity.yaml` (the 070 endpoints/fields were registered in Rust but the generated contract was never refreshed; caught by the pre-push parity check).
- A `.gitignore` for the `widgets-cli` Tier-1 fixture (pytest artifacts).

## Verification

- ✅ Pre-push hook green: clippy + full test suite + **OpenAPI parity**.
- ✅ End-to-end verified against `newton serve` with seeded data; the newton-ui consumer (gonewton/newton-ui#25, merged) connects same-origin to all 070 endpoints.

## Follow-ups (local specs, not in this PR)

- **072** — port the loop into `newton-template` + ship a real command-grader (`generate.sh` emitting an Assessment to stdout).
- **073** + **ADR 0013** — in-process `newton optimize` driver + Optimize-Run realtime events (supersedes 045); the UI is realtime-ready, polling until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)