### PR TITLE
ci: fix optimize-loop test in CI + finish loop docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
        - name: Build
          run: cargo build --workspace --release
 
+       - name: Set up Python (optimize-loop fixture test)
+         uses: actions/setup-python@v5
+         with:
+           python-version: '3.12'
+
+       - name: Install pytest
+         run: python3 -m pip install pytest
+
        - name: Run tests
          run: cargo test --workspace --all-features
 
@@ -208,6 +216,14 @@ jobs:
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
+
+      - name: Set up Python (optimize-loop fixture test)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: python3 -m pip install pytest
 
       - name: Run workflow-graph coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### feat: close the optimization loop (specs 069/070/071)
+
+Newton now drives an autonomous, GitHub-free **optimization loop**: `grade → reconcile → change-request → plan → develop → merge → re-grade`, over the durable `Finding → Change Request → Plan → Execution` spine in Newton's store (no board).
+
+- **Entities/store**: `Plan` extended (`body`, `executionId`, `attempts`, `lastError`, `module`; status `draft→ready→running→complete|failed`, plus `abandoned`); `Finding` gains a system-set **`blocked`** state; `ChangeRequest` rolls up `risk`/`confidence`. New `OptimizeRun`/`OptimizeCycle` tables (migrations 005/006).
+- **Loop**: board-stripped `grading.yaml`/`planner.yaml`/`develop.yaml`; `.newton/scripts/optimize.sh` driver; six break conditions incl. **failed-Plan quarantine** (`blocked` → `stalled_on_blocked`); multi-grader gates (per-grader target conjunction, regression disjunction); deterministic-grader `K=1` convergence forcing.
+- **Read API (070)**: `GET /api/v1/optimize-runs[/{id}/trajectory|/cycles]`, `POST /api/v1/findings/{id}/unblock` (409-safe), blocked-context inline on findings, new Plan fields on `/plans`. Read-only over HTTP (ADR 0004); run/cycle state mirrored to the store via the local CLI.
+- **Tests**: deterministic Tier-1 loop test on the `widgets-cli` fixture (content-coupled patches, strict oracle asserts, zero-GitHub guard).
+- **Removed**: `flow.yaml` (board flow); the `webhook` and `health` CLI commands (ADR 0004; `health`→`doctor`).
+- **Rename**: `Opportunity` → **`Finding`** (061); `batch` command → **`optimize`** (ADR 0003).
+
+> The earlier `POST /opportunities` ingest below is superseded by the Finding/grading surface above.
+
 ### feat: POST /opportunities — create/upsert opportunity records from external analysis tools (issue #388)
 
 `POST /api/v1/opportunities` accepts a `CreateOpportunityBody` and upserts by `id`, returning the upserted `OpportunityItem` with HTTP 201. Repeated POSTs with the same `id` update all fields except `createdAt` (idempotent ingest). `newton data post opportunity` and `newton data get opportunities` CLI dispatch now works against a local workspace. A companion ingest script `.newton/scripts/ingest-dk-review.sh` supports feeding `dk review --output-format json` findings directly into Newton's opportunity surface.

--- a/architecture.md
+++ b/architecture.md
@@ -135,23 +135,18 @@ Goal gates, terminal tasks, and explicit completion policy produce deterministic
 
 ## Major subsystems
 
-### Batch runner
+### Optimize driver / optimization loop
 
-Implemented primarily in `crates/cli/src/cli/commands/batch.rs` using `newton_core::core::batch_config` and the workflow executor.
+The `optimize` command (renamed from `batch`, ADR 0003; `crates/cli/src/cli/commands/optimize.rs`) drains the **Plan** queue under `.newton/plan/<project_id>/todo/`, running the configured workflow per Plan.
 
-Flow:
+The **full closed loop** — `grade → reconcile → change-request → plan → develop → re-grade` — is driven by `.newton/scripts/optimize.sh` (interim; the in-process `newton optimize` is spec 073). It composes the grading operators and the board-stripped `grading.yaml`/`planner.yaml`/`develop.yaml` workflows, evaluates break conditions over the **Trajectory**, and mirrors `OptimizeRun`/`OptimizeCycle` state into the store via the local CLI.
 
-1. Discover workspace root (walk up to `.newton/`).
-2. Load `.newton/configs/<project_id>.conf` (`project_root`, `workflow_file`).
-3. Poll `.newton/plan/<project_id>/todo/` for plan markdown files.
-4. Copy plan to `.newton/tasks/<task_id>/input/spec.md`.
-5. Run configured workflow with plan path in trigger payload.
-6. Move plan to `completed/` or `failed/`.
+The durable spine — `Finding → Change Request → Plan → Execution` — lives in the store (ADR 0010). Operators: `GraderCommandOperator` (runs a command-Grader, persists its Assessment), `ReconcileOperator` (Observations → Findings), `ChangeRequestOperator` (Findings → Change Request). A failed Plan quarantines its Findings as `blocked` and the loop continues (ADR 0012).
 
 ### HTTP serve API
 
 - **Router**: `crates/core/src/api/mod.rs` — Axum 0.8, mounted at `/api/v1/`.
-- **Modules**: workflows, streaming (SSE/WebSocket), HIL, operators, dashboard, portfolio, opportunities, plans, catalog, persistence, magic tools (aikit-magictool).
+- **Modules**: workflows, streaming (SSE/WebSocket), HIL, operators, dashboard, portfolio, findings, change-requests, plans, optimize-runs (read-only), catalog, persistence, magic tools (aikit-magictool). (`opportunities` is the legacy alias of `findings`.)
 - **OpenAPI**: generated from utoipa annotations; canonical file at [openapi/newton-backend-parity.yaml](openapi/newton-backend-parity.yaml).
 - **Realtime**: [openapi/newton-realtime.asyncapi.yaml](openapi/newton-realtime.asyncapi.yaml).
 - **Static UI**: optional `--static-ui` serves a built frontend via `tower-http` `ServeDir`.


### PR DESCRIPTION
Follow-up to #457 (squash-merged at an earlier commit, so these two changes didn't land in main).

## Why this matters

**main's CI is currently broken.** The Tier-1 optimize-loop test (`test_optimize_loop.rs`) runs `python3 -m pytest` on the `widgets-cli` fixture every cycle, but the **CI and Coverage jobs have no Python/pytest setup** — so pytest is unavailable to the system `python3` and the test fails on cycle 1 with a misleading `pytest failed after applying branching_discipline patch` (really "pytest not importable"). It passes locally only because local `python3` has pytest.

## Changes

- **`ci.yml`**: add `actions/setup-python@v5` (3.12) + `pip install pytest` to the **CI** and **Coverage** jobs before the test/coverage steps.
- **`CHANGELOG.md`**: Unreleased entry for specs 069/070/071 (loop, entities, read API, `Opportunity→Finding`, `batch→optimize`, webhook/health removal); legacy `/opportunities` marked superseded.
- **`architecture.md`**: "Batch runner" → "Optimize driver / optimization loop"; serve modules list `findings`/`change-requests`/`optimize-runs`.

## Verification

Local pre-push hook green (clippy + full test suite + OpenAPI parity). The CI fix is the actual unblock for the `Run tests` / `Coverage` jobs that failed on #457's first (and main's) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)