### PR TITLE
fix: make the optimization loop actually runnable via the CLI

### DIFF
--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -57,6 +57,10 @@ GRADERS="${optimize_graders:-}"
 MAX_FAILED_ATTEMPTS="${optimize_max_failed_attempts:-2}"
 REGRESSION_TOLERANCE="${optimize_regression_tolerance:-3}"
 
+# Operate from the workspace so `newton data` / `newton workflow run` resolve it
+# via cwd discovery (most data calls below do not pass --workspace explicitly).
+cd "${WORKSPACE}" || { echo "workspace not found: ${WORKSPACE}" >&2; exit 1; }
+
 GRADERS_LIST=()
 read -ra GRADERS_LIST <<< "$GRADERS"
 
@@ -70,7 +74,6 @@ TRAJ_DIR="${WORKSPACE}/.newton/optimize/${PROJECT_ID}"
 mkdir -p "$TRAJ_DIR"
 TRAJ="${TRAJ_DIR}/trajectory.jsonl"
 
-newton() { command newton --workspace "$WORKSPACE" "$@"; }
 
 log() { echo "[optimize] $*" >&2; }
 traj_append() { echo "$1" >> "$TRAJ"; }
@@ -136,12 +139,12 @@ PY
 traj_blocked_count() {
   # Count Findings with status=blocked for this repo
   newton data get findings 2>/dev/null \
-    | python3 -c "
+    | REPO_ID="$REPO_ID" python3 -c "
 import sys, json, os
 repo_id = os.environ.get('REPO_ID','')
 data = json.load(sys.stdin)
 blocked = [f for f in data if f.get('status') == 'blocked' and (not repo_id or f.get('repoId') == repo_id)]
-print(len(blocked))" REPO_ID="$REPO_ID" 2>/dev/null || echo 0
+print(len(blocked))" 2>/dev/null || echo 0
 }
 
 traj_prev_grade() {
@@ -190,12 +193,25 @@ run_grading() {
     return
   fi
   local grader_cmd="${grader_script} ${scope_id} ${REPO_PATH}"
-  newton run "${WORKSPACE}/.newton/workflows/grading.yaml" \
-    --arg "grader=${grader}" \
-    --arg "grader_cmd=${grader_cmd}" \
-    --arg "scope=${scope}" \
-    --arg "scope_id=${scope_id}" \
-    2>&1 | tee /dev/stderr | grep -E "^PROPOSED |^CONVERGED" | head -1 || echo "none"
+  # grade → reconcile → change-request. Workflow output is logged to stderr; the
+  # decision + CR id are read from the store, because the terminal echo
+  # ("PROPOSED <id>") uses capture_stdout:false and does not reliably reach the
+  # CLI's stdout.
+  newton workflow run "${WORKSPACE}/.newton/workflows/grading.yaml" \
+    --trigger "grader=${grader}" \
+    --trigger "grader_cmd=${grader_cmd}" \
+    --trigger "scope=${scope}" \
+    --trigger "scope_id=${scope_id}" >&2 || true
+  local cr_id
+  cr_id=$(newton data get change-requests 2>/dev/null \
+    | RID="$scope_id" python3 -c "
+import sys, json, os
+data = json.load(sys.stdin)
+rid = os.environ.get('RID','')
+props = sorted((c for c in data if c.get('repoId') == rid and c.get('status') == 'proposed'),
+               key=lambda c: c.get('createdAt',''))
+print(props[-1]['id'] if props else '')" 2>/dev/null || echo "")
+  if [ -n "$cr_id" ]; then echo "PROPOSED ${cr_id}"; else echo "CONVERGED"; fi
 }
 
 # ── Approve CR ───────────────────────────────────────────────────────────────
@@ -218,18 +234,26 @@ approve_cr() {
 # ── Run planner ──────────────────────────────────────────────────────────────
 run_planner() {
   local cr_id="$1"
-  newton run "${WORKSPACE}/.newton/workflows/planner.yaml" \
-    --arg "change_request_id=${cr_id}" \
-    2>&1 | grep -oE '[0-9a-f-]{36}' | tail -1 || echo ""
+  newton workflow run "${WORKSPACE}/.newton/workflows/planner.yaml" \
+    --trigger "change_request_id=${cr_id}" >&2 || true
+  # Read the Plan the planner wrote for this CR from the store.
+  newton data get plans 2>/dev/null \
+    | CR="$cr_id" python3 -c "
+import sys, json, os
+data = json.load(sys.stdin)
+cr = os.environ.get('CR','')
+plans = sorted((p for p in data if p.get('linkedChangeRequestId') == cr),
+               key=lambda p: p.get('createdAt',''))
+print(plans[-1]['id'] if plans else '')" 2>/dev/null || echo ""
 }
 
 # ── Run develop ──────────────────────────────────────────────────────────────
 run_develop() {
   local plan_id="$1"
-  newton run "${WORKSPACE}/.newton/workflows/develop.yaml" \
-    --arg "plan_id=${plan_id}" \
-    --arg "delivery=${DELIVERY}" \
-    --arg "test_cmd=${TEST_CMD}"
+  newton workflow run "${WORKSPACE}/.newton/workflows/develop.yaml" \
+    --trigger "plan_id=${plan_id}" \
+    --trigger "delivery=${DELIVERY}" \
+    --trigger "test_cmd=${TEST_CMD}"
 }
 
 # ── Break condition helpers ──────────────────────────────────────────────────
@@ -301,7 +325,7 @@ while true; do
 
     # Extract grade from most recent EvalRun
     CURRENT_GRADE=$(newton data get eval-runs --scope repo --scope-id "$REPO_ID" 2>/dev/null \
-      | python3 -c "
+      | GRADER="$grader" python3 -c "
 import sys, json, os
 data = json.load(sys.stdin)
 grader = os.environ.get('GRADER','')
@@ -312,16 +336,16 @@ for r in reversed(data):
         if score is not None:
             print(score)
             sys.exit(0)
-print(0)" GRADER="$grader" 2>/dev/null || echo "0")
+print(0)" 2>/dev/null || echo "0")
 
     OPEN_FINDINGS=$(newton data get findings 2>/dev/null \
-      | python3 -c "
+      | REPO_ID="$REPO_ID" python3 -c "
 import sys, json, os
 data = json.load(sys.stdin)
 repo_id = os.environ.get('REPO_ID','')
 open_s = {'awaiting_triage','triaged','approved_for_planning'}
 open_f = [f for f in data if f.get('repoId') == repo_id and f.get('status') in open_s]
-print(len(open_f))" REPO_ID="$REPO_ID" 2>/dev/null || echo "0")
+print(len(open_f))" 2>/dev/null || echo "0")
 
     # Break: regression guard (per-grader disjunction)
     if ! check_regression "$grader" "$CURRENT_GRADE"; then

--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -56,6 +56,8 @@ GRADERS="${optimize_graders:-}"
 : "${AUTO_APPROVE:=${optimize_auto_approve:-false}}"
 MAX_FAILED_ATTEMPTS="${optimize_max_failed_attempts:-2}"
 REGRESSION_TOLERANCE="${optimize_regression_tolerance:-3}"
+DEVELOP_ENGINE="${optimize_develop_engine:-${develop_primary_engine:-codex}}"
+DEVELOP_MODEL="${optimize_develop_model:-${develop_primary_model:-}}"
 
 # Operate from the workspace so `newton data` / `newton workflow run` resolve it
 # via cwd discovery (most data calls below do not pass --workspace explicitly).
@@ -235,7 +237,10 @@ approve_cr() {
 run_planner() {
   local cr_id="$1"
   newton workflow run "${WORKSPACE}/.newton/workflows/planner.yaml" \
-    --trigger "change_request_id=${cr_id}" >&2 || true
+    --trigger "change_request_id=${cr_id}" \
+    --trigger "workspace=${WORKSPACE}" \
+    --trigger "develop_primary_engine=${DEVELOP_ENGINE}" \
+    --trigger "develop_primary_model=${DEVELOP_MODEL}" >&2 || true
   # Read the Plan the planner wrote for this CR from the store.
   newton data get plans 2>/dev/null \
     | CR="$cr_id" python3 -c "

--- a/.newton/workflows/planner.yaml
+++ b/.newton/workflows/planner.yaml
@@ -1,0 +1,214 @@
+version: "2.0"
+mode: workflow_graph
+
+metadata:
+  name: planner-workflow
+  description: "Change Request → Plan. Reads a CR + its Findings, enriches via planning_enriching.yaml, writes a Plan (status: ready)."
+
+triggers:
+  type: manual
+  schema_version: "1.0"
+  payload:
+    change_request_id: ""
+    workspace: ""
+    develop_primary_engine: ""
+    develop_primary_model: ""
+
+workflow:
+  settings:
+    entry_task: read_cr
+    max_time_seconds: 999999999
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 3
+    max_workflow_iterations: 15
+    default_engine: codex
+    command_operator:
+      allow_shell: true
+
+  context:
+    preamble: |-
+      You are enriching a product/spec document so that requirements are clearly and explicitly defined and implementation-ready. The user provided a spec (path or content below).
+
+      CODEBASE GROUNDING (do this first):
+      Before writing the enriched document, you MUST explore the target codebase (read key files, list directories) to ground every section in the actual project structure. File paths in the "Modified files" table MUST correspond to real files. If the spec references entities (commands, endpoints, modules), enumerate them from the source, not from the user's prose.
+
+      You MUST produce an enriched markdown document that MANDATORILY covers these aspects in this order (use the exact section headers):
+
+      TECHNICAL CONTEXT (sections 1-7):
+      1. **Problem statement** - What is broken or missing today. One paragraph grounded in actual codebase state. MUST include an explicit "out of scope" sentence for related work not in this spec.
+      2. **Goals** - Numbered list of concrete outcomes. Each goal MUST be verifiable.
+      3. **Current behavior** - Table: Component | Role | Mutable at runtime? Plus 1-2 sentences on current build and resume flow. Grounded in code inspection.
+      4. **Design** - The core "how". Subsections for each major mechanism (data structures, concurrency model, API surface, integration points). MUST include: storage types and data structure choices with concrete types, concurrency/locking strategy, invariants, identity/naming conventions, collision and error conditions, tick/lifecycle visibility rules. Include YAML or config examples where applicable.
+      5. **Schema and API** - Exact struct/type definitions and method signatures that implementers will create or modify. Use the project's language (Rust, Python, etc.) for code blocks.
+      6. **Error codes** - Table: Code | Category | Trigger. One row per error the implementation introduces.
+      7. **Acceptance criteria** - Numbered, testable conditions.
+
+      PLANNING (sections 8-14):
+      8. **Functionality comparison (before vs after)**
+      9. **Benefit of implementing this functionality**
+      10. **Stages** - ordered stages with concrete deliverables
+      11. **Breaking changes**
+      12. **Modified files and summary**
+      13. **Dependencies**
+      14. **Proposed folder structure** (new projects only)
+
+      VERIFICATION AND REFERENCE (sections 15-17):
+      15. **Design decisions**
+      16. **Out of scope (explicit)**
+      17. **References**
+
+  tasks:
+    - id: read_cr
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          CR_ID:
+            $expr: 'triggers.change_request_id'
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          set -eo pipefail
+          newton --workspace "${WORKSPACE:-.}" data get change-request "$CR_ID"
+      transitions:
+        - to: build_spec_prompt
+
+    - id: build_spec_prompt
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          CR_JSON:
+            $expr: 'tasks.read_cr.output.stdout'
+          CR_ID:
+            $expr: 'triggers.change_request_id'
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          set -eo pipefail
+          # Write a temporary spec file from the CR body for the enricher
+          SLUG=$(echo "$CR_ID" | cut -c1-8)
+          OUT="tmp/cr-${SLUG}.md"
+          mkdir -p tmp
+          echo "$CR_JSON" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          print('# Change Request: ' + data.get('title', ''))
+          print()
+          print(data.get('body', '(no body)'))
+          " > "$OUT"
+          echo "$OUT"
+      transitions:
+        - to: enrich_spec
+
+    - id: enrich_spec
+      operator: WorkflowOperator
+      params:
+        workflow_path:
+          $expr: 'triggers.workspace + "/.newton/workflows/planning_enriching.yaml"'
+        triggers:
+          prompt:
+            $expr: 'tasks.build_spec_prompt.output.stdout'
+          output_path:
+            $expr: '"tmp/plan-" + triggers.change_request_id + "-enriched.md"'
+        context:
+          preamble:
+            $expr: 'context.preamble'
+          develop_primary_engine:
+            $expr: 'triggers.develop_primary_engine'
+          develop_primary_model:
+            $expr: 'triggers.develop_primary_model'
+      transitions:
+        - to: read_enriched_spec
+
+    - id: read_enriched_spec
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          CR_ID:
+            $expr: 'triggers.change_request_id'
+        cmd: |
+          set -eo pipefail
+          cat "tmp/plan-${CR_ID}-enriched.md"
+      transitions:
+        - to: read_cr_metadata
+
+    - id: read_cr_metadata
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          CR_ID:
+            $expr: 'triggers.change_request_id'
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          set -eo pipefail
+          newton --workspace "${WORKSPACE:-.}" data get change-request "$CR_ID"
+      transitions:
+        - to: write_plan
+
+    - id: write_plan
+      operator: CommandOperator
+      params:
+        shell: true
+        capture_stdout: true
+        env:
+          CR_ID:
+            $expr: 'triggers.change_request_id'
+          ENRICHED_BODY:
+            $expr: 'tasks.read_enriched_spec.output.stdout'
+          CR_JSON:
+            $expr: 'tasks.read_cr_metadata.output.stdout'
+          WORKSPACE:
+            $expr: 'triggers.workspace'
+        cmd: |
+          set -eo pipefail
+          PLAN_ID=$(python3 -c "import uuid; print(str(uuid.uuid4()))")
+
+          # Extract risk/confidence/repoId/componentId from CR
+          RISK=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('risk','medium'))")
+          CONFIDENCE=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('confidence'); print(v if v is not None else 80)")
+          REPO_ID=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('repoId') or '')")
+          COMPONENT_ID=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('componentId') or '')")
+          TITLE=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print('Plan: ' + d.get('title',''))")
+
+          PAYLOAD=$(python3 -c "
+          import sys, json, os
+          d = {
+            'id': os.environ['PLAN_ID'],
+            'title': os.environ['TITLE'],
+            'linkedChangeRequestId': os.environ['CR_ID'],
+            'body': os.environ['ENRICHED_BODY'],
+            'status': 'ready',
+            'risk': os.environ['RISK'],
+            'confidence': int(os.environ['CONFIDENCE']),
+          }
+          repo_id = os.environ.get('REPO_ID','')
+          comp_id = os.environ.get('COMPONENT_ID','')
+          if repo_id: d['repoId'] = repo_id
+          if comp_id: d['componentId'] = comp_id
+          print(json.dumps(d))
+          ")
+
+          echo "$PAYLOAD" | newton --workspace "${WORKSPACE:-.}" data post plan --file -
+          echo "$PLAN_ID"
+      transitions:
+        - to: done
+
+    - id: done
+      operator: CommandOperator
+      params:
+        shell: true
+        cmd: 'echo "Planner completed; plan_id=${PLAN_ID}"'
+        capture_stdout: false
+        env:
+          PLAN_ID:
+            $expr: 'tasks.write_plan.output.stdout'
+      terminal: success

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -50,7 +50,7 @@ fn resolve_workflow_workspace(path: Option<PathBuf>) -> StdResult<PathBuf, AppEr
     }
 }
 
-fn build_operator_registry(
+async fn build_operator_registry(
     workspace: PathBuf,
     settings: &workflow_schema::WorkflowSettings,
     ailoop_ctx: Option<newton_core::integrations::ailoop::AiloopContext>,
@@ -60,16 +60,48 @@ fn build_operator_registry(
         ailoop_ctx,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
+    // Wire the workspace backend store so the grading operators
+    // (GraderCommandOperator, ReconcileOperator, ChangeRequestOperator,
+    // GraderAgentOperator) register — they are only available when a store is
+    // present. Without this, `optimize` / `workflow run` cannot run grading.yaml
+    // (operator 'GraderCommandOperator' is not registered).
+    let backend_store = open_workspace_store(&workspace).await;
     workflow_operators::register_builtins_with_deps(
         &mut builder,
         workspace,
         settings.clone(),
         workflow_operators::BuiltinOperatorDeps {
             interviewer: Some(interviewer),
+            backend_store,
             ..Default::default()
         },
     );
     builder.build()
+}
+
+/// Open the workspace SQLite backend store when it exists, so grading operators
+/// can be registered. Returns None (with a warning) if absent or unopenable —
+/// non-grading workflows still run.
+async fn open_workspace_store(
+    workspace: &Path,
+) -> Option<std::sync::Arc<dyn newton_backend::BackendStore>> {
+    let paths = crate::cli::workspace_paths::WorkspacePaths::new(workspace.to_path_buf());
+    if !paths.backend_sqlite_exists() {
+        return None;
+    }
+    match newton_backend::SqliteBackendStore::new(&paths.backend_sqlite_url()).await {
+        Ok(store) => {
+            Some(std::sync::Arc::new(store) as std::sync::Arc<dyn newton_backend::BackendStore>)
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: could not open backend store at {}: {} — grading operators unavailable",
+                paths.backend_sqlite.display(),
+                e.message
+            );
+            None
+        }
+    }
 }
 
 fn parse_kvp_value(s: &str) -> Value {

--- a/crates/cli/src/cli/commands/optimize.rs
+++ b/crates/cli/src/cli/commands/optimize.rs
@@ -153,7 +153,7 @@ async fn execute_workflow_for_plan(
         newton_core::integrations::ailoop::init_context_for_command_name(&workspace, "optimize")
             .ok()
             .flatten();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx);
+    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx).await;
 
     let previous_state_dir = env::var_os("NEWTON_STATE_DIR");
     env::set_var("NEWTON_STATE_DIR", &task_layout.state_dir);

--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -84,7 +84,7 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     info!("Starting Newton API server on {}: {}", args.host, args.port);
 
     let serve_settings: workflow_schema::WorkflowSettings = Default::default();
-    let registry = super::build_operator_registry(PathBuf::from("."), &serve_settings, None);
+    let registry = super::build_operator_registry(PathBuf::from("."), &serve_settings, None).await;
 
     let operator_names = registry.operator_names();
     let operator_descriptors: Vec<newton_types::OperatorDescriptor> = operator_names

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -101,7 +101,7 @@ async fn execute_run_command(args: &RunArgs) -> StdResult<(), AppError> {
         newton_core::integrations::ailoop::init_context_for_command_name(&workspace, "run")
             .ok()
             .flatten();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx);
+    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx).await;
 
     let summary_result = workflow_executor::execute_workflow(
         document,
@@ -322,7 +322,7 @@ pub async fn resume(args: ResumeArgs) -> StdResult<(), AppError> {
     let execution =
         checkpoint::load_execution_from_base(&state_checkpoints_dir(&state_dir), &args.run_id)?;
     let settings = execution.settings_effective.clone();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, None);
+    let registry = super::build_operator_registry(workspace.clone(), &settings, None).await;
     let summary = workflow_executor::resume_workflow(
         registry,
         workspace.clone(),


### PR DESCRIPTION
## Why

Specs 069/070/071 landed the optimization loop (grade → reconcile → change-request → plan → develop → re-grade) as *implemented*, but it could not actually run end-to-end through the CLI. This PR fixes the three concrete blockers found while driving a real loop on a sample repo.

## What

### 1. Wire the workspace backend store into the operator registry (`e00d14d3`)
The grading operators (`GraderCommandOperator`, `ReconcileOperator`, `ChangeRequestOperator`) only register when a `backend_store` is present (`operators/mod.rs`), but the CLI never opened one — so the loop silently had **no grading operators** and could never grade. `build_operator_registry` is now async and opens the workspace SQLite store (`open_workspace_store`); 4 callers updated to `.await` (optimize/workflow/serve).

### 2. Make `optimize.sh` actually drive the loop (`2c0c9797`)
The bash driver had never been smoke-run:
- `newton run` → `newton workflow run`; `--arg` → `--trigger`.
- Decision/CR-id/plan-id were parsed from workflow stdout, but the terminal echoes use `capture_stdout:false` → read the proposed CR / linked Plan from the store instead.
- Python env vars were passed positionally (`python3 -c "…" VAR=…`) so `os.environ` never saw them → move assignments before `python3`.
- No `cd` into the workspace → `newton data` cwd-discovery hit the wrong workspace.

### 3. Fix the planner trigger contract (`6b8eda0b`)
`planner.yaml` referenced `triggers.workspace` and bare `develop_primary_engine`/`develop_primary_model`, but only `change_request_id` was declared in the triggers payload. Those resolved to **null**, and a `CommandOperator` env value of null fails with *"invalid type: null, expected a string"* — so the planner never ran from the loop.
- `planner.yaml`: declare `workspace`/`develop_primary_engine`/`develop_primary_model`; reference engine/model via `triggers.*`. Now tracked in-repo (`develop.yaml` already was).
- `optimize.sh run_planner`: pass those triggers, resolved from config (`optimize_develop_engine`/`model`, default `codex`).

## Validation
- Deterministic sample loop (widgets-cli) converges 60 → 100 over 5 cycles, running the **real** grade → reconcile → change-request pipeline each cycle; UI ↔ API validated against it.
- `optimize.sh` validated through grade → CR → approve → planner-invocation.
- `planner.yaml` passes `newton workflow validate`; full pre-push suite (clippy + 278 unit tests + OpenAPI parity + docs) green.

## Known limitation
`enrich_spec` and `develop` ultimately invoke **LLM agents** (`planning_enriching.yaml`, the develop engine). This PR unblocks the *real* path; it does not make it token-free or guaranteed. The deterministic demo remains the dependable end-to-end proof. `grading.yaml` / `planning_enriching.yaml` are still untracked under the gitignored `.newton/` — full repo-level reproducibility of the loop would want those added too (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)