### PR TITLE
fix(develop): declare workspace trigger + quote cmd scalar

### DIFF
--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -257,6 +257,7 @@ run_develop() {
   local plan_id="$1"
   newton workflow run "${WORKSPACE}/.newton/workflows/develop.yaml" \
     --trigger "plan_id=${plan_id}" \
+    --trigger "workspace=${WORKSPACE}" \
     --trigger "delivery=${DELIVERY}" \
     --trigger "test_cmd=${TEST_CMD}"
 }

--- a/.newton/workflows/develop.yaml
+++ b/.newton/workflows/develop.yaml
@@ -9,6 +9,7 @@ triggers:
   payload:
     plan_id: ''
     raw_spec_path: ''
+    workspace: ''
     delivery: 'local'
     test_cmd: './scripts/run-tests.sh'
     skip_gh_pr_approve: 'true'
@@ -549,7 +550,7 @@ workflow:
       operator: CommandOperator
       params:
         shell: true
-        cmd: echo "develop: completed plan ${PLAN_ID}"
+        cmd: 'echo "develop: completed plan ${PLAN_ID}"'
         capture_stdout: false
         env:
           PLAN_ID:


### PR DESCRIPTION
## Why

Follow-up to #463. With the planner unblocked, the optimize loop now reaches the **develop** step — which surfaced two latent bugs in `develop.yaml` that had never run before (the loop never got that far).

## What

1. **Undeclared `triggers.workspace`** — `develop.yaml` references `triggers.workspace` in three `CommandOperator` env blocks, but the triggers payload declared only `plan_id`/`raw_spec_path`/`delivery`/`test_cmd`/`skip_gh_pr_approve`. It resolved to **null**, and a `CommandOperator` env value of null fails with *"invalid type: null, expected a string"*. Identical class to the `planner.yaml` fix in #463.
   - `develop.yaml`: declare `workspace` in the triggers payload.
   - `optimize.sh run_develop`: pass `--trigger workspace=${WORKSPACE}`.

2. **Unquoted `cmd` scalar with `: `** — the `success` task's `cmd` was `echo "develop: completed plan ${PLAN_ID}"` as a bare YAML scalar. The `: ` made YAML parse it as a mapping, so the **whole file failed to load** (*"mapping values are not allowed in this context"* at line 553). Quoted it.

## Validation
- `newton workflow validate .newton/workflows/develop.yaml` → **valid** (previously failed to parse).
- `optimize.sh` passes `bash -n`; full pre-commit suite (clippy + unit tests) green.

## Note
These are static, deterministic config fixes (same pattern as #463), found by inspecting the trigger contract — not yet exercised by a live token-spending develop run. The actual LLM-driven `implement_spec` agent behavior is the next thing to validate once these wiring fixes are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)