### PR TITLE
fix(loop): move --workspace after the subcommand in planner/develop workflows

### DIFF
--- a/.newton/workflows/develop.yaml
+++ b/.newton/workflows/develop.yaml
@@ -91,7 +91,7 @@ workflow:
           mkdir -p .newton/plan tmp
           if [ -n "$PLAN_ID" ]; then
             OUT="tmp/plan-${PLAN_ID}.md"
-            newton --workspace "${WORKSPACE:-.}" data get plan "$PLAN_ID" \
+            newton data get plan "$PLAN_ID" --workspace "${WORKSPACE:-.}" \
               | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('body',''))" > "$OUT"
             BRANCH="feature/plan-${PLAN_ID}"
           elif [ -n "$RAW_SPEC" ] && [ -f "$RAW_SPEC" ]; then
@@ -427,7 +427,7 @@ workflow:
           echo "local_merge: merged $BRANCH into main"
           # Update Plan status to complete
           if [ -n "$PLAN_ID" ]; then
-            newton --workspace "${WORKSPACE:-.}" data patch plan "$PLAN_ID" \
+            newton data patch plan "$PLAN_ID" --workspace "${WORKSPACE:-.}" \
               --body '{"status":"complete"}' || true
           fi
       transitions:
@@ -540,7 +540,7 @@ workflow:
             $expr: 'triggers.workspace'
         cmd: |
           if [ -n "$PLAN_ID" ]; then
-            newton --workspace "${WORKSPACE:-.}" data patch plan "$PLAN_ID" \
+            newton data patch plan "$PLAN_ID" --workspace "${WORKSPACE:-.}" \
               --body '{"status":"complete"}' || true
           fi
       transitions:

--- a/.newton/workflows/planner.yaml
+++ b/.newton/workflows/planner.yaml
@@ -71,7 +71,7 @@ workflow:
             $expr: 'triggers.workspace'
         cmd: |
           set -eo pipefail
-          newton --workspace "${WORKSPACE:-.}" data get change-request "$CR_ID"
+          newton data get change-request "$CR_ID" --workspace "${WORKSPACE:-.}"
       transitions:
         - to: build_spec_prompt
 
@@ -150,7 +150,7 @@ workflow:
             $expr: 'triggers.workspace'
         cmd: |
           set -eo pipefail
-          newton --workspace "${WORKSPACE:-.}" data get change-request "$CR_ID"
+          newton data get change-request "$CR_ID" --workspace "${WORKSPACE:-.}"
       transitions:
         - to: write_plan
 
@@ -197,7 +197,7 @@ workflow:
           print(json.dumps(d))
           ")
 
-          echo "$PAYLOAD" | newton --workspace "${WORKSPACE:-.}" data post plan --file -
+          echo "$PAYLOAD" | newton data post plan --file - --workspace "${WORKSPACE:-.}"
           echo "$PLAN_ID"
       transitions:
         - to: done


### PR DESCRIPTION
## Why

Follow-up to #463/#465. With the planner and develop trigger contracts fixed, a live 1-cycle run of the optimize loop reached the **planner** — which immediately failed at `read_cr`:

```
error[E002]: unknown argument
```

`planner.yaml` and `develop.yaml` invoked `newton --workspace X data …` with `--workspace` in the **global** position (before the subcommand). In `newton 0.5.120`, `--workspace` is a **subcommand** flag, so the global position is rejected and the task aborts. This only surfaced now because the loop had never advanced far enough to run these commands.

## What

Move `--workspace` to **after** the subcommand at all 6 call sites:
- `planner.yaml`: `read_cr`, `read_cr_metadata` (`data get change-request`), `write_plan` (`data post plan`).
- `develop.yaml`: `data get plan`, two `data patch plan` sites.

## Validation (live)

Ran the real loop on the widgets-demo workspace with the installed `newton 0.5.120`:
- **Before:** planner `read_cr` → `E002 unknown argument`.
- **After:** `read_cr` / `build_spec_prompt` / `write_plan` run; the loop advances into `enrich_spec`.

The loop now executes every deterministic step end-to-end: grade (60, 4 findings) → reconcile → change-request (auto-approved) → planner → enrichment sub-workflow.

## Known next blocker (separate, not wiring)

The run then stops inside the enrichment agent: codex-cli **0.138.0** emits 4 stream events but aikit_sdk's codex adapter maps **0** of them (`json_lines_unmapped=4`), so the agent's output isn't captured and the enriched spec file is never written. That's an **engine-adapter/version** issue in the agent layer, not a workflow bug — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)