### PR TITLE
chore(engine): bump aikit to engine-interface fixes; defer engine roster to aikit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 [[package]]
 name = "aikit-agent"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit.git?branch=main#8f97c8889127864357bd5e82e07cb6e2a1645602"
+source = "git+https://github.com/goaikit/aikit.git?branch=main#a5eca636651625fbb5ab89d128c1d4884a61fc99"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 name = "aikit-magictool"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit.git?branch=main#8f97c8889127864357bd5e82e07cb6e2a1645602"
+source = "git+https://github.com/goaikit/aikit.git?branch=main#a5eca636651625fbb5ab89d128c1d4884a61fc99"
 dependencies = [
  "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit.git?branch=main)",
  "axum",
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "aikit-sdk"
 version = "0.3.0"
-source = "git+https://github.com/goaikit/aikit.git?branch=main#8f97c8889127864357bd5e82e07cb6e2a1645602"
+source = "git+https://github.com/goaikit/aikit.git?branch=main#a5eca636651625fbb5ab89d128c1d4884a61fc99"
 dependencies = [
  "aikit-agent 0.1.0 (git+https://github.com/goaikit/aikit.git?branch=main)",
  "dirs 6.0.0",

--- a/crates/core/src/workflow/operators/engine/mod.rs
+++ b/crates/core/src/workflow/operators/engine/mod.rs
@@ -112,10 +112,12 @@ impl AikitEngineManager {
         AppError,
     > {
         if !aikit_sdk::is_runnable(engine_name) {
+            // Don't hardcode the engine roster — defer to aikit for the source of truth.
             return Err(AppError::new(
                 ErrorCategory::ValidationError,
                 format!(
-                    "engine '{engine_name}' is not runnable by aikit-sdk; supported: codex, claude, gemini, opencode, agent"
+                    "engine '{engine_name}' is not runnable by aikit-sdk; supported: {}",
+                    aikit_sdk::runnable_agents().join(", ")
                 ),
             )
             .with_code("WFG-SDK-002"));


### PR DESCRIPTION
## Why

Newton should be **agent-agnostic** — the agent run mechanism and per-engine quirks belong in aikit (the single common interface), not scattered through newton. Driving the optimization loop surfaced engine-specific behaviour leaking into newton; this moves it out.

**goaikit/aikit#82 is merged**; this pins aikit back to `main` (which now carries those fixes).

## What

- **Bump `aikit-sdk` / `aikit-magictool` to current `main`** (goaikit/aikit#82), which brings:
  - codex-cli ≥ 0.13x event-schema normalization + **error surfacing** (a failed codex turn is no longer a silent empty "completed" run),
  - empty model string → engine's default (no more `-m ""` failures),
  - opencode `--yolo` in events mode (no more auto-rejected writes).
- **`execute_engine_events`:** drop the temporary empty-model workaround (aikit now owns it), and stop hardcoding the engine roster in the error message — defer to `aikit_sdk::runnable_agents()` as the single source of truth.

## Validation (live)

Re-ran the optimization loop on the widgets-demo workspace with newton built against the merged aikit and **no engine-specific handling left in newton**:
- The demo config sets no model → newton passes it through verbatim → aikit drops the empty model → **codex enriches the spec successfully** (16 KB grounded spec written). Previously this failed with codex `400 "The '' model is not supported"`.
- Pre-commit suite green (clippy + 278 unit tests).

## Follow-up / not in this PR

- Remaining agnosticism nit (separate): three operators still default `engine` to a literal `"claude"` (`change_request_op`/`grader_agent`/`reconcile`). These are config defaults, not run-mechanism knowledge; candidate to source from workflow `settings.default_engine` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)