### PR TITLE
fix(backend): stop wiping Plan.linkedChangeRequestId on every store open

### DIFF
--- a/.newton/scripts/optimize.sh
+++ b/.newton/scripts/optimize.sh
@@ -507,4 +507,17 @@ print(json.dumps({'cycle':int(sys.argv[1]),'latestGrades':json.loads(sys.argv[2]
 done
 
 log "Optimize loop finished. Trajectory: $TRAJ"
-newton data patch optimize-run "$RUN_ID" --body '{"status":"complete"}' > /dev/null 2>&1 || true
+# Map the last recorded stop reason to a canonical OptimizeRun status
+# (running|converged|stalled_on_blocked|max_cycles|regressed|no_progress) instead
+# of an out-of-vocabulary "complete" that downstream consumers (UI) can't render.
+STOP_REASON=$(grep '"event":"stop"' "$TRAJ" 2>/dev/null | tail -1 \
+  | python3 -c "import sys,json; print(json.loads(sys.stdin.readline() or '{}').get('reason',''))" 2>/dev/null || echo "")
+case "$STOP_REASON" in
+  converged|target_grade) FINAL_STATUS="converged" ;;
+  stalled_on_blocked)     FINAL_STATUS="stalled_on_blocked" ;;
+  regression|regressed)   FINAL_STATUS="regressed" ;;
+  no_progress)            FINAL_STATUS="no_progress" ;;
+  *)                      FINAL_STATUS="max_cycles" ;;
+esac
+log "Final status: ${FINAL_STATUS} (stop reason: ${STOP_REASON:-none})"
+newton data patch optimize-run "$RUN_ID" --body "{\"status\":\"${FINAL_STATUS}\"}" > /dev/null 2>&1 || true

--- a/.newton/workflows/planner.yaml
+++ b/.newton/workflows/planner.yaml
@@ -174,11 +174,13 @@ workflow:
 
           # Extract risk/confidence/repoId/componentId from CR
           RISK=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('risk','medium'))")
-          CONFIDENCE=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('confidence'); print(v if v is not None else 80)")
+          CONFIDENCE=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('confidence'); v=80 if v is None else (round(float(v)*100) if float(v)<=1 else round(float(v))); print(int(v))")
           REPO_ID=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('repoId') or '')")
           COMPONENT_ID=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('componentId') or '')")
           TITLE=$(echo "$CR_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print('Plan: ' + d.get('title',''))")
 
+          # Export shell-local vars so the python heredoc below can read them via os.environ
+          export PLAN_ID TITLE RISK CONFIDENCE REPO_ID COMPONENT_ID
           PAYLOAD=$(python3 -c "
           import sys, json, os
           d = {

--- a/crates/backend/migrations/004_grading.sql
+++ b/crates/backend/migrations/004_grading.sql
@@ -55,41 +55,12 @@ CREATE TABLE IF NOT EXISTS ChangeRequest (
 );
 CREATE INDEX IF NOT EXISTS idx_changerequest_status ON ChangeRequest(status);
 
-CREATE TABLE IF NOT EXISTS Plan_new (
-  id TEXT PRIMARY KEY,
-  title TEXT NOT NULL,
-  componentId TEXT NULL,
-  repoId TEXT NULL,
-  status TEXT NOT NULL,
-  linkedChangeRequestId TEXT NULL,
-  confidence INTEGER NOT NULL,
-  risk TEXT NOT NULL,
-  expectedValue TEXT NULL,
-  agentGenerated INTEGER NOT NULL DEFAULT 0,
-  waitingSince TEXT NULL,
-  expectedDelta TEXT NULL,
-  createdAt TEXT NOT NULL,
-  updatedAt TEXT NOT NULL,
-  FOREIGN KEY(componentId) REFERENCES Component(id),
-  FOREIGN KEY(repoId) REFERENCES Repo(id),
-  FOREIGN KEY(linkedChangeRequestId) REFERENCES ChangeRequest(id)
-);
-
-INSERT OR IGNORE INTO Plan_new (
-  id, title, componentId, repoId, status, linkedChangeRequestId,
-  confidence, risk, expectedValue, agentGenerated, waitingSince,
-  expectedDelta, createdAt, updatedAt
-)
-SELECT
-  id, title, componentId, repoId, status, NULL,
-  confidence, risk, expectedValue, agentGenerated, waitingSince,
-  expectedDelta, createdAt, updatedAt
-FROM Plan;
-
-DROP TABLE Plan;
-ALTER TABLE Plan_new RENAME TO Plan;
-
-CREATE INDEX IF NOT EXISTS idx_plan_status ON Plan(status);
-CREATE INDEX IF NOT EXISTS idx_plan_componentId ON Plan(componentId);
+-- NOTE: The legacy Plan rebuild (linkedRequestId -> linkedChangeRequestId,
+-- re-pointing the FK from Request to ChangeRequest) was previously performed
+-- here with an `INSERT ... SELECT ..., NULL, ...` into a Plan_new table. This
+-- file is re-executed on EVERY store open, so that rebuild wiped every plan's
+-- linkedChangeRequestId (and other columns) on each open. The rebuild now lives
+-- in the guarded Rust migration `upgrade_plan_change_request_link`, which only
+-- runs when the legacy `linkedRequestId` column is still present.
 
 PRAGMA foreign_keys = ON;

--- a/crates/backend/src/store/migration.rs
+++ b/crates/backend/src/store/migration.rs
@@ -523,6 +523,111 @@ pub(super) async fn upgrade_finding_blocked_by_plan(pool: &SqlitePool) -> Result
     Ok(())
 }
 
+/// Migrate the legacy Plan schema (`linkedRequestId` -> `Request`) to the
+/// grading-era schema (`linkedChangeRequestId` -> `ChangeRequest`).
+///
+/// This is the one-time rebuild that used to live in `004_grading.sql`. Because
+/// that file is re-run on every store open, performing the rebuild there wiped
+/// every plan's `linkedChangeRequestId` (the `INSERT ... SELECT ..., NULL, ...`)
+/// on each open. Here it is guarded: if the Plan table already has
+/// `linkedChangeRequestId`, this is a no-op, so existing links are preserved.
+pub(super) async fn upgrade_plan_change_request_link(pool: &SqlitePool) -> Result<(), ApiError> {
+    #[derive(Debug, FromRow)]
+    struct ColRow {
+        name: String,
+    }
+
+    let cols: Vec<ColRow> = sqlx::query_as::<_, ColRow>("PRAGMA table_info(Plan)")
+        .fetch_all(pool)
+        .await
+        .map_err(|e| err_internal(&format!("schema check Plan failed: {e}")))?;
+
+    // No Plan table yet, or already migrated: nothing to do (and, crucially,
+    // never rebuild a Plan that already has the column — that is what wiped links).
+    if cols.is_empty() || cols.iter().any(|c| c.name == "linkedChangeRequestId") {
+        return Ok(());
+    }
+
+    let mut conn = pool
+        .acquire()
+        .await
+        .map_err(|e| err_internal(&format!("acquire conn error: {e}")))?;
+
+    sqlx::query("PRAGMA foreign_keys = OFF;")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("pragma error: {e}")))?;
+
+    sqlx::query(
+        "CREATE TABLE Plan_new (\
+          id TEXT PRIMARY KEY,\
+          title TEXT NOT NULL,\
+          componentId TEXT NULL,\
+          repoId TEXT NULL,\
+          status TEXT NOT NULL,\
+          linkedChangeRequestId TEXT NULL,\
+          confidence INTEGER NOT NULL,\
+          risk TEXT NOT NULL,\
+          expectedValue TEXT NULL,\
+          agentGenerated INTEGER NOT NULL DEFAULT 0,\
+          waitingSince TEXT NULL,\
+          expectedDelta TEXT NULL,\
+          createdAt TEXT NOT NULL,\
+          updatedAt TEXT NOT NULL,\
+          FOREIGN KEY(componentId) REFERENCES Component(id),\
+          FOREIGN KEY(repoId) REFERENCES Repo(id),\
+          FOREIGN KEY(linkedChangeRequestId) REFERENCES ChangeRequest(id)\
+        );",
+    )
+    .execute(&mut *conn)
+    .await
+    .map_err(|e| err_internal(&format!("create Plan_new failed: {e}")))?;
+
+    // The legacy link pointed at the (now-dropped) Request table, so it cannot be
+    // carried over; new links are populated going forward by create_plan.
+    sqlx::query(
+        "INSERT OR IGNORE INTO Plan_new \
+          (id, title, componentId, repoId, status, linkedChangeRequestId, \
+           confidence, risk, expectedValue, agentGenerated, waitingSince, \
+           expectedDelta, createdAt, updatedAt) \
+         SELECT \
+          id, title, componentId, repoId, status, NULL, \
+          confidence, risk, expectedValue, agentGenerated, waitingSince, \
+          expectedDelta, createdAt, updatedAt \
+         FROM Plan;",
+    )
+    .execute(&mut *conn)
+    .await
+    .map_err(|e| err_internal(&format!("copy Plan failed: {e}")))?;
+
+    sqlx::query("DROP TABLE Plan;")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("drop Plan failed: {e}")))?;
+
+    sqlx::query("ALTER TABLE Plan_new RENAME TO Plan;")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("rename Plan failed: {e}")))?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_plan_status ON Plan(status);")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("index Plan status failed: {e}")))?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_plan_componentId ON Plan(componentId);")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("index Plan componentId failed: {e}")))?;
+
+    sqlx::query("PRAGMA foreign_keys = ON;")
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| err_internal(&format!("pragma error: {e}")))?;
+
+    Ok(())
+}
+
 pub(super) async fn upgrade_plan_optimize(pool: &SqlitePool) -> Result<(), ApiError> {
     #[derive(Debug, FromRow)]
     struct ColRow {

--- a/crates/backend/src/store/mod.rs
+++ b/crates/backend/src/store/mod.rs
@@ -68,6 +68,10 @@ impl SqliteBackendStore {
         migration::upgrade_legacy_component_schema(&pool).await?;
         migration::upgrade_legacy_repo_schema(&pool).await?;
 
+        // Must run after 004 created ChangeRequest (the new FK target) and before
+        // upgrade_plan_optimize re-adds the optimize-loop columns on the rebuilt table.
+        migration::upgrade_plan_change_request_link(&pool).await?;
+
         migration::upgrade_plan_optimize(&pool).await?;
         migration::upgrade_optimize_run(&pool).await?;
         migration::upgrade_finding_blocked_by_plan(&pool).await?;
@@ -1811,6 +1815,74 @@ mod kpi_create_inline_grade_tests {
             grades.len(),
             0,
             "no grades must be created when grades is None"
+        );
+    }
+}
+
+#[cfg(test)]
+mod plan_link_persistence_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Regression: `004_grading.sql` is re-executed on every store open. It used
+    /// to rebuild the Plan table with `INSERT ... SELECT ..., NULL, ...`, wiping
+    /// every plan's `linkedChangeRequestId` (and body) on each re-open. The
+    /// rebuild is now guarded (`upgrade_plan_change_request_link`), so links must
+    /// survive a re-open.
+    #[tokio::test]
+    async fn plan_link_and_body_survive_store_reopen() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("plan_link.sqlite");
+        let url = format!("sqlite://{}", db_path.display());
+
+        let store = SqliteBackendStore::new(&url).await.unwrap();
+
+        // Seed a ChangeRequest so the Plan FK is satisfiable.
+        let now = "2026-01-01T00:00:00Z";
+        sqlx::query(
+            "INSERT INTO ChangeRequest (id, title, status, findingIds, createdAt, updatedAt) \
+             VALUES (?, ?, 'approved', '[]', ?, ?)",
+        )
+        .bind("cr-1")
+        .bind("CR One")
+        .bind(now)
+        .bind(now)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let created = store
+            .create_plan(CreatePlanBody {
+                id: "plan-1".into(),
+                title: "Plan One".into(),
+                linked_change_request_id: "cr-1".into(),
+                body: Some("enriched body".into()),
+                status: "ready".into(),
+                component_id: None,
+                repo_id: None,
+                module: None,
+                confidence: 80,
+                risk: "low".into(),
+                expected_value: None,
+                expected_delta: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(created.linked_change_request_id.as_deref(), Some("cr-1"));
+        drop(store);
+
+        // Re-open the SAME file: migrations run again.
+        let store2 = SqliteBackendStore::new(&url).await.unwrap();
+        let fetched = store2.get_plan("plan-1").await.unwrap().plan;
+        assert_eq!(
+            fetched.linked_change_request_id.as_deref(),
+            Some("cr-1"),
+            "linkedChangeRequestId must survive a store re-open (regression: 004 rebuild wiped it)"
+        );
+        assert_eq!(
+            fetched.body.as_deref(),
+            Some("enriched body"),
+            "Plan.body must survive a store re-open"
         );
     }
 }


### PR DESCRIPTION
## The bug

The optimize loop never reached `develop`: `run_planner` reported *"planner did not return a plan_id"*. The planner **did** write a Plan with the correct `linkedChangeRequestId`, but the very next `newton` invocation found the link gone, so the CR→Plan correlation (`data get plans` filtered by `linkedChangeRequestId`) matched nothing.

## Root cause

`migrations/004_grading.sql` is **re-executed on every `SqliteBackendStore::new()`** — the `run_migration` helper has no applied-migrations ledger. That file rebuilt the Plan table:

```sql
CREATE TABLE IF NOT EXISTS Plan_new (... linkedChangeRequestId ...);
INSERT OR IGNORE INTO Plan_new (..., linkedChangeRequestId, ...)
  SELECT ..., NULL, ... FROM Plan;     -- ← hardcoded NULL
DROP TABLE Plan;
ALTER TABLE Plan_new RENAME TO Plan;
```

This was a correct **one-time** migration of the legacy `linkedRequestId`→`Request` schema to `linkedChangeRequestId`→`ChangeRequest` (the data couldn't carry across the FK retarget, so `NULL` was right *once*). But because it runs on **every store open**, it wiped every plan's `linkedChangeRequestId` — and `body`, `attempts`, etc. — each time the store was opened.

That's why the write looked correct (the create response, read in the same process, showed the link) but the next CLI invocation re-opened the store and nulled it.

## Diagnosis trail

- Reproduced `data post plan` → link in raw DB → run `newton data get plans` (read-only) → **link flips to `NULL`**. A read nulled the column ⇒ migration-on-open.
- Isolated to `004_grading.sql:84` (`SELECT ..., NULL, ...`) running unconditionally.

## Fix

Move the rebuild out of the always-run SQL into a **guarded** Rust migration `upgrade_plan_change_request_link`, which only rebuilds when the legacy `linkedRequestId` column is still present (i.e. `linkedChangeRequestId` is absent). Already-migrated stores → **no-op**, so links are preserved on every subsequent open.

- `004_grading.sql`: destructive Plan rebuild removed (ChangeRequest/Finding creation kept).
- `migration.rs`: guarded `upgrade_plan_change_request_link` (same rebuild, runs once).
- `mod.rs`: wired in `new()` between the 004 run and `upgrade_plan_optimize`.

## Tests

- **`plan_link_and_body_survive_store_reopen`** (new): create a Plan with a link + body, drop the store, re-open, assert link **and** body survive. Fails on the old code, passes now.
- Backend suite green (32), optimize-loop integration test green.
- Verified end-to-end against the demo store: link survives repeated opens, and `run_planner`'s correlation now resolves the plan id.

## Also included (loop driver, track-A)

These unblocked `write_plan` producing a valid payload in the first place:
- `planner.yaml`: `write_plan` `export`s shell vars for the python heredoc (was `KeyError`), and coerces CR `confidence` (0–1 float) → int percent (was `ValueError`).
- `optimize.sh`: derives a canonical `OptimizeRun` final status from the trajectory stop reason (`converged`/`stalled_on_blocked`/`regressed`/`no_progress`/`max_cycles`) instead of the out-of-vocabulary `"complete"`.

## Deploy note

The loop runs the installed `newton` from `PATH`; the fix takes effect once a release carrying it is installed (the bug is in the migration, so any `newton` without this fix still nulls links on open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)