### PR TITLE
ci(web): add embedded-UI vendor drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,63 @@ jobs:
             fi
           done
 
+  web-ui-vendor-drift:
+    name: Web UI vendor drift
+    runs-on: ubuntu-latest
+    # The embedded UI bundle (crates/core/assets/web/index.html.gz) is vendored
+    # from the SEPARATE, PRIVATE gonewton/newton-ui repo via scripts/vendor-web.sh.
+    # This job rebuilds the UI and fails if the committed bundle is stale. Because
+    # newton-ui is private, it only runs when a read-only PAT is configured as the
+    # NEWTON_UI_RO_TOKEN secret; otherwise it is a no-op (forks / unconfigured
+    # repos stay green). The vite build is deterministic, so the exact-content
+    # comparison is not flaky as long as this job's pinned node/pnpm match the
+    # versions used when vendoring.
+    steps:
+      - name: Checkout newton
+        uses: actions/checkout@v4
+
+      - name: Detect newton-ui token
+        id: tok
+        env:
+          NEWTON_UI_RO_TOKEN: ${{ secrets.NEWTON_UI_RO_TOKEN }}
+        run: |
+          if [ -n "$NEWTON_UI_RO_TOKEN" ]; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::NEWTON_UI_RO_TOKEN not set; skipping embedded-UI drift check."
+          fi
+
+      - name: Checkout newton-ui
+        if: steps.tok.outputs.has == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: gonewton/newton-ui
+          token: ${{ secrets.NEWTON_UI_RO_TOKEN }}
+          path: newton-ui
+
+      - name: Set up pnpm
+        if: steps.tok.outputs.has == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.21.0"
+
+      - name: Set up Node.js
+        if: steps.tok.outputs.has == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: newton-ui/pnpm-lock.yaml
+
+      - name: Install newton-ui dependencies
+        if: steps.tok.outputs.has == 'true'
+        run: cd newton-ui && pnpm install --frozen-lockfile
+
+      - name: Verify embedded UI bundle is up to date
+        if: steps.tok.outputs.has == 'true'
+        run: scripts/vendor-web.sh --check ./newton-ui
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/scripts/vendor-web.sh
+++ b/scripts/vendor-web.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regenerate the embedded Newton UI bundle served by `newton serve`.
+# Regenerate (or verify) the embedded Newton UI bundle served by `newton serve`.
 #
 # The UI lives in a SEPARATE repo (gonewton/newton-ui). Its production build is a
 # single self-contained `index.html` (vite-plugin-singlefile inlines all JS/CSS).
@@ -7,21 +7,39 @@
 # crates/core/src/api/mod.rs, so a single `newton` binary serves the whole UI with
 # no runtime dependency on the UI repo.
 #
-# Run this whenever the UI changes. CI does not rebuild it automatically.
+# Run this whenever the UI changes. CI does not rebuild it automatically (the UI
+# repo is private); the `--check` mode below is wired into CI behind a token so
+# drift is caught when the secret is configured. The vite build is deterministic,
+# so `--check` compares the freshly built HTML against the committed bundle and
+# is not flaky.
 #
 # Usage:
-#   scripts/vendor-web.sh [path-to-newton-ui]
+#   scripts/vendor-web.sh [--check] [path-to-newton-ui]
 #
-# Defaults to ../newton-ui relative to this repo root.
+#   (default)  Build the UI and (re)write the vendored gzip bundle.
+#   --check    Build the UI and FAIL if the committed bundle is stale, without
+#              modifying it. Intended for CI and pre-PR verification.
+#
+# newton-ui path defaults to ../newton-ui relative to this repo root.
 set -euo pipefail
 
+check_only=false
+ui_repo=""
+for arg in "$@"; do
+  case "$arg" in
+    --check) check_only=true ;;
+    -*) echo "error: unknown flag '$arg'" >&2; exit 2 ;;
+    *) ui_repo="$arg" ;;
+  esac
+done
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ui_repo="${1:-${repo_root}/../newton-ui}"
+ui_repo="${ui_repo:-${repo_root}/../newton-ui}"
 out="${repo_root}/crates/core/assets/web/index.html.gz"
 
 if [[ ! -d "${ui_repo}" ]]; then
   echo "error: newton-ui repo not found at ${ui_repo}" >&2
-  echo "       pass its path explicitly: scripts/vendor-web.sh /path/to/newton-ui" >&2
+  echo "       pass its path explicitly: scripts/vendor-web.sh [--check] /path/to/newton-ui" >&2
   exit 1
 fi
 
@@ -38,6 +56,24 @@ fi
 # external src=/href= asset references.
 if grep -oE '(src|href)="[^"]+"' "${dist}" | grep -vE '"(data:|#|/)"?' | grep -qE '\.(js|css)"'; then
   echo "error: build is not self-contained (external js/css refs found in ${dist})" >&2
+  exit 1
+fi
+
+if [[ "${check_only}" == true ]]; then
+  # The vite build is deterministic, so the committed bundle must decompress to
+  # exactly the freshly built HTML. Compare decompressed content (gzip framing
+  # itself is irrelevant) so the check never flakes on compression metadata.
+  if [[ ! -f "${out}" ]]; then
+    echo "error: vendored bundle missing at ${out}; run scripts/vendor-web.sh" >&2
+    exit 1
+  fi
+  if cmp -s <(gzip -dc "${out}") "${dist}"; then
+    echo "==> OK: embedded UI bundle is up to date with newton-ui"
+    exit 0
+  fi
+  echo "error: embedded UI bundle is STALE — newton-ui changed without re-vendoring." >&2
+  echo "       Run: scripts/vendor-web.sh ${ui_repo}" >&2
+  echo "       and commit crates/core/assets/web/index.html.gz" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why

The Newton UI is vendored into the binary as `crates/core/assets/web/index.html.gz` (via `scripts/vendor-web.sh`), built from the **separate, private** `gonewton/newton-ui` repo. Nothing currently catches the bundle going stale when the UI changes — `newton serve` would silently ship an old UI. This adds that guard.

## What

- **`scripts/vendor-web.sh --check`** — rebuilds the UI and **fails if the committed bundle is stale**, without modifying it. The vite build is deterministic (verified: two builds → identical sha256, matching the committed bundle), so it compares decompressed content (gzip framing aside) and is **not flaky**. Clear remediation message on drift:
  ```
  error: embedded UI bundle is STALE — newton-ui changed without re-vendoring.
         Run: scripts/vendor-web.sh /path/to/newton-ui
  ```
- **`ci.yml` → `web-ui-vendor-drift` job** — runs the check in CI. Because `newton-ui` is **private**, the job is a **no-op unless** a read-only PAT is configured as the `NEWTON_UI_RO_TOKEN` secret; forks and unconfigured repos stay green (it emits a `::notice::` and skips). When the secret is set, it checks out `newton-ui`, installs deps (frozen lockfile), and runs `vendor-web.sh --check`.

## Activating it

Add a repo secret `NEWTON_UI_RO_TOKEN` = a PAT (or fine-grained token) with **read** access to `gonewton/newton-ui`. Until then the job is inert.

## Caveat

The check compares exact content, so CI's pinned `node@22` / `pnpm@10.21.0` must match the toolchain used when vendoring (they do today). If a future toolchain bump makes the vite output differ across machines, relax the comparison or re-vendor on the CI toolchain.

## Verified locally

- `--check` passes against the current committed bundle.
- `--check` correctly **fails** when the committed `.gz` is tampered, then passes again after restore.
- `ci.yml` is valid YAML; the vendored `.gz` is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)