### PR TITLE
feat(serve): print a startup banner with the UI/API URLs

### DIFF
--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -274,6 +274,37 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
         );
     }
 
+    // Human-readable startup banner. Newton's `info!` startup logs are silenced
+    // in the serve (Server) console context, and cli-framework's `serve()` prints
+    // nothing, so without this `newton serve` looks like it hangs with no output.
+    {
+        // 0.0.0.0 / :: aren't browsable; point the user at a loopback address.
+        let browse_host = match args.host.as_str() {
+            "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+            h => h,
+        };
+        let base = format!("http://{browse_host}:{}", args.port);
+        eprintln!();
+        eprintln!("  Newton serving on {base}");
+        if web_ui_mode != "disabled" {
+            eprintln!("    Web UI     {base}/");
+        }
+        eprintln!("    REST API   {base}/api/v1/");
+        eprintln!("    Health     {base}/healthz");
+        eprintln!("    API docs   {base}/api/docs");
+        if args.with_mcp {
+            eprintln!("    MCP        {base}/mcp");
+        }
+        if args.with_embedded_ailoop {
+            eprintln!("    ailoop     {base}{}", args.ailoop_base_path);
+        }
+        if web_ui_mode == "disabled" {
+            eprintln!("    (web UI disabled via --no-web)");
+        }
+        eprintln!("  Press Ctrl+C to stop.");
+        eprintln!();
+    }
+
     server
         .serve(&addr)
         .await

--- a/crates/cli/tests/integration/serve_host_level.rs
+++ b/crates/cli/tests/integration/serve_host_level.rs
@@ -224,3 +224,49 @@ fn embedded_web_ui_serves_spa_deeplinks_by_default() {
     }
     assert_eq!(healthz, 200, "/healthz must still be handled by the API");
 }
+
+#[test]
+fn serve_prints_startup_banner_with_urls() {
+    use std::io::Read;
+    // `newton serve` must print a human-readable banner: its `info!` startup logs
+    // are silenced in the serve console context and cli-framework prints nothing,
+    // so without the banner the process looks like it hangs.
+    let port = pick_free_port();
+    let dir = tempdir().unwrap();
+    let errpath = dir.path().join("stderr.log");
+    let errfile = std::fs::File::create(&errpath).unwrap();
+    let bin = assert_cmd::cargo::cargo_bin("newton");
+    let mut child = Command::new(bin)
+        .current_dir(dir.path())
+        .args(["serve", "--host", "127.0.0.1", "--port", &port.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(errfile))
+        .spawn()
+        .expect("spawn newton serve");
+
+    let ready = wait_ready(port);
+    // The banner is flushed just before the listener binds; give it a beat.
+    std::thread::sleep(Duration::from_millis(250));
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(ready, "server did not become ready");
+
+    let mut stderr = String::new();
+    std::fs::File::open(&errpath)
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+
+    assert!(
+        stderr.contains("Newton serving on"),
+        "startup banner missing; stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("http://127.0.0.1:{port}/")),
+        "web UI URL missing from banner; stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains("/api/v1/"),
+        "REST API URL missing from banner; stderr=\n{stderr}"
+    );
+}

--- a/crates/cli/tests/integration/serve_with_embedded_ailoop_health.rs
+++ b/crates/cli/tests/integration/serve_with_embedded_ailoop_health.rs
@@ -60,6 +60,25 @@ fn start_embedded_ailoop_server(port: u16, base_path: &str) -> (std::process::Ch
             panic!("structured ailoop_serve_started log line not observed within 30s");
         }
     };
+
+    // The `ailoop_serve_started` line is emitted just before the listener binds,
+    // so it is NOT a reliable "accepting connections" signal. Poll the socket
+    // until it actually accepts before returning — otherwise callers race the
+    // bind and get a spurious connection-refused (flaky under the slow
+    // coverage-instrumented binary).
+    let ready_deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            break;
+        }
+        if Instant::now() >= ready_deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("server did not accept connections on port {port} within 30s");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
     (child, startup_line)
 }
 


### PR DESCRIPTION
## Why

`newton serve` printed **nothing** on startup (verified: stdout and stderr both empty even though the server is up). Its `info!` startup logs are silenced in the serve "Server" console context (`ConsoleOutput::None`), and cli-framework's `serve()` emits no output of its own — so the process looks like it hangs with no clue where the UI or API live. (Reported: *"I start newton and have no clue what is happening."*)

cli-framework has no banner hook, so newton prints its own.

## What

A concise banner to **stderr** just before the listener binds:

```
  Newton serving on http://127.0.0.1:9090
    Web UI     http://127.0.0.1:9090/
    REST API   http://127.0.0.1:9090/api/v1/
    Health     http://127.0.0.1:9090/healthz
    API docs   http://127.0.0.1:9090/api/docs
  Press Ctrl+C to stop.
```

- `0.0.0.0` / `::` are mapped to `127.0.0.1` for the browsable URL.
- The **Web UI** line is omitted under `--no-web` (replaced by `(web UI disabled via --no-web)`).
- **MCP** / **ailoop** lines appear when `--with-mcp` / `--with-embedded-ailoop` are set.
- Uses `eprintln!` so it shows regardless of the suppressed tracing layer.

## Test

`serve_prints_startup_banner_with_urls` — spawns `newton serve`, waits for readiness, asserts the banner + Web UI + `/api/v1/` URLs are on stderr. Verified all flag combinations by hand (default / `--no-web` / `--with-mcp` / `--host 0.0.0.0`).

## Note

The banner prints just before bind, so a bind failure (port in use) shows the banner followed by the error. cli-framework owns the bind, so there's no clean "after bind" hook; the error message is clear enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)