### PR TITLE
docs(api): rename OpenAPI title to "Newton API"

### DIFF
--- a/crates/core/src/api/openapi.rs
+++ b/crates/core/src/api/openapi.rs
@@ -1,6 +1,6 @@
 use utoipa::OpenApi;
 
-/// Generated OpenAPI document for the Newton backend parity surface.
+/// Generated OpenAPI document for the Newton HTTP API.
 #[derive(OpenApi)]
 #[openapi(
     paths(
@@ -172,9 +172,9 @@ use utoipa::OpenApi;
     ),
     servers((url = "/api/v1")),
     info(
-        title = "Newton Backend Parity API",
+        title = "Newton API",
         version = env!("CARGO_PKG_VERSION"),
-        description = "Contract for Rust `newton serve` parity endpoints sourced from Rust DTOs and handlers."
+        description = "HTTP API served by `newton serve`."
     ),
     external_docs(
         url = "./newton-realtime.asyncapi.yaml",

--- a/openapi/newton-backend-parity.yaml
+++ b/openapi/newton-backend-parity.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
-  title: Newton Backend Parity API
-  description: Contract for Rust `newton serve` parity endpoints sourced from Rust DTOs and handlers.
+  title: Newton API
+  description: HTTP API served by `newton serve`.
   contact:
     name: Newton Loop Framework
   license:


### PR DESCRIPTION
## Why

The API docs page (`GET /api/docs`) showed **"Newton Backend Parity API"** with a description about *"parity endpoints sourced from Rust DTOs and handlers."* That's internal jargon — "parity" means the spec is generated from, and kept in sync with, the Rust backend. To a user it's just **the Newton API**.

## What

- `crates/core/src/api/openapi.rs` (the utoipa source the YAML is generated from):
  - title: `Newton Backend Parity API` → **`Newton API`**
  - description: → **`HTTP API served by \`newton serve\`.`**
- Regenerated `openapi/newton-backend-parity.yaml` to match (CI parity check stays green).

## Not in this PR

The contract **file** is still named `openapi/newton-backend-parity.yaml`. Renaming it is a bigger, riskier change — it'd touch 3 files (`.yaml` / `.fixtures.json` / `.sqlite.sql`) and ~10 references including the release pipeline (`auto-release.yml`), `generate-openapi.rs`, CI, fixtures, and docs. Left as a separate change if you want the filename de-jargoned too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)