### PR TITLE
chore(hooks): add OpenAPI parity check to tracked pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -36,6 +36,17 @@ else
     exit 1
 fi
 
+# Verify the OpenAPI contract is regenerated (mirrors the CI parity step)
+echo ""
+echo "📜 Verifying OpenAPI contract..."
+if ./scripts/generate-openapi.sh && git diff --exit-code openapi/newton-api.yaml; then
+    echo "✅ OpenAPI contract is up to date"
+else
+    echo "❌ openapi/newton-api.yaml is out of date."
+    echo "   Run ./scripts/generate-openapi.sh and commit the updated file."
+    exit 1
+fi
+
 # Check documentation builds
 echo ""
 echo "📚 Building documentation..."


### PR DESCRIPTION
## Why

I diffed the tracked `.githooks/` against the active local `.git/hooks/` (the only thing that had diverged). All hooks were identical **except `pre-push`**: the active local one runs the OpenAPI parity check, but the **tracked** `.githooks/pre-push` does not.

That's a real gap — `CONTRIBUTING.md` tells contributors to `git config core.hooksPath .githooks`. Anyone who does gets the tracked hooks **without** the parity check, so they could push a stale `openapi/newton-api.yaml` and only discover it when CI fails. The check existed locally but was never committed back to the source-of-truth hooks.

## What

Add the parity check to `.githooks/pre-push` (styled like the rest of the hook), mirroring the CI step exactly:

```bash
./scripts/generate-openapi.sh && git diff --exit-code openapi/newton-api.yaml
```

Uses the new `newton-api.yaml` name (post-#484). Verified the check passes on current `main`.

## Scope

Only `.githooks/pre-push`. The other three hooks (`pre-commit`, `commit-msg`, `post-commit`) were already identical between tracked and active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)