### PR TITLE
fix: tranche 1 audit remediation — running-system hardening (spec 074)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,6 +197,15 @@ re-matched), never relying on exact per-Finding bookkeeping. Mis-matches degrade
 Request), not *correctness* — the loop does not declare victory while a problem is
 still detectable.
 
+**Fuzziness is not failure tolerance.** The best-effort stance covers
+*mis-matches* between Observations and Findings — it does not cover a
+Reconciliation that runs *without* its semantic-matching half. If adjudication
+itself fails (the LLM matcher errors), the Reconciliation **fails as a task**
+(normal retry applies; a persistent failure fails the cycle) rather than
+proceeding fingerprint-only — because a sweep without semantic matching would
+mass-resolve open Findings (including `blocked` ones, which only a human may
+clear) and could end a run falsely `converged`.
+
 ### Plan
 A unit of queued work a project's optimization loop consumes — the spec for one
 Step. This is the canonical noun; "work item", "task", and "batch item" are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,6 +2517,7 @@ dependencies = [
  "indexmap",
  "insta",
  "jsonschema 0.18.3",
+ "libc",
  "newton-backend",
  "newton-types",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,11 +1523,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3163,14 +3165,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls 0.23.40",
@@ -3292,6 +3295,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,4 @@ jsonschema = { version = "0.18", default-features = false }
 schemars = { version = "1.2", features = ["chrono04", "uuid1", "indexmap2"] }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "migrate", "chrono", "uuid"] }
 flate2 = "1.0"
+libc = "0.2"

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -35,9 +35,9 @@ pub fn err_validation(message: &str) -> ApiError {
     }
 }
 
-pub fn err_forbidden_in_prod(message: &str) -> ApiError {
+pub fn err_testing_reset_disabled(message: &str) -> ApiError {
     ApiError {
-        code: "ERR_FORBIDDEN_IN_PROD".to_string(),
+        code: "ERR_TESTING_RESET_DISABLED".to_string(),
         category: "authorization".to_string(),
         message: message.to_string(),
         details: None,

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -35,6 +35,8 @@ pub fn err_validation(message: &str) -> ApiError {
     }
 }
 
+/// 403 `ApiError` body for the disabled testing-reset endpoint
+/// (code `ERR_TESTING_RESET_DISABLED`).
 pub fn err_testing_reset_disabled(message: &str) -> ApiError {
     ApiError {
         code: "ERR_TESTING_RESET_DISABLED".to_string(),

--- a/crates/backend/src/store/eval.rs
+++ b/crates/backend/src/store/eval.rs
@@ -126,7 +126,11 @@ impl super::SqliteBackendStore {
         let now = Self::now_iso();
         let evaluated_at = body.evaluated_at.clone().unwrap_or_else(|| now.clone());
 
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         let table = scope_table(&body.scope).ok_or_else(|| {
             err_validation("scope must be one of: product, component, repo, module")
@@ -321,7 +325,11 @@ impl super::SqliteBackendStore {
             .as_ref()
             .map(|m| serde_json::to_string(m).unwrap_or_default());
 
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         let run_exists: bool =
             sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM EvalRun WHERE id = ?")

--- a/crates/backend/src/store/mod.rs
+++ b/crates/backend/src/store/mod.rs
@@ -13,9 +13,10 @@ use crate::models::*;
 use crate::BackendStore;
 use chrono::{DateTime, Utc};
 use newton_types::ApiError;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::SqlitePool;
 use std::str::FromStr;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct SqliteBackendStore {
@@ -24,10 +25,20 @@ pub struct SqliteBackendStore {
 
 impl SqliteBackendStore {
     pub async fn new(database_url: &str) -> Result<Self, ApiError> {
+        // Newton opens SEVERAL independent connection pools onto the SAME
+        // backend.sqlite (executor DbSink, grading-operator store, `data`,
+        // `serve` — one state root, many callers). Without WAL + a busy
+        // timeout, SQLite's default rollback-journal locking makes a second
+        // pool's writer fail immediately with "database is locked" the
+        // instant it races a writer from another pool, instead of waiting.
+        // WAL allows one writer concurrently with readers from other
+        // connections, and the busy timeout absorbs writer-vs-writer races.
         let options = SqliteConnectOptions::from_str(database_url)
             .map_err(|e| err_internal(&format!("invalid database URL: {e}")))?
             .create_if_missing(true)
-            .foreign_keys(true);
+            .foreign_keys(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_secs(10));
 
         let pool = SqlitePoolOptions::new()
             .max_connections(5)

--- a/crates/backend/src/store/plan.rs
+++ b/crates/backend/src/store/plan.rs
@@ -423,7 +423,11 @@ impl super::SqliteBackendStore {
     }
 
     pub(super) async fn approve_plan_db(&self, id: &str) -> Result<ApprovedPlan, ApiError> {
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         let plan: Option<PlanRow> =
             sqlx::query_as::<_, PlanRow>(&format!("{PLAN_SELECT} WHERE p.id = ?"))
@@ -466,7 +470,11 @@ impl super::SqliteBackendStore {
     }
 
     pub(super) async fn reject_plan_db(&self, id: &str) -> Result<PlanItem, ApiError> {
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         let plan: Option<PlanRow> =
             sqlx::query_as::<_, PlanRow>(&format!("{PLAN_SELECT} WHERE p.id = ?"))
@@ -636,7 +644,11 @@ impl super::SqliteBackendStore {
             "Persistence",
         ];
 
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         for table in &tables {
             tx.execute(sqlx::query(&format!("DELETE FROM {table}")))

--- a/crates/backend/src/store/workflow_runtime.rs
+++ b/crates/backend/src/store/workflow_runtime.rs
@@ -306,7 +306,11 @@ impl super::SqliteBackendStore {
         node_id: &str,
         line: &newton_types::LogLine,
     ) -> Result<(), ApiError> {
-        let mut tx = self.pool.begin().await.map_err(tx_err)?;
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(tx_err)?;
 
         sqlx::query(
             "INSERT INTO WorkflowLog (instanceId, nodeId, seq, ts, level, message)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -242,3 +242,11 @@ path = "tests/integration/test_chat_error_codes.rs"
 [[test]]
 name = "test_chat_tool_filtering"
 path = "tests/integration/test_chat_tool_filtering.rs"
+
+[[test]]
+name = "mcp_data_malformed_call_no_exit"
+path = "tests/integration/mcp_data_malformed_call_no_exit.rs"
+
+[[test]]
+name = "exit_codes_preserved"
+path = "tests/integration/exit_codes_preserved.rs"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -236,6 +236,10 @@ name = "test_data_post_grade_local_store"
 path = "tests/integration/test_data_post_grade_local_store.rs"
 
 [[test]]
+name = "test_state_dir_one_root"
+path = "tests/integration/test_state_dir_one_root.rs"
+
+[[test]]
 name = "test_chat_error_codes"
 path = "tests/integration/test_chat_error_codes.rs"
 

--- a/crates/cli/src/cli/args.rs
+++ b/crates/cli/src/cli/args.rs
@@ -37,6 +37,10 @@ pub enum RunsCommand {
         /// Emit machine-readable JSON
         #[arg(long)]
         json: bool,
+        /// Override the state root directory where checkpoints/executions are
+        /// stored. Defaults to auto-resolved from workspace root.
+        #[arg(long, value_name = "PATH")]
+        state_dir: Option<PathBuf>,
     },
     #[command(
         about = "Replay task-by-task execution detail for a specific run",
@@ -57,6 +61,10 @@ pub enum RunsCommand {
         /// Emit machine-readable JSON
         #[arg(long)]
         json: bool,
+        /// Override the state root directory where checkpoints/executions are
+        /// stored. Defaults to auto-resolved from workspace root.
+        #[arg(long, value_name = "PATH")]
+        state_dir: Option<PathBuf>,
     },
 }
 
@@ -443,6 +451,10 @@ pub struct DataArgs {
     pub json: bool,
     pub dry_run: bool,
     pub workspace: Option<PathBuf>,
+    /// Override the state root directory where backend.sqlite is stored.
+    /// Defaults to auto-resolved from workspace root (flag > NEWTON_STATE_DIR
+    /// > newton.toml [workflow].state_dir > workspace default).
+    pub state_dir: Option<PathBuf>,
     /// Optional filter: restrict grade listings to a single evaluation run.
     pub run_id: Option<String>,
     /// Optional filter: restrict grade listings to a single KPI.

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -17,7 +17,9 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         Some(ref p) => p.clone(),
         None => std::env::current_dir()?,
     };
-    let workspace_paths = WorkspacePaths::new(workspace);
+    let state_dir =
+        crate::cli::workspace_paths::resolve_state_dir(&workspace, args.state_dir.as_deref());
+    let workspace_paths = WorkspacePaths::with_state_dir(workspace, state_dir);
     let db_url = workspace_paths.backend_sqlite_url();
     let store = match newton_backend::SqliteBackendStore::new(&db_url).await {
         Ok(s) => s,

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -653,3 +653,295 @@ async fn dispatch_data(
         (v, r) => Err(format!("unsupported combination: {v} {r}")),
     }
 }
+
+/// Direct (in-process) unit tests for `data()`'s `CliExit` error-return paths
+/// (spec 074, PR-1). These call `data()` itself rather than spawning a
+/// subprocess so they are reliably attributed by coverage tooling — mirrors
+/// `mcp_data_malformed_call_no_exit.rs`'s in-process dispatch seam, one level
+/// closer to the handler.
+#[cfg(test)]
+mod cli_exit_path_tests {
+    use super::*;
+    use crate::cli::args::DataVerb;
+    use tempfile::TempDir;
+
+    /// A workspace whose `.newton/state/` directory already exists, so
+    /// `SqliteBackendStore::new` (which opens with `mode=rwc` but does not
+    /// create missing *directories*, only the db file itself) can open
+    /// `backend.sqlite` and run migrations. Mirrors
+    /// `mcp_data_malformed_call_no_exit.rs::setup_workspace_with_db`.
+    fn setup_workspace() -> TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".newton/state")).expect("create state dir");
+        dir
+    }
+
+    fn base_args(ws: &TempDir, verb: DataVerb, resource: &str) -> DataArgs {
+        DataArgs {
+            verb,
+            resource: resource.to_string(),
+            id: None,
+            file: None,
+            body: None,
+            json: false,
+            dry_run: false,
+            workspace: Some(ws.path().to_path_buf()),
+            state_dir: None,
+            run_id: None,
+            kpi_id: None,
+            scope: None,
+            scope_id: None,
+            source: None,
+            limit: None,
+        }
+    }
+
+    /// Downcasts the `anyhow::Error` returned by `data()` to the `CliExit`
+    /// every one of its error-return paths constructs.
+    fn expect_cli_exit(err: anyhow::Error) -> CliExit {
+        err.downcast::<CliExit>()
+            .unwrap_or_else(|e| panic!("expected a CliExit, got: {e}"))
+    }
+
+    async fn seed_eval_run(ws: &TempDir, run_id: &str) {
+        let state_dir = crate::cli::workspace_paths::resolve_state_dir(ws.path(), None);
+        let workspace_paths = WorkspacePaths::with_state_dir(ws.path().to_path_buf(), state_dir);
+        let db_url = workspace_paths.backend_sqlite_url();
+        let store = newton_backend::SqliteBackendStore::new(&db_url)
+            .await
+            .expect("open store to seed eval-run");
+        // create_eval_run validates its scope FK, so a real Product must
+        // exist for scope="product" to be accepted.
+        let product = store
+            .create_product(newton_backend::CreateProductBody {
+                name: "seed-product".to_string(),
+            })
+            .await
+            .expect("seed product for eval-run scope FK");
+        store
+            .create_eval_run(newton_backend::CreateEvalRunBody {
+                id: run_id.to_string(),
+                source: "test".to_string(),
+                scope: "product".to_string(),
+                scope_id: product.id,
+                score: None,
+                verdict: None,
+                summary: None,
+                evaluated_at: None,
+                grades: None,
+                raw_assessment: None,
+            })
+            .await
+            .expect("seed eval-run");
+    }
+
+    #[tokio::test]
+    async fn data_001_file_and_body_are_mutually_exclusive() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "product");
+        args.file = Some(ws.path().join("body.json"));
+        args.body = Some("{}".to_string());
+
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert_eq!(exit.code, 1);
+        assert!(exit.message.contains("DATA-001"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn store_open_failure_surfaces_as_cli_exit() {
+        // No `.newton/state` dir created, and an explicit --state-dir that
+        // does not exist either — SqliteBackendStore::new does not create
+        // missing parent directories, only the db file itself, so opening it
+        // must fail.
+        let ws = tempfile::tempdir().expect("tempdir");
+        let mut args = base_args(&ws, DataVerb::Get, "products");
+        args.state_dir = Some(ws.path().join("does-not-exist").join("nested"));
+
+        let err = data(args).await.expect_err("store open must fail");
+        let exit = expect_cli_exit(err);
+        assert_eq!(exit.code, 1);
+        assert!(
+            exit.message.contains("Failed to open backend store"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn data_004_invalid_json_in_file() {
+        let ws = setup_workspace();
+        let file_path = ws.path().join("bad.json");
+        std::fs::write(&file_path, b"{not valid json").expect("write bad json");
+        let mut args = base_args(&ws, DataVerb::Post, "product");
+        args.file = Some(file_path);
+
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-004"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn data_006_run_id_rejected_for_unsupported_resource() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Get, "products");
+        args.run_id = Some("run-1".to_string());
+
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-006"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn data_008_scope_rejected_for_unsupported_resource() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Get, "products");
+        args.scope = Some("product".to_string());
+
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-008"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn data_005_missing_body_for_post() {
+        let ws = setup_workspace();
+        let args = base_args(&ws, DataVerb::Post, "product");
+
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-005"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn dry_run_component_rejects_missing_product_fk() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "component");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"productId": "ghost-product"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed") && exit.message.contains("ghost-product"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_repo_rejects_missing_component_fk() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "repo");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"componentId": "ghost-component"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed")
+                && exit.message.contains("ghost-component"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_module_rejects_missing_repo_fk() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "module");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"repoId": "ghost-repo"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed") && exit.message.contains("ghost-repo"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_eval_run_requires_scope_and_scope_id() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "eval-run");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"source": "dk-review"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("scope and scopeId are required"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_eval_run_rejects_missing_scope_target() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "eval-run");
+        args.dry_run = true;
+        args.body =
+            Some(serde_json::json!({"scope": "product", "scopeId": "ghost-product"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed") && exit.message.contains("ghost-product"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_grade_requires_run_id() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "grade");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"dimension": "tests"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("runId is required"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_grade_rejects_missing_run_id_fk() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Post, "grade");
+        args.dry_run = true;
+        args.body = Some(serde_json::json!({"runId": "ghost-run"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed") && exit.message.contains("ghost-run"),
+            "{}",
+            exit.message
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_grade_rejects_missing_kpi_id_fk() {
+        let ws = setup_workspace();
+        seed_eval_run(&ws, "real-run-1").await;
+        let mut args = base_args(&ws, DataVerb::Post, "grade");
+        args.dry_run = true;
+        args.body =
+            Some(serde_json::json!({"runId": "real-run-1", "kpiId": "ghost-kpi"}).to_string());
+
+        let err = data(args).await.expect_err("dry-run FK check must fail");
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("FK validation failed") && exit.message.contains("ghost-kpi"),
+            "{}",
+            exit.message
+        );
+    }
+}

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -1,12 +1,16 @@
 use crate::cli::args::{DataArgs, DataVerb};
+use crate::cli::exit::CliExit;
 use crate::cli::WorkspacePaths;
 use newton_backend::BackendStore;
 use std::fs;
 
 pub async fn data(args: DataArgs) -> anyhow::Result<()> {
     if args.file.is_some() && args.body.is_some() {
-        eprintln!("DATA-001: --file and --body are mutually exclusive; provide at most one");
-        std::process::exit(1);
+        return Err(CliExit::new(
+            1,
+            "DATA-001: --file and --body are mutually exclusive; provide at most one",
+        )
+        .into());
     }
 
     let workspace = match args.workspace {
@@ -18,8 +22,9 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
     let store = match newton_backend::SqliteBackendStore::new(&db_url).await {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Failed to open backend store: {}", e.message);
-            std::process::exit(1);
+            return Err(
+                CliExit::new(1, format!("Failed to open backend store: {}", e.message)).into(),
+            );
         }
     };
 
@@ -35,16 +40,16 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         match serde_json::from_str::<serde_json::Value>(&raw) {
             Ok(v) => Some(v),
             Err(e) => {
-                eprintln!("DATA-004: invalid JSON in body: {e}");
-                std::process::exit(1);
+                return Err(CliExit::new(1, format!("DATA-004: invalid JSON in body: {e}")).into());
             }
         }
     } else if let Some(ref s) = args.body {
         match serde_json::from_str::<serde_json::Value>(s) {
             Ok(v) => Some(v),
             Err(e) => {
-                eprintln!("DATA-004: invalid JSON in --body: {e}");
-                std::process::exit(1);
+                return Err(
+                    CliExit::new(1, format!("DATA-004: invalid JSON in --body: {e}")).into(),
+                );
             }
         }
     } else {
@@ -57,10 +62,11 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         && resource != "grades"
         && resource != "optimize-cycles"
     {
-        eprintln!(
-            "DATA-006: --run-id/--kpi-id are only supported with: resource=grades, optimize-cycles"
-        );
-        std::process::exit(1);
+        return Err(CliExit::new(
+            1,
+            "DATA-006: --run-id/--kpi-id are only supported with: resource=grades, optimize-cycles",
+        )
+        .into());
     }
     if (args.scope.is_some()
         || args.scope_id.is_some()
@@ -68,10 +74,11 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         || args.limit.is_some())
         && resource != "eval-runs"
     {
-        eprintln!(
-            "DATA-008: --scope/--scope-id/--source/--limit are only supported with: resource=eval-runs"
-        );
-        std::process::exit(1);
+        return Err(CliExit::new(
+            1,
+            "DATA-008: --scope/--scope-id/--source/--limit are only supported with: resource=eval-runs",
+        )
+        .into());
     }
 
     let valid_resources = [
@@ -103,14 +110,16 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         "optimize-cycles",
     ];
     if !valid_resources.contains(&resource) {
-        eprintln!("DATA-003: unknown resource '{resource}'; must be one of: product, products, component, components, repo, repos, module, modules, module-dependency, module-dependencies, kpi, kpis, eval-run, eval-runs, grade, grades, finding, findings, change-request, change-requests, plan, plans, optimize-run, optimize-runs, optimize-cycle, optimize-cycles");
-        std::process::exit(1);
+        return Err(CliExit::new(1, format!("DATA-003: unknown resource '{resource}'; must be one of: product, products, component, components, repo, repos, module, modules, module-dependency, module-dependencies, kpi, kpis, eval-run, eval-runs, grade, grades, finding, findings, change-request, change-requests, plan, plans, optimize-run, optimize-runs, optimize-cycle, optimize-cycles")).into());
     }
 
     if matches!(args.verb, DataVerb::Post | DataVerb::Put | DataVerb::Patch) && body_value.is_none()
     {
-        eprintln!("DATA-005: --file or --body is required for {}", args.verb);
-        std::process::exit(1);
+        return Err(CliExit::new(
+            1,
+            format!("DATA-005: --file or --body is required for {}", args.verb),
+        )
+        .into());
     }
 
     let needs_id = match args.verb {
@@ -134,8 +143,11 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
         DataVerb::Put | DataVerb::Patch | DataVerb::Delete => true,
     };
     if needs_id && args.id.is_none() {
-        eprintln!("DATA-002: ID is required for {} {}", args.verb, resource);
-        std::process::exit(1);
+        return Err(CliExit::new(
+            1,
+            format!("DATA-002: ID is required for {} {}", args.verb, resource),
+        )
+        .into());
     }
 
     if args.dry_run {
@@ -145,30 +157,35 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
                     "component" | "components" => {
                         if let Some(product_id) = v.get("productId").and_then(|p| p.as_str()) {
                             if let Err(e) = store.get_product(product_id).await {
-                                eprintln!(
-                                    "[dry-run] FK validation failed: productId '{}' not found: {}",
-                                    product_id, e.message
-                                );
-                                std::process::exit(1);
+                                return Err(CliExit::new(
+                                    1,
+                                    format!(
+                                        "[dry-run] FK validation failed: productId '{}' not found: {}",
+                                        product_id, e.message
+                                    ),
+                                )
+                                .into());
                             }
                         }
                     }
                     "repo" | "repos" => {
                         if let Some(component_id) = v.get("componentId").and_then(|c| c.as_str()) {
                             if let Err(e) = store.get_component(component_id).await {
-                                eprintln!("[dry-run] FK validation failed: componentId '{}' not found: {}", component_id, e.message);
-                                std::process::exit(1);
+                                return Err(CliExit::new(1, format!("[dry-run] FK validation failed: componentId '{}' not found: {}", component_id, e.message)).into());
                             }
                         }
                     }
                     "module" | "modules" => {
                         if let Some(repo_id) = v.get("repoId").and_then(|r| r.as_str()) {
                             if let Err(e) = store.get_repo(repo_id).await {
-                                eprintln!(
-                                    "[dry-run] FK validation failed: repoId '{}' not found: {}",
-                                    repo_id, e.message
-                                );
-                                std::process::exit(1);
+                                return Err(CliExit::new(
+                                    1,
+                                    format!(
+                                        "[dry-run] FK validation failed: repoId '{}' not found: {}",
+                                        repo_id, e.message
+                                    ),
+                                )
+                                .into());
                             }
                         }
                     }
@@ -176,10 +193,11 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
                         let scope = v.get("scope").and_then(|s| s.as_str()).unwrap_or("");
                         let scope_id = v.get("scopeId").and_then(|s| s.as_str()).unwrap_or("");
                         if scope.is_empty() || scope_id.is_empty() {
-                            eprintln!(
-                                "[dry-run] FK validation failed: scope and scopeId are required"
-                            );
-                            std::process::exit(1);
+                            return Err(CliExit::new(
+                                1,
+                                "[dry-run] FK validation failed: scope and scopeId are required",
+                            )
+                            .into());
                         }
                         let fk_result = match scope {
                             "product" => store.get_product(scope_id).await.map(|_| ()),
@@ -191,33 +209,45 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
                             )),
                         };
                         if let Err(e) = fk_result {
-                            eprintln!(
-                                "[dry-run] FK validation failed: {} '{}' not found: {}",
-                                scope, scope_id, e.message
-                            );
-                            std::process::exit(1);
+                            return Err(CliExit::new(
+                                1,
+                                format!(
+                                    "[dry-run] FK validation failed: {} '{}' not found: {}",
+                                    scope, scope_id, e.message
+                                ),
+                            )
+                            .into());
                         }
                     }
                     "grade" | "grades" => {
                         let run_id = v.get("runId").and_then(|r| r.as_str());
                         let Some(run_id) = run_id else {
-                            eprintln!("[dry-run] FK validation failed: runId is required");
-                            std::process::exit(1);
+                            return Err(CliExit::new(
+                                1,
+                                "[dry-run] FK validation failed: runId is required",
+                            )
+                            .into());
                         };
                         if let Err(e) = store.get_eval_run(run_id).await {
-                            eprintln!(
-                                "[dry-run] FK validation failed: runId '{}' not found: {}",
-                                run_id, e.message
-                            );
-                            std::process::exit(1);
+                            return Err(CliExit::new(
+                                1,
+                                format!(
+                                    "[dry-run] FK validation failed: runId '{}' not found: {}",
+                                    run_id, e.message
+                                ),
+                            )
+                            .into());
                         }
                         if let Some(kpi_id) = v.get("kpiId").and_then(|k| k.as_str()) {
                             if let Err(e) = store.get_kpi(kpi_id).await {
-                                eprintln!(
-                                    "[dry-run] FK validation failed: kpiId '{}' not found: {}",
-                                    kpi_id, e.message
-                                );
-                                std::process::exit(1);
+                                return Err(CliExit::new(
+                                    1,
+                                    format!(
+                                        "[dry-run] FK validation failed: kpiId '{}' not found: {}",
+                                        kpi_id, e.message
+                                    ),
+                                )
+                                .into());
                             }
                         }
                     }
@@ -242,10 +272,7 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
             println!("{}", serde_json::to_string_pretty(&value)?);
             Ok(())
         }
-        Err(msg) => {
-            eprintln!("{msg}");
-            std::process::exit(1);
-        }
+        Err(msg) => Err(CliExit::new(1, msg).into()),
     }
 }
 

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::{RunsArgs, RunsCommand};
+use crate::cli::workspace_paths::{resolve_state_dir, state_checkpoints_dir};
 use humantime::parse_duration;
 use newton_core::core::error::AppError;
 use newton_core::core::types::ErrorCategory;
@@ -85,14 +86,16 @@ pub fn log(args: RunsArgs) -> StdResult<(), AppError> {
             workspace,
             last,
             json,
-        } => log_list(workspace, last, json),
+            state_dir,
+        } => log_list(workspace, last, json, state_dir),
         RunsCommand::Show {
             run_id,
             workspace,
             task,
             verbose,
             json,
-        } => log_show(run_id, workspace, task, verbose, json),
+            state_dir,
+        } => log_show(run_id, workspace, task, verbose, json, state_dir),
     }
 }
 
@@ -100,6 +103,7 @@ fn log_list(
     workspace: Option<PathBuf>,
     last: Option<usize>,
     emit_json: bool,
+    state_dir: Option<PathBuf>,
 ) -> StdResult<(), AppError> {
     if let Some(n) = last {
         if n == 0 {
@@ -112,7 +116,8 @@ fn log_list(
     }
 
     let workspace = super::resolve_workflow_workspace(workspace)?;
-    let base = WorkflowStatePaths::workspace_root(&workspace);
+    let state_dir = resolve_state_dir(&workspace, state_dir.as_deref());
+    let base = state_checkpoints_dir(&state_dir);
 
     let mut entries: Vec<(WorkflowExecution, Option<usize>)> = Vec::new();
 
@@ -244,9 +249,11 @@ fn log_show(
     task_filter: Option<String>,
     verbose: bool,
     emit_json: bool,
+    state_dir: Option<PathBuf>,
 ) -> StdResult<(), AppError> {
     let workspace = super::resolve_workflow_workspace(workspace)?;
-    let paths = WorkflowStatePaths::new(&workspace, &execution_id);
+    let state_dir = resolve_state_dir(&workspace, state_dir.as_deref());
+    let paths = WorkflowStatePaths::from_base(&state_checkpoints_dir(&state_dir), &execution_id);
 
     if !paths.execution_file.exists() {
         return Err(AppError::new(

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -52,6 +52,7 @@ fn resolve_workflow_workspace(path: Option<PathBuf>) -> StdResult<PathBuf, AppEr
 
 async fn build_operator_registry(
     workspace: PathBuf,
+    state_dir: &Path,
     settings: &workflow_schema::WorkflowSettings,
     ailoop_ctx: Option<newton_core::integrations::ailoop::AiloopContext>,
 ) -> OperatorRegistry {
@@ -60,12 +61,15 @@ async fn build_operator_registry(
         ailoop_ctx,
         Duration::from_secs(settings.human.default_timeout_seconds),
     );
-    // Wire the workspace backend store so the grading operators
+    // Wire the resolved-state-root backend store so the grading operators
     // (GraderCommandOperator, ReconcileOperator, ChangeRequestOperator,
     // GraderAgentOperator) register — they are only available when a store is
     // present. Without this, `optimize` / `workflow run` cannot run grading.yaml
-    // (operator 'GraderCommandOperator' is not registered).
-    let backend_store = open_workspace_store(&workspace).await;
+    // (operator 'GraderCommandOperator' is not registered). `state_dir` MUST be
+    // the same resolved root the executor's DbSink writes to (one state root —
+    // see WorkspacePaths::with_state_dir), never re-derived from `workspace`
+    // alone, or grading operators split-brain against the executor's store.
+    let backend_store = open_state_store(&workspace, state_dir).await;
     workflow_operators::register_builtins_with_deps(
         &mut builder,
         workspace,
@@ -79,13 +83,17 @@ async fn build_operator_registry(
     builder.build()
 }
 
-/// Open the workspace SQLite backend store when it exists, so grading operators
-/// can be registered. Returns None (with a warning) if absent or unopenable —
-/// non-grading workflows still run.
-async fn open_workspace_store(
+/// Open the resolved-state-root SQLite backend store when it exists, so
+/// grading operators can be registered. Returns None (with a warning) if
+/// absent or unopenable — non-grading workflows still run.
+async fn open_state_store(
     workspace: &Path,
+    state_dir: &Path,
 ) -> Option<std::sync::Arc<dyn newton_backend::BackendStore>> {
-    let paths = crate::cli::workspace_paths::WorkspacePaths::new(workspace.to_path_buf());
+    let paths = crate::cli::workspace_paths::WorkspacePaths::with_state_dir(
+        workspace.to_path_buf(),
+        state_dir.to_path_buf(),
+    );
     if !paths.backend_sqlite_exists() {
         return None;
     }

--- a/crates/cli/src/cli/commands/optimize.rs
+++ b/crates/cli/src/cli/commands/optimize.rs
@@ -5,7 +5,7 @@ use newton_core::core::plan_queue_config::PlanQueueConfig;
 use newton_core::workflow::{schema as workflow_schema, transform as workflow_transform};
 use serde_json::json;
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -153,10 +153,17 @@ async fn execute_workflow_for_plan(
         newton_core::integrations::ailoop::init_context_for_command_name(&workspace, "optimize")
             .ok()
             .flatten();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx).await;
-
-    let previous_state_dir = env::var_os("NEWTON_STATE_DIR");
-    env::set_var("NEWTON_STATE_DIR", &task_layout.state_dir);
+    // Pass the resolved state root explicitly (the same one `build_execution_setup`
+    // above just wired into the executor's DbSink) instead of mutating the
+    // process-global NEWTON_STATE_DIR env var — that workaround let concurrent
+    // executions race each other's state resolution.
+    let registry = super::build_operator_registry(
+        workspace.clone(),
+        &task_layout.state_dir,
+        &settings,
+        ailoop_ctx,
+    )
+    .await;
 
     let result = newton_core::workflow::executor::execute_workflow(
         document,
@@ -166,12 +173,6 @@ async fn execute_workflow_for_plan(
         exec_setup.overrides,
     )
     .await;
-
-    if let Some(previous) = previous_state_dir {
-        env::set_var("NEWTON_STATE_DIR", previous);
-    } else {
-        env::remove_var("NEWTON_STATE_DIR");
-    }
 
     result
         .map(|_| ())

--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -81,8 +81,21 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
 
     info!("Starting Newton API server on {}: {}", args.host, args.port);
 
+    let workspace_paths = WorkspacePaths::from_cwd().map_err(|e| {
+        AppError::new(
+            ErrorCategory::IoError,
+            format!("failed to resolve workspace paths: {e}"),
+        )
+    })?;
+    let cwd = std::env::current_dir().unwrap_or_else(|_| workspace_paths.workspace_root.clone());
+    // Resolve once, up front, so both the operator registry's grading-operator
+    // store and the AppState backend below open the SAME database — the split
+    // brain this hardening pass closes.
+    let state_dir = resolve_state_dir(&cwd, args.state_dir.as_deref());
+
     let serve_settings: workflow_schema::WorkflowSettings = Default::default();
-    let registry = super::build_operator_registry(PathBuf::from("."), &serve_settings, None).await;
+    let registry =
+        super::build_operator_registry(PathBuf::from("."), &state_dir, &serve_settings, None).await;
 
     let operator_names = registry.operator_names();
     let operator_descriptors: Vec<newton_types::OperatorDescriptor> = operator_names
@@ -94,14 +107,6 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
         })
         .collect();
 
-    let workspace_paths = WorkspacePaths::from_cwd().map_err(|e| {
-        AppError::new(
-            ErrorCategory::IoError,
-            format!("failed to resolve workspace paths: {e}"),
-        )
-    })?;
-    let cwd = std::env::current_dir().unwrap_or_else(|_| workspace_paths.workspace_root.clone());
-    let state_dir = resolve_state_dir(&cwd, args.state_dir.as_deref());
     if state_dir.exists() && !state_dir.is_dir() {
         return Err(AppError::new(
             ErrorCategory::ValidationError,

--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -53,6 +53,91 @@ fn is_loopback_host(host: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Checks whether `host` is a non-loopback bind target and, if so, emits the
+/// `unauthenticated_exposure` warning event. Returns `true` when the bind is
+/// non-loopback (the caller uses this to also print the louder startup-banner
+/// warning). Extracted from `serve()`'s body so the check/warn decision is
+/// unit-testable without starting a real HTTP listener (spec 074 PR-6 / B5).
+fn check_non_loopback_bind(host: &str, port: u16) -> bool {
+    let non_loopback_bind = !is_loopback_host(host);
+    if non_loopback_bind {
+        tracing::warn!(
+            event = "unauthenticated_exposure",
+            host = %host,
+            port = port,
+            "newton serve is binding a non-loopback host; the Newton HTTP API is UNAUTHENTICATED and will be reachable from other hosts on this interface"
+        );
+    }
+    non_loopback_bind
+}
+
+/// Builds the human-readable startup banner lines. Newton's `info!` startup
+/// logs are silenced in the serve (Server) console context, and
+/// cli-framework's `serve()` prints nothing, so without this `newton serve`
+/// looks like it hangs with no output. Pure so the banner text — including
+/// the non-loopback exposure warning block — can be unit tested without
+/// starting a real HTTP listener.
+#[allow(clippy::too_many_arguments)]
+fn startup_banner_lines(
+    host: &str,
+    port: u16,
+    web_ui_mode: &str,
+    with_mcp: bool,
+    with_embedded_ailoop: bool,
+    ailoop_base_path: &str,
+    non_loopback_bind: bool,
+) -> Vec<String> {
+    // 0.0.0.0 / :: aren't browsable; point the user at a loopback address.
+    let browse_host = match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        h => h,
+    };
+    let base = format!("http://{browse_host}:{port}");
+    let mut lines = Vec::new();
+    lines.push(String::new());
+    lines.push(format!("  Newton serving on {base}"));
+    if web_ui_mode != "disabled" {
+        lines.push(format!("    Web UI     {base}/"));
+    }
+    lines.push(format!("    REST API   {base}/api/v1/"));
+    lines.push(format!("    Health     {base}/healthz"));
+    lines.push(format!("    API docs   {base}/api/docs"));
+    if with_mcp {
+        lines.push(format!("    MCP        {base}/mcp"));
+    }
+    if with_embedded_ailoop {
+        lines.push(format!("    ailoop     {base}{ailoop_base_path}"));
+    }
+    if web_ui_mode == "disabled" {
+        lines.push("    (web UI disabled via --no-web)".to_string());
+    }
+    if non_loopback_bind {
+        lines.push(String::new());
+        lines.push(
+            "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!".to_string(),
+        );
+        lines.push(format!(
+            "  !! WARNING: bound to non-loopback host \"{}\" — the Newton API is    !!",
+            host
+        ));
+        lines.push(
+            "  !! UNAUTHENTICATED and exposed to any host that can reach this    !!".to_string(),
+        );
+        lines.push(
+            "  !! interface. --host is your explicit opt-in; real authentication  !!".to_string(),
+        );
+        lines.push(
+            "  !! is not yet implemented (deferred to a future spec).             !!".to_string(),
+        );
+        lines.push(
+            "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!".to_string(),
+        );
+    }
+    lines.push("  Press Ctrl+C to stop.".to_string());
+    lines.push(String::new());
+    lines
+}
+
 fn ensure_no_ailoop_path_collision(ailoop_path: &str) -> StdResult<(), AppError> {
     for prefix in NEWTON_REST_ROUTE_PREFIXES {
         if ailoop_path == *prefix
@@ -96,15 +181,7 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
 
     info!("Starting Newton API server on {}: {}", args.host, args.port);
 
-    let non_loopback_bind = !is_loopback_host(&args.host);
-    if non_loopback_bind {
-        tracing::warn!(
-            event = "unauthenticated_exposure",
-            host = %args.host,
-            port = args.port,
-            "newton serve is binding a non-loopback host; the Newton HTTP API is UNAUTHENTICATED and will be reachable from other hosts on this interface"
-        );
-    }
+    let non_loopback_bind = check_non_loopback_bind(&args.host, args.port);
 
     let workspace_paths = WorkspacePaths::from_cwd().map_err(|e| {
         AppError::new(
@@ -302,47 +379,18 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
         );
     }
 
-    // Human-readable startup banner. Newton's `info!` startup logs are silenced
-    // in the serve (Server) console context, and cli-framework's `serve()` prints
-    // nothing, so without this `newton serve` looks like it hangs with no output.
-    {
-        // 0.0.0.0 / :: aren't browsable; point the user at a loopback address.
-        let browse_host = match args.host.as_str() {
-            "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
-            h => h,
-        };
-        let base = format!("http://{browse_host}:{}", args.port);
-        eprintln!();
-        eprintln!("  Newton serving on {base}");
-        if web_ui_mode != "disabled" {
-            eprintln!("    Web UI     {base}/");
-        }
-        eprintln!("    REST API   {base}/api/v1/");
-        eprintln!("    Health     {base}/healthz");
-        eprintln!("    API docs   {base}/api/docs");
-        if args.with_mcp {
-            eprintln!("    MCP        {base}/mcp");
-        }
-        if args.with_embedded_ailoop {
-            eprintln!("    ailoop     {base}{}", args.ailoop_base_path);
-        }
-        if web_ui_mode == "disabled" {
-            eprintln!("    (web UI disabled via --no-web)");
-        }
-        if non_loopback_bind {
-            eprintln!();
-            eprintln!("  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-            eprintln!(
-                "  !! WARNING: bound to non-loopback host \"{}\" — the Newton API is    !!",
-                args.host
-            );
-            eprintln!("  !! UNAUTHENTICATED and exposed to any host that can reach this    !!");
-            eprintln!("  !! interface. --host is your explicit opt-in; real authentication  !!");
-            eprintln!("  !! is not yet implemented (deferred to a future spec).             !!");
-            eprintln!("  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-        }
-        eprintln!("  Press Ctrl+C to stop.");
-        eprintln!();
+    // Human-readable startup banner (see `startup_banner_lines` doc comment
+    // for why this exists).
+    for line in startup_banner_lines(
+        &args.host,
+        args.port,
+        web_ui_mode,
+        args.with_mcp,
+        args.with_embedded_ailoop,
+        &args.ailoop_base_path,
+        non_loopback_bind,
+    ) {
+        eprintln!("{line}");
     }
 
     server
@@ -462,5 +510,169 @@ mod serve_ailoop_validation_tests {
                 "expected collision for prefix {prefix}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod is_loopback_host_tests {
+    use super::*;
+
+    #[test]
+    fn ipv4_loopback_is_loopback() {
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.0.0.5"));
+    }
+
+    #[test]
+    fn ipv4_non_loopback_is_not_loopback() {
+        assert!(!is_loopback_host("0.0.0.0"));
+        assert!(!is_loopback_host("203.0.113.5"));
+        assert!(!is_loopback_host("10.0.0.1"));
+    }
+
+    #[test]
+    fn ipv6_loopback_is_loopback() {
+        assert!(is_loopback_host("::1"));
+    }
+
+    #[test]
+    fn bracketed_ipv6_loopback_is_loopback() {
+        assert!(is_loopback_host("[::1]"));
+    }
+
+    #[test]
+    fn ipv6_non_loopback_is_not_loopback() {
+        assert!(!is_loopback_host("::"));
+        assert!(!is_loopback_host("2001:db8::1"));
+        assert!(!is_loopback_host("[2001:db8::1]"));
+    }
+
+    #[test]
+    fn localhost_hostname_is_loopback_case_insensitive() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(is_loopback_host("LocalHost"));
+    }
+
+    #[test]
+    fn arbitrary_hostname_is_not_loopback() {
+        assert!(!is_loopback_host("example.com"));
+        assert!(!is_loopback_host("my-host"));
+    }
+
+    #[test]
+    fn empty_host_is_not_loopback() {
+        assert!(!is_loopback_host(""));
+    }
+}
+
+#[cfg(test)]
+mod non_loopback_warn_tests {
+    use super::*;
+
+    #[test]
+    fn loopback_host_does_not_warn() {
+        assert!(!check_non_loopback_bind("127.0.0.1", 3000));
+        assert!(!check_non_loopback_bind("localhost", 3000));
+    }
+
+    #[test]
+    fn non_loopback_host_warns_and_returns_true() {
+        assert!(check_non_loopback_bind("0.0.0.0", 3000));
+        assert!(check_non_loopback_bind("203.0.113.5", 8080));
+    }
+}
+
+#[cfg(test)]
+mod startup_banner_tests {
+    use super::*;
+
+    #[test]
+    fn loopback_bind_has_no_warning_banner() {
+        let lines = startup_banner_lines(
+            "127.0.0.1",
+            3000,
+            "embedded",
+            false,
+            false,
+            "/ailoop",
+            false,
+        );
+        let joined = lines.join("\n");
+        assert!(joined.contains("Newton serving on http://127.0.0.1:3000"));
+        assert!(joined.contains("Web UI     http://127.0.0.1:3000/"));
+        assert!(!joined.contains("WARNING"));
+    }
+
+    #[test]
+    fn non_loopback_bind_includes_warning_banner() {
+        let lines =
+            startup_banner_lines("0.0.0.0", 3000, "embedded", false, false, "/ailoop", true);
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("WARNING: bound to non-loopback host \"0.0.0.0\""),
+            "{joined}"
+        );
+        assert!(joined.contains("UNAUTHENTICATED and exposed"));
+    }
+
+    #[test]
+    fn unspecified_bind_addresses_map_to_browsable_loopback() {
+        let lines =
+            startup_banner_lines("0.0.0.0", 3000, "embedded", false, false, "/ailoop", false);
+        assert!(lines.iter().any(|l| l.contains("http://127.0.0.1:3000")));
+
+        let lines = startup_banner_lines("::", 3000, "embedded", false, false, "/ailoop", false);
+        assert!(lines.iter().any(|l| l.contains("http://127.0.0.1:3000")));
+
+        let lines = startup_banner_lines("[::]", 3000, "embedded", false, false, "/ailoop", false);
+        assert!(lines.iter().any(|l| l.contains("http://127.0.0.1:3000")));
+    }
+
+    #[test]
+    fn disabled_web_ui_mode_omits_web_ui_line_and_notes_disabled() {
+        let lines = startup_banner_lines(
+            "127.0.0.1",
+            3000,
+            "disabled",
+            false,
+            false,
+            "/ailoop",
+            false,
+        );
+        let joined = lines.join("\n");
+        assert!(!joined.contains("Web UI"));
+        assert!(joined.contains("(web UI disabled via --no-web)"));
+    }
+
+    #[test]
+    fn mcp_enabled_adds_mcp_line() {
+        let lines =
+            startup_banner_lines("127.0.0.1", 3000, "embedded", true, false, "/ailoop", false);
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("MCP        http://127.0.0.1:3000/mcp")));
+    }
+
+    #[test]
+    fn ailoop_enabled_adds_ailoop_line_with_base_path() {
+        let lines = startup_banner_lines("127.0.0.1", 3000, "embedded", false, true, "/hil", false);
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("ailoop     http://127.0.0.1:3000/hil")));
+    }
+
+    #[test]
+    fn always_ends_with_press_ctrl_c() {
+        let lines = startup_banner_lines(
+            "127.0.0.1",
+            3000,
+            "embedded",
+            false,
+            false,
+            "/ailoop",
+            false,
+        );
+        assert!(lines.iter().any(|l| l.contains("Press Ctrl+C to stop.")));
     }
 }

--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -38,6 +38,21 @@ fn validate_ailoop_path(p: &str) -> StdResult<(), AppError> {
     Ok(())
 }
 
+/// True when `host` resolves to a loopback interface (127.0.0.0/8, `::1`) or
+/// the `localhost` hostname. `--host` defaults to `127.0.0.1`; passing
+/// anything else is the operator's explicit opt-in to wider exposure (see
+/// spec 074 PR-6 / B5 — no separate `--allow-remote`-style flag is added).
+fn is_loopback_host(host: &str) -> bool {
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    if trimmed.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    trimmed
+        .parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
 fn ensure_no_ailoop_path_collision(ailoop_path: &str) -> StdResult<(), AppError> {
     for prefix in NEWTON_REST_ROUTE_PREFIXES {
         if ailoop_path == *prefix
@@ -80,6 +95,16 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     })?;
 
     info!("Starting Newton API server on {}: {}", args.host, args.port);
+
+    let non_loopback_bind = !is_loopback_host(&args.host);
+    if non_loopback_bind {
+        tracing::warn!(
+            event = "unauthenticated_exposure",
+            host = %args.host,
+            port = args.port,
+            "newton serve is binding a non-loopback host; the Newton HTTP API is UNAUTHENTICATED and will be reachable from other hosts on this interface"
+        );
+    }
 
     let workspace_paths = WorkspacePaths::from_cwd().map_err(|e| {
         AppError::new(
@@ -303,6 +328,18 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
         }
         if web_ui_mode == "disabled" {
             eprintln!("    (web UI disabled via --no-web)");
+        }
+        if non_loopback_bind {
+            eprintln!();
+            eprintln!("  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+            eprintln!(
+                "  !! WARNING: bound to non-loopback host \"{}\" — the Newton API is    !!",
+                args.host
+            );
+            eprintln!("  !! UNAUTHENTICATED and exposed to any host that can reach this    !!");
+            eprintln!("  !! interface. --host is your explicit opt-in; real authentication  !!");
+            eprintln!("  !! is not yet implemented (deferred to a future spec).             !!");
+            eprintln!("  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         }
         eprintln!("  Press Ctrl+C to stop.");
         eprintln!();

--- a/crates/cli/src/cli/commands/shared_execution.rs
+++ b/crates/cli/src/cli/commands/shared_execution.rs
@@ -95,6 +95,7 @@ pub async fn build_execution_setup(
         artifact_base_path: Some(artifacts),
         sink,
         pre_seed_nodes: true,
+        state_dir: Some(state_dir.clone()),
         ..Default::default()
     };
 

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3,6 +3,7 @@
 use crate::cli::args::{
     DotArgs, ExplainArgs, LintArgs, OutputFormat, ResumeArgs, RunArgs, ValidateArgs,
 };
+use crate::cli::exit::CliExit;
 use crate::cli::workspace_paths::{resolve_state_dir, state_checkpoints_dir};
 use newton_core::core::error::AppError;
 use newton_core::core::types::ErrorCategory;
@@ -18,20 +19,28 @@ use newton_core::workflow::{
 use serde_json::Value;
 use std::{fs, result::Result as StdResult};
 
+/// Emits the completion envelope, then either exits (via the returned error,
+/// mapped to `std::process::exit` only in `main.rs`) or returns the
+/// underlying `AppError` for normal (non `--emit-completion-json`) dispatch.
+///
+/// The envelope is always printed to stdout *before* the error is
+/// constructed, so a served invocation (MCP/chat) that turns the `Err` into
+/// an error frame instead of exiting still gets the same stdout envelope a
+/// direct CLI invocation would have seen before exiting.
 fn emit_or_return(
     emit_json: bool,
     envelope: CompletionEnvelope,
     err: AppError,
     exit_code: i32,
-) -> StdResult<(), AppError> {
+) -> anyhow::Result<()> {
     if emit_json {
         println!("{}", serde_json::to_string(&envelope).unwrap_or_default());
-        std::process::exit(exit_code);
+        return Err(CliExit::new(exit_code, err.to_string()).into());
     }
-    Err(err)
+    Err(err.into())
 }
 
-async fn execute_run_command(args: &RunArgs) -> StdResult<(), AppError> {
+async fn execute_run_command(args: &RunArgs) -> anyhow::Result<()> {
     let emit_json = args.emit_completion_json;
     let workflow_path = args.workflow.clone();
     let workspace = super::resolve_workflow_workspace(args.workspace.clone())?;
@@ -198,14 +207,14 @@ async fn execute_run_command(args: &RunArgs) -> StdResult<(), AppError> {
                 };
                 println!("{}", serde_json::to_string(&envelope).unwrap_or_default());
                 let exit_code = if is_workflow_failure { 2 } else { 1 };
-                std::process::exit(exit_code);
+                return Err(CliExit::new(exit_code, app_error.to_string()).into());
             }
-            Err(app_error)
+            Err(app_error.into())
         }
     }
 }
 
-pub async fn workflow_run(args: RunArgs) -> StdResult<(), AppError> {
+pub async fn workflow_run(args: RunArgs) -> anyhow::Result<()> {
     execute_run_command(&args).await
 }
 

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -98,7 +98,7 @@ async fn execute_run_command(args: &RunArgs) -> anyhow::Result<()> {
     let io_block = document.workflow.settings.io.clone();
 
     let exec_setup = super::shared_execution::build_execution_setup(
-        state_dir,
+        state_dir.clone(),
         args.parallel_limit,
         args.timeout_seconds,
         args.server.as_deref(),
@@ -110,7 +110,8 @@ async fn execute_run_command(args: &RunArgs) -> anyhow::Result<()> {
         newton_core::integrations::ailoop::init_context_for_command_name(&workspace, "run")
             .ok()
             .flatten();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, ailoop_ctx).await;
+    let registry =
+        super::build_operator_registry(workspace.clone(), &state_dir, &settings, ailoop_ctx).await;
 
     let summary_result = workflow_executor::execute_workflow(
         document,
@@ -331,7 +332,8 @@ pub async fn resume(args: ResumeArgs) -> StdResult<(), AppError> {
     let execution =
         checkpoint::load_execution_from_base(&state_checkpoints_dir(&state_dir), &args.run_id)?;
     let settings = execution.settings_effective.clone();
-    let registry = super::build_operator_registry(workspace.clone(), &settings, None).await;
+    let registry =
+        super::build_operator_registry(workspace.clone(), &state_dir, &settings, None).await;
     let summary = workflow_executor::resume_workflow(
         registry,
         workspace.clone(),

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -347,3 +347,127 @@ pub async fn resume(args: ResumeArgs) -> StdResult<(), AppError> {
     );
     Ok(())
 }
+
+/// In-process (no subprocess) coverage of `emit_or_return`'s two branches
+/// (spec 074, PR-1 / B3): non-`--emit-completion-json` invocations return a
+/// plain `Err`, not a `CliExit`; `--emit-completion-json` on an actual
+/// workflow-execution failure returns a `CliExit` with exit code 2. Calls
+/// `workflow_run` directly rather than spawning `newton` — mirrors the seam
+/// `mcp_data_malformed_call_no_exit.rs` and `data.rs`'s own in-crate tests
+/// use for the same "handler no longer calls `std::process::exit`" family of
+/// coverage. `test_e2e_io_contract.rs` (assert_cmd, subprocess) already pins
+/// the `--emit-completion-json` exit codes end-to-end; these are the
+/// same-crate complement for the `emit_json == false` branch that no
+/// existing `--emit-completion-json`-named test exercises.
+#[cfg(test)]
+mod emit_or_return_tests {
+    use super::*;
+
+    const MAX_INPUT_BYTES_YAML: &str = r#"
+version: "2.0"
+mode: workflow_graph
+workflow:
+  settings:
+    entry_task: start
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 1
+    max_workflow_iterations: 5
+    io_settings:
+      max_input_bytes: 1
+  tasks:
+    - id: start
+      operator: NoOpOperator
+      params: {}
+      terminal: success
+"#;
+
+    const FAILING_TASK_YAML: &str = r#"
+version: "2.0"
+mode: workflow_graph
+workflow:
+  settings:
+    entry_task: fail
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 1
+    max_workflow_iterations: 5
+    command_operator:
+      allow_shell: true
+  tasks:
+    - id: fail
+      operator: CommandOperator
+      params:
+        cmd: "false"
+        shell: true
+      terminal: success
+"#;
+
+    fn base_run_args(workflow: std::path::PathBuf, workspace: std::path::PathBuf) -> RunArgs {
+        RunArgs {
+            workflow,
+            input_file: None,
+            workspace: Some(workspace),
+            trigger: vec![],
+            context: vec![],
+            parameters_json: None,
+            emit_completion_json: false,
+            parallel_limit: None,
+            timeout_seconds: None,
+            verbose: false,
+            server: None,
+            state_dir: None,
+        }
+    }
+
+    /// Line 40 (`Err(err.into())`): without `--emit-completion-json`, a
+    /// `max_input_bytes` violation must surface as a plain error, NOT a
+    /// `CliExit` — only a direct-CLI-with-the-flag invocation gets the
+    /// stdout-envelope-then-CliExit treatment.
+    #[tokio::test]
+    async fn without_emit_json_max_input_bytes_violation_is_a_plain_error() {
+        let ws = tempfile::tempdir().expect("tempdir");
+        let wf_path = ws.path().join("wf.yaml");
+        std::fs::write(&wf_path, MAX_INPUT_BYTES_YAML).expect("write workflow");
+        let params_file = ws.path().join("params.json");
+        std::fs::write(&params_file, r#"{"repo":"my-repo"}"#).expect("write params");
+
+        let mut args = base_run_args(wf_path, ws.path().to_path_buf());
+        args.parameters_json = Some(params_file);
+        args.emit_completion_json = false;
+
+        let err = workflow_run(args)
+            .await
+            .expect_err("payload exceeding max_input_bytes must fail");
+        assert!(
+            err.downcast_ref::<CliExit>().is_none(),
+            "emit_json=false must not produce a CliExit; got: {err:?}"
+        );
+        assert!(err.to_string().contains("max_input_bytes"), "err={err}");
+    }
+
+    /// Line 211 (`return Err(CliExit::new(exit_code, ...))`): with
+    /// `--emit-completion-json`, an actual workflow execution failure
+    /// (WFG-EXEC-001, a task failing with `continue_on_error: false`) must
+    /// surface as a `CliExit` with exit code 2 (the `is_workflow_failure`
+    /// branch), after printing the JSON envelope to stdout.
+    #[tokio::test]
+    async fn emit_json_workflow_execution_failure_returns_cli_exit_code_2() {
+        let ws = tempfile::tempdir().expect("tempdir");
+        let wf_path = ws.path().join("wf.yaml");
+        std::fs::write(&wf_path, FAILING_TASK_YAML).expect("write workflow");
+
+        let mut args = base_run_args(wf_path, ws.path().to_path_buf());
+        args.emit_completion_json = true;
+
+        let err = workflow_run(args)
+            .await
+            .expect_err("a failing task must fail the run");
+        let exit = err
+            .downcast::<CliExit>()
+            .unwrap_or_else(|e| panic!("expected a CliExit, got: {e}"));
+        assert_eq!(exit.code, 2, "WFG-EXEC-001 is a workflow failure (exit 2)");
+    }
+}

--- a/crates/cli/src/cli/exit.rs
+++ b/crates/cli/src/cli/exit.rs
@@ -1,0 +1,80 @@
+//! Process-exit-code carrying error (spec 074, PR-1 / B3).
+//!
+//! Command handlers are reachable via three surfaces: a direct CLI
+//! invocation (`newton data ...`), `newton serve --with-mcp` (MCP tool
+//! calls), and the chat command surface. Only the first surface is a single
+//! short-lived process where an immediate `std::process::exit` is safe; the
+//! other two are long-running servers where one bad request must not take
+//! the whole process down.
+//!
+//! `CliExit` lets a handler express "this run must terminate the process
+//! with exit code N and this message" without calling `std::process::exit`
+//! itself. The handler returns `Err(CliExit::new(code, message).into())`,
+//! which flows through the framework's normal `anyhow::Result` dispatch:
+//!
+//! - Over MCP/chat, cli-framework's `tool_bridge` maps the `Err` to a
+//!   `BridgeError::Execution`, which `dispatch_tool_call` turns into a
+//!   structured `MCP_EXECUTION_FAILED` error frame — the server keeps
+//!   running and answers the next request.
+//! - For a direct CLI invocation, `main.rs` downcasts the top-level error;
+//!   if it is a `CliExit`, it prints `message` to stderr and calls
+//!   `std::process::exit(code)`, exactly reproducing the historical
+//!   behavior of the sites this type replaces.
+//!
+//! Only `crates/cli/src/main.rs` may act on a `CliExit` by exiting the
+//! process; every other crate/module must let it propagate as a normal
+//! error.
+use std::fmt;
+
+/// An error that carries the process exit code a direct CLI invocation
+/// should terminate with, without exiting the process itself.
+#[derive(Debug)]
+pub struct CliExit {
+    /// The exit code a direct CLI invocation should terminate with.
+    pub code: i32,
+    /// The message a direct CLI invocation should print to stderr before
+    /// exiting. Also the `Display`/error message seen by any other consumer
+    /// (e.g. an MCP error frame).
+    pub message: String,
+}
+
+impl CliExit {
+    /// Build a `CliExit` with the given exit code and message.
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for CliExit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CliExit {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_renders_message_only() {
+        let exit = CliExit::new(1, "DATA-001: boom");
+        assert_eq!(exit.to_string(), "DATA-001: boom");
+        assert_eq!(exit.code, 1);
+    }
+
+    #[test]
+    fn converts_into_anyhow_and_downcasts_back() {
+        let exit = CliExit::new(2, "some failure");
+        let err: anyhow::Error = exit.into();
+        let downcast = err
+            .downcast_ref::<CliExit>()
+            .expect("anyhow::Error must downcast back to CliExit");
+        assert_eq!(downcast.code, 2);
+        assert_eq!(downcast.message, "some failure");
+    }
+}

--- a/crates/cli/src/cli/framework_setup/commands/data.rs
+++ b/crates/cli/src/cli/framework_setup/commands/data.rs
@@ -106,6 +106,15 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             help: "Workspace root containing .newton/state/backend.sqlite",
             ..Default::default()
         },
+        ArgSpec {
+            name: "state-dir",
+            kind: ArgKind::Option,
+            long: Some("state-dir"),
+            value_type: ArgValueType::String,
+            cardinality: Cardinality::Optional,
+            help: "Override the state root directory where checkpoints, artifacts, and backend.sqlite are stored. Defaults to auto-resolved from workspace root.",
+            ..Default::default()
+        },
     ];
 
     if matches!(verb, DataVerb::Get) {

--- a/crates/cli/src/cli/framework_setup/commands/ops.rs
+++ b/crates/cli/src/cli/framework_setup/commands/ops.rs
@@ -6,6 +6,7 @@ use cli_framework::spec::arg_spec::{ArgKind, ArgSpec, ArgValueType, Cardinality}
 use cli_framework::spec::command_tree::CommandSpec;
 
 use crate::cli::categories;
+use crate::cli::exit::CliExit;
 use crate::cli::framework_setup::error_codes;
 use crate::cli::framework_setup::get_opt_path;
 use crate::cli::framework_setup::get_opt_str;
@@ -42,7 +43,7 @@ pub(crate) fn doctor_command() -> Command {
                 let report = ops::doctor::run(ops::doctor::DoctorArgs { workspace })?;
                 report.print();
                 if report.any_failed() {
-                    std::process::exit(1);
+                    return Err(CliExit::new(1, "doctor: one or more probes failed").into());
                 }
                 Ok(())
             })

--- a/crates/cli/src/cli/framework_setup/commands/workflow.rs
+++ b/crates/cli/src/cli/framework_setup/commands/workflow.rs
@@ -407,6 +407,7 @@ pub(crate) fn workflow_command() -> Command {
                                         workspace: get_opt_path(&args, "workspace"),
                                         last,
                                         json: get_bool(&args, "json"),
+                                        state_dir: get_opt_path(&args, "state-dir"),
                                     },
                                 };
                                 commands::log(dto).map_err(anyhow::Error::from)
@@ -433,6 +434,7 @@ pub(crate) fn workflow_command() -> Command {
                                         task: get_opt_str(&args, "task"),
                                         verbose: get_bool(&args, "verbose"),
                                         json: get_bool(&args, "json"),
+                                        state_dir: get_opt_path(&args, "state-dir"),
                                     },
                                 };
                                 commands::log(dto).map_err(anyhow::Error::from)

--- a/crates/cli/src/cli/framework_setup/commands/workflow.rs
+++ b/crates/cli/src/cli/framework_setup/commands/workflow.rs
@@ -453,7 +453,7 @@ pub(crate) fn workflow_command() -> Command {
                             }
                         }
                         let run_args = RunArgs::from_arg_value_map(&map);
-                        commands::workflow_run(run_args).await.map_err(anyhow::Error::from)
+                        commands::workflow_run(run_args).await
                     }
                     "import" => {
                         let import_args = ImportArgs {

--- a/crates/cli/src/cli/framework_setup/mod.rs
+++ b/crates/cli/src/cli/framework_setup/mod.rs
@@ -359,6 +359,7 @@ impl DataArgs {
                 .unwrap_or(false);
         let dry_run = get_bool(map, "dry-run");
         let workspace = get_opt_path(map, "workspace");
+        let state_dir = get_opt_path(map, "state-dir");
         let run_id = get_opt_str(map, "run-id");
         let kpi_id = get_opt_str(map, "kpi-id");
         let scope = get_opt_str(map, "scope");
@@ -388,6 +389,7 @@ impl DataArgs {
             json,
             dry_run,
             workspace,
+            state_dir,
             run_id,
             kpi_id,
             scope,

--- a/crates/cli/src/cli/mcp.rs
+++ b/crates/cli/src/cli/mcp.rs
@@ -132,7 +132,8 @@ pub async fn probe_bind(flags: &McpFlags) -> Result<(), std::io::Error> {
 }
 
 /// Run MCP mode using cli-framework's `serve_mcp` entry point. Returns the
-/// process exit code; callers `std::process::exit` on it.
+/// process exit code; the caller in `main.rs` terminates the process with it
+/// (the only place outside this MCP-mode short-circuit permitted to do so).
 pub async fn run(argv: Vec<String>, ctx: crate::cli::context::NewtonContext) -> i32 {
     let flags = parse_mcp_flags(&argv);
     let bind_address = format!("{}:{}", flags.host, flags.port);

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod args;
 pub mod categories;
 pub mod commands;
 pub mod context;
+pub mod exit;
 pub mod framework_setup;
 pub mod init;
 pub mod log_invocation;
@@ -11,6 +12,7 @@ pub mod ops;
 pub mod workspace_paths;
 
 pub use context::NewtonContext;
+pub use exit::CliExit;
 pub use framework_setup::build_app;
 pub use log_invocation::kind_for_command;
 pub use workspace_paths::WorkspacePaths;

--- a/crates/cli/src/cli/workspace_paths.rs
+++ b/crates/cli/src/cli/workspace_paths.rs
@@ -81,6 +81,26 @@ impl WorkspacePaths {
         self.workflows_dir.exists()
     }
 
+    /// Build paths from an explicit workspace root AND an explicit, already
+    /// resolved state root (the output of [`resolve_state_dir`]).
+    ///
+    /// This is the seam that keeps `workflow run`/`serve` (which already go
+    /// through `resolve_state_dir`) and secondary consumers — grading
+    /// operators, `data`, `runs` — reading and writing the *same* state tree
+    /// when `--state-dir` / `NEWTON_STATE_DIR` / `newton.toml` relocates it.
+    /// Only the state-bearing fields (`workflows_state_dir`, `backend_sqlite`,
+    /// `artifacts_dir`) are overridden; `configs_dir`, `monitor_conf`,
+    /// `plan_dir`, and `workflows_dir` stay anchored to `root` because they
+    /// are workspace configuration, not state.
+    pub fn with_state_dir(root: PathBuf, state_root: PathBuf) -> Self {
+        let mut paths = Self::new(root);
+        let state_root = make_absolute(state_root);
+        paths.backend_sqlite = state_backend_sqlite(&state_root);
+        paths.artifacts_dir = state_root.join("artifacts");
+        paths.workflows_state_dir = state_root;
+        paths
+    }
+
     /// Build paths from the process current working directory.
     /// Returns `Err` only if `current_dir()` fails (e.g. CWD was deleted).
     pub fn from_cwd() -> Result<Self> {
@@ -365,6 +385,42 @@ mod tests {
         assert!(url.starts_with("sqlite:"));
         assert!(url.ends_with("?mode=rwc"));
         assert!(url.contains("backend.sqlite"));
+    }
+
+    #[test]
+    fn test_with_state_dir_overrides_state_fields_only() {
+        let root = PathBuf::from("/tmp/test-newton-workspace-with-state-dir");
+        let state_root = PathBuf::from("/tmp/test-newton-state-override");
+        let paths = WorkspacePaths::with_state_dir(root.clone(), state_root.clone());
+
+        // State-bearing fields follow the override.
+        assert_eq!(paths.workflows_state_dir, state_root);
+        assert_eq!(paths.backend_sqlite, state_root.join("backend.sqlite"));
+        assert_eq!(paths.artifacts_dir, state_root.join("artifacts"));
+        assert!(paths
+            .backend_sqlite_url()
+            .contains("test-newton-state-override"));
+
+        // Non-state fields stay anchored to the workspace root.
+        let expected_root = make_absolute(root);
+        assert_eq!(paths.workspace_root, expected_root);
+        assert_eq!(paths.dot_newton, expected_root.join(".newton"));
+        assert_eq!(
+            paths.configs_dir,
+            expected_root.join(".newton").join("configs")
+        );
+        assert_eq!(
+            paths.monitor_conf,
+            expected_root
+                .join(".newton")
+                .join("configs")
+                .join("monitor.conf")
+        );
+        assert_eq!(paths.plan_dir, expected_root.join(".newton").join("plan"));
+        assert_eq!(
+            paths.workflows_dir,
+            expected_root.join(".newton").join("workflows")
+        );
     }
 
     #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod cli;
 
 pub use cli::context::NewtonContext;
+pub use cli::exit::CliExit;
 pub use cli::framework_setup::build_app;
 pub use cli::log_invocation::kind_for_command;
 pub use cli::ops;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use newton_cli::cli::context::NewtonContext;
+use newton_cli::cli::exit::CliExit;
 use newton_cli::cli::framework_setup::build_app;
 use newton_cli::cli::log_invocation::{kind_for_command, peek_command};
 use newton_cli::cli::mcp;
@@ -22,7 +23,23 @@ async fn main() -> Result<()> {
 
     let mut app = build_app(ctx)?;
 
-    app.run_with_args(app_args).await
+    // Extend the exit seam above: a handler that needs to terminate a direct
+    // CLI invocation with a specific exit code returns `Err(CliExit{..}.into())`
+    // instead of calling `std::process::exit` itself (spec 074, PR-1 / B3).
+    // That keeps the same `Err` safe to flow through `newton serve --with-mcp`
+    // (cli-framework turns it into an MCP error frame; the server keeps
+    // running) while still reproducing the historical CLI exit behavior here,
+    // the only place allowed to call `std::process::exit` outside `mcp::run`.
+    match app.run_with_args(app_args).await {
+        Ok(()) => Ok(()),
+        Err(e) => match e.downcast::<CliExit>() {
+            Ok(exit) => {
+                eprintln!("{}", exit.message);
+                std::process::exit(exit.code);
+            }
+            Err(e) => Err(e),
+        },
+    }
 }
 
 /// Strip `--log-dir <value>` / `--log-dir=<value>` from argv, preserving argv[0].

--- a/crates/cli/tests/integration/exit_codes_preserved.rs
+++ b/crates/cli/tests/integration/exit_codes_preserved.rs
@@ -1,0 +1,116 @@
+//! Spec 074, PR-1 / B3: converting handler `std::process::exit` call sites to
+//! `Err(CliExit{..}.into())` (mapped back to `std::process::exit` only in
+//! `main.rs`) must not change what a direct CLI invocation observes: same
+//! exit code, same stderr content. This file pins the exact exit codes for
+//! the two non-workflow files touched by the conversion (`data.rs`,
+//! `framework_setup/commands/ops.rs`); `test_e2e_io_contract.rs` already
+//! pins the workflow `--emit-completion-json` exit codes (0/1/2) exactly.
+#[path = "../support/mod.rs"]
+mod support;
+
+use support::newton;
+
+fn setup_workspace_with_db() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".newton/state")).unwrap();
+    dir
+}
+
+#[test]
+fn data_unknown_resource_exits_exactly_1() {
+    let dir = setup_workspace_with_db();
+    let out = newton()
+        .args([
+            "data",
+            "get",
+            "not-a-real-resource",
+            "--workspace",
+            &dir.path().to_string_lossy(),
+        ])
+        .output()
+        .expect("newton should execute");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "DATA-003 unknown resource must exit exactly 1"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("DATA-003"),
+        "stderr should mention DATA-003; got: {stderr}"
+    );
+}
+
+#[test]
+fn data_missing_id_exits_exactly_1() {
+    let dir = setup_workspace_with_db();
+    let out = newton()
+        .args([
+            "data",
+            "get",
+            "product",
+            "--workspace",
+            &dir.path().to_string_lossy(),
+        ])
+        .output()
+        .expect("newton should execute");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "DATA-002 missing id must exit exactly 1"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("DATA-002"),
+        "stderr should mention DATA-002; got: {stderr}"
+    );
+}
+
+#[test]
+fn data_invalid_json_body_exits_exactly_1() {
+    let dir = setup_workspace_with_db();
+    let out = newton()
+        .args([
+            "data",
+            "post",
+            "product",
+            "--workspace",
+            &dir.path().to_string_lossy(),
+            "--body",
+            "{not valid json",
+        ])
+        .output()
+        .expect("newton should execute");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "DATA-004 invalid JSON body must exit exactly 1"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("DATA-004"),
+        "stderr should mention DATA-004; got: {stderr}"
+    );
+}
+
+#[test]
+fn doctor_failing_probe_exits_exactly_1() {
+    // A workspace with no `.newton/` at all: `--workspace` makes the
+    // workspace probe actually FAIL (as opposed to the SKIP fallback used
+    // when no --workspace is given at all and cwd has no .newton either).
+    let dir = tempfile::tempdir().unwrap();
+    let out = newton()
+        .args(["doctor", "--workspace", &dir.path().to_string_lossy()])
+        .output()
+        .expect("newton should execute");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("FAIL"),
+        "expected at least one FAIL probe line; got: {stdout}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "doctor with a failing probe must exit exactly 1; stdout={stdout}"
+    );
+}

--- a/crates/cli/tests/integration/mcp_data_malformed_call_no_exit.rs
+++ b/crates/cli/tests/integration/mcp_data_malformed_call_no_exit.rs
@@ -1,0 +1,131 @@
+//! Spec 074, PR-1 / B3: a malformed `newton data` invocation dispatched over
+//! the MCP tool-call path must return a structured error frame, not exit the
+//! process. Handlers previously called `std::process::exit(1)` on validation
+//! failure (see `crates/cli/src/cli/commands/data.rs`); one bad tool call
+//! would have taken down the whole `newton serve --with-mcp` process.
+//!
+//! This test exercises the exact seam `newton serve --with-mcp` uses —
+//! `cli_framework::mcp::dispatch_tool_call` over the same `McpToolRegistry`
+//! Newton builds for MCP export (`build_mcp_command_registry`) — in-process.
+//! If a regression reintroduced `std::process::exit` on this path, this test
+//! process would be killed outright rather than merely failing an assertion,
+//! which is a strictly stronger signal than a subprocess exit-code check.
+//!
+//! Prior art: `mcp_tool_call_health.rs` (registry construction),
+//! `serve_with_mcp_responds.rs` (surface-level MCP reachability),
+//! `test_chat_error_codes.rs` (in-process tool dispatch against a real
+//! `McpToolRegistry`).
+use cli_framework::mcp::{
+    dispatch_tool_call, McpToolExportPolicy, McpToolRegistry, McpTransportKind,
+};
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Mirrors `test_e2e_data.rs::setup_workspace_with_db` — a workspace whose
+/// `.newton/state/` directory exists so `SqliteBackendStore::new` (which
+/// opens with `mode=rwc`) can create `backend.sqlite` and run migrations.
+fn setup_workspace_with_db() -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".newton/state")).unwrap();
+    dir
+}
+
+fn tool_registry() -> Arc<McpToolRegistry> {
+    let registry = newton_cli::cli::framework_setup::build_mcp_command_registry()
+        .expect("build_mcp_command_registry should succeed");
+    Arc::new(McpToolRegistry::from_command_registry_with_policy(
+        &registry,
+        "newton",
+        McpToolExportPolicy::ExposeMcpOnly,
+    ))
+}
+
+#[tokio::test]
+async fn malformed_data_call_returns_error_frame_and_server_keeps_serving() {
+    let ws = setup_workspace_with_db();
+    let registry = tool_registry();
+
+    // 1. Malformed call: `resource` is not one of the resources `newton data`
+    //    understands. This is exactly the DATA-003 validation path that used
+    //    to call `std::process::exit(1)` inside the handler
+    //    (crates/cli/src/cli/commands/data.rs).
+    let bad_args = json!({
+        "resource": "not-a-real-resource",
+        "workspace": ws.path().to_string_lossy(),
+    })
+    .as_object()
+    .cloned();
+
+    let bad_result = dispatch_tool_call(
+        &registry,
+        "newton_data_get",
+        bad_args,
+        McpTransportKind::Http,
+    )
+    .await;
+
+    let err = bad_result.expect_err("malformed data call must return an MCP error, not Ok");
+    assert!(
+        err.message.contains("DATA-003"),
+        "expected DATA-003 in MCP error frame message, got: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("MCP_EXECUTION_FAILED"),
+        "expected the standard MCP_EXECUTION_FAILED wrapper, got: {}",
+        err.message
+    );
+
+    // 2. The whole point of B3: this test process is still alive to make a
+    //    second call, and that second call succeeds normally. A handler that
+    //    still called `std::process::exit` would have killed this test
+    //    process on step 1 rather than merely failing the assertion above.
+    let good_args = json!({
+        "resource": "products",
+        "workspace": ws.path().to_string_lossy(),
+    })
+    .as_object()
+    .cloned();
+
+    let good_result = dispatch_tool_call(
+        &registry,
+        "newton_data_get",
+        good_args,
+        McpTransportKind::Http,
+    )
+    .await;
+
+    good_result.expect("subsequent well-formed call must still succeed after a bad call");
+}
+
+#[tokio::test]
+async fn malformed_data_call_missing_id_returns_error_frame() {
+    // A second malformed-call shape (DATA-002: missing required ID for a
+    // single-item GET) to prove the conversion covers more than one exit
+    // site, not just DATA-003.
+    let ws = setup_workspace_with_db();
+    let registry = tool_registry();
+
+    let bad_args = json!({
+        "resource": "product",
+        "workspace": ws.path().to_string_lossy(),
+    })
+    .as_object()
+    .cloned();
+
+    let bad_result = dispatch_tool_call(
+        &registry,
+        "newton_data_get",
+        bad_args,
+        McpTransportKind::Http,
+    )
+    .await;
+
+    let err = bad_result.expect_err("missing id for single-item GET must return an MCP error");
+    assert!(
+        err.message.contains("DATA-002"),
+        "expected DATA-002 in MCP error frame message, got: {}",
+        err.message
+    );
+}

--- a/crates/cli/tests/integration/serve_host_level.rs
+++ b/crates/cli/tests/integration/serve_host_level.rs
@@ -270,3 +270,80 @@ fn serve_prints_startup_banner_with_urls() {
         "REST API URL missing from banner; stderr=\n{stderr}"
     );
 }
+
+#[test]
+fn default_serve_binds_loopback_without_exposure_warning() {
+    use std::io::Read;
+    // Default `--host` (127.0.0.1) must NOT print the unauthenticated-exposure
+    // warning; only an explicit non-loopback `--host` is the opt-in for that.
+    let port = pick_free_port();
+    let dir = tempdir().unwrap();
+    let errpath = dir.path().join("stderr.log");
+    let errfile = std::fs::File::create(&errpath).unwrap();
+    let bin = assert_cmd::cargo::cargo_bin("newton");
+    let mut child = Command::new(bin)
+        .current_dir(dir.path())
+        .args(["serve", "--host", "127.0.0.1", "--port", &port.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(errfile))
+        .spawn()
+        .expect("spawn newton serve");
+
+    let ready = wait_ready(port);
+    std::thread::sleep(Duration::from_millis(250));
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(ready, "server did not become ready");
+
+    let mut stderr = String::new();
+    std::fs::File::open(&errpath)
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+
+    assert!(
+        !stderr.contains("UNAUTHENTICATED"),
+        "default loopback bind must not print the unauthenticated-exposure warning; stderr=\n{stderr}"
+    );
+}
+
+#[test]
+fn non_loopback_host_prints_unauthenticated_exposure_warning() {
+    use std::io::Read;
+    // `--host` itself is the explicit opt-in to non-loopback exposure (spec 074
+    // PR-6 / B5) — no separate flag. Binding non-loopback must print a loud
+    // stderr warning that the API is unauthenticated.
+    let port = pick_free_port();
+    let dir = tempdir().unwrap();
+    let errpath = dir.path().join("stderr.log");
+    let errfile = std::fs::File::create(&errpath).unwrap();
+    let bin = assert_cmd::cargo::cargo_bin("newton");
+    let mut child = Command::new(bin)
+        .current_dir(dir.path())
+        .args(["serve", "--host", "0.0.0.0", "--port", &port.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(errfile))
+        .spawn()
+        .expect("spawn newton serve");
+
+    let ready = wait_ready(port);
+    // The warning banner is printed just before the listener binds; give it a
+    // beat to flush, matching `serve_prints_startup_banner_with_urls`.
+    std::thread::sleep(Duration::from_millis(250));
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(ready, "server did not become ready");
+
+    let mut stderr = String::new();
+    std::fs::File::open(&errpath)
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+
+    // Keep this assertion to a stable substring so banner rewording doesn't
+    // break the test.
+    assert!(
+        stderr.contains("UNAUTHENTICATED"),
+        "non-loopback --host must print an unauthenticated-exposure warning; stderr=\n{stderr}"
+    );
+}

--- a/crates/cli/tests/integration/test_log_commands.rs
+++ b/crates/cli/tests/integration/test_log_commands.rs
@@ -119,6 +119,7 @@ fn log_list_last_zero_returns_log003() {
             workspace: Some(workspace.clone()),
             last: Some(0),
             json: false,
+            state_dir: None,
         },
     };
     let result = commands::log(args);
@@ -141,6 +142,7 @@ fn log_show_nonexistent_returns_log001() {
             task: None,
             verbose: false,
             json: false,
+            state_dir: None,
         },
     };
     let result = commands::log(args);
@@ -174,6 +176,7 @@ fn log_show_task_filter_no_match_returns_log002() {
             task: Some("nonexistent".to_string()),
             verbose: false,
             json: false,
+            state_dir: None,
         },
     };
     let result = commands::log(args);
@@ -206,6 +209,7 @@ fn log_list_two_executions_text_mode() {
             workspace: Some(workspace.clone()),
             last: None,
             json: false,
+            state_dir: None,
         },
     };
     // Just verify it succeeds (output goes to stdout).
@@ -237,6 +241,7 @@ fn log_list_with_last_limits_output() {
             workspace: Some(workspace.clone()),
             last: Some(2),
             json: false,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -261,6 +266,7 @@ fn log_list_json_has_required_keys() {
             workspace: Some(workspace.clone()),
             last: None,
             json: true,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -296,6 +302,7 @@ fn log_show_success_run_shows_task_sections() {
             task: None,
             verbose: false,
             json: false,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -330,6 +337,7 @@ fn log_show_task_filter_succeeds() {
             task: Some("fetch_data".to_string()),
             verbose: false,
             json: false,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -362,6 +370,7 @@ fn log_show_json_no_task_filter_key() {
             task: None,
             verbose: false,
             json: true,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -392,6 +401,7 @@ fn log_show_json_with_task_filter() {
             task: Some("task_a".to_string()),
             verbose: false,
             json: true,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -428,6 +438,7 @@ fn log_show_json_two_run_seqs_for_same_task_id() {
             task: Some("retry_task".to_string()),
             verbose: false,
             json: true,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -452,6 +463,7 @@ fn log_show_without_checkpoint_shows_fallback_notice() {
             task: None,
             verbose: false,
             json: false,
+            state_dir: None,
         },
     };
     assert!(commands::log(args).is_ok());
@@ -875,6 +887,7 @@ fn log_list_last_zero_via_internal_api() {
             workspace: Some(workspace.clone()),
             last: Some(0),
             json: false,
+            state_dir: None,
         },
     };
     let result = commands::log(args);

--- a/crates/cli/tests/integration/test_state_dir_one_root.rs
+++ b/crates/cli/tests/integration/test_state_dir_one_root.rs
@@ -1,0 +1,302 @@
+//! PR-2 · B4 — one state root (spec 074, tranche 1).
+//!
+//! `--state-dir` (and its NEWTON_STATE_DIR / newton.toml precedents) MUST
+//! relocate the durable store, checkpoints, and artifacts as one tree, so
+//! that the executor's DbSink, the grading operators, `newton data`, and
+//! `newton workflow runs` all read and write the SAME database. Before this
+//! fix three consumers hard-coded the workspace default and silently
+//! split-brained against any `--state-dir` override:
+//!   - grading operators (commands/mod.rs open_workspace_store)
+//!   - `newton data` (commands/data.rs)
+//!   - `newton workflow runs list`/`show` (commands/log.rs)
+//!
+//! These tests exercise the CLI seam end-to-end (prior art:
+//! tests/integration/test_data_post_grade_local_store.rs).
+
+#[path = "../support/mod.rs"]
+mod support;
+
+use serde_json::{json, Value};
+
+fn run_json(cmd: &mut assert_cmd::Command) -> Value {
+    let out = cmd.assert().success().get_output().stdout.clone();
+    serde_json::from_slice(&out).expect("stdout is valid JSON")
+}
+
+/// Grading workflow run with `--state-dir X`: backend.sqlite is created and
+/// written under X, the workspace-default location is never touched, and
+/// `newton data get ... --state-dir X` reads back what the run wrote.
+#[test]
+fn grading_run_with_state_dir_writes_isolated_store_and_data_reads_it_back() {
+    let ws = support::TempWorkspace::new();
+    let ws_path = ws.path().to_string_lossy().to_string();
+
+    let override_dir = tempfile::tempdir().expect("override state dir");
+    let override_path = override_dir.path().to_string_lossy().to_string();
+
+    // Seed the FK chain (product -> component -> repo) directly into the
+    // OVERRIDE store, via `data post --state-dir`, so the grading workflow's
+    // create_eval_run FK check (scope=repo, scope_id) resolves against the
+    // same database the run will use.
+    let product = run_json(support::newton().args([
+        "data",
+        "post",
+        "product",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--body",
+        r#"{"name":"Product SD"}"#,
+    ]));
+    let product_id = product["id"].as_str().expect("product id").to_string();
+
+    let component_body = json!({
+        "name": "Component SD",
+        "productId": product_id,
+        "domain": "backend",
+        "owner": "team-a",
+        "criticality": "high",
+        "autonomy": "full",
+        "lastEval": "2026-05-26T00:00:00Z"
+    });
+    let component = run_json(support::newton().args([
+        "data",
+        "post",
+        "component",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--body",
+        &component_body.to_string(),
+    ]));
+    let component_id = component["id"].as_str().expect("component id").to_string();
+
+    let repo_body = json!({
+        "name": "repo-sd",
+        "componentId": component_id,
+        "owner": "team-a",
+        "criticality": "high",
+        "autonomy": "full",
+        "qualityScore": 0,
+        "coverage": 0,
+        "secScore": 0,
+        "execStatus": "unknown",
+        "lastEval": "2026-05-26T00:00:00Z"
+    });
+    let repo = run_json(support::newton().args([
+        "data",
+        "post",
+        "repo",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--body",
+        &repo_body.to_string(),
+    ]));
+    let repo_id = repo["id"].as_str().expect("repo id").to_string();
+
+    // A single-task grading workflow using GraderCommandOperator, which
+    // registers only when a grading operators' backend store resolves —
+    // exercising the commands/mod.rs::open_state_store fix.
+    let workflow_yaml = r#"version: "2.0"
+mode: workflow_graph
+metadata:
+  name: "grading state-dir test"
+workflow:
+  settings:
+    entry_task: grade_repo
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 1
+    max_workflow_iterations: 10
+  tasks:
+    - id: grade_repo
+      operator: GraderCommandOperator
+      terminal: success
+      params:
+        grader: "state-dir-test-grader"
+        scope: "repo"
+        scope_id: "__REPO_ID__"
+        cmd: "printf '%s' '{\"overall_score\": 80, \"verdict\": \"approve\", \"summary\": \"ok\", \"scores\": [{\"dimension\": \"tests\", \"score\": 80}]}'"
+"#
+    .replace("__REPO_ID__", &repo_id);
+    let workflow_path = ws.write_workflow("grading_state_dir.yaml", &workflow_yaml);
+
+    support::newton()
+        .arg("workflow")
+        .arg("run")
+        .arg(&workflow_path)
+        .arg("--workspace")
+        .arg(&ws_path)
+        .arg("--state-dir")
+        .arg(&override_path)
+        .assert()
+        .success();
+
+    // Backend store landed under the override root...
+    let override_db = override_dir.path().join("backend.sqlite");
+    assert!(
+        override_db.exists(),
+        "expected backend.sqlite under override state dir at {}",
+        override_db.display()
+    );
+
+    // ...and the workspace-default state root was never created: the run
+    // and every `data post` above used --state-dir throughout, so if any
+    // consumer had silently fallen back to the workspace default it would
+    // have created this path as a side effect of opening it (sqlite
+    // mode=rwc creates the file on open).
+    let default_db = ws.path().join(".newton/state/backend.sqlite");
+    assert!(
+        !default_db.exists(),
+        "workspace-default backend.sqlite must not exist — the run must have used ONLY the \
+         override state dir, not split-brained against the workspace default: {}",
+        default_db.display()
+    );
+
+    // `newton data get grades --state-dir X` reads back what the grading
+    // operator wrote to X.
+    let grades = run_json(support::newton().args([
+        "data",
+        "get",
+        "grades",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--json",
+    ]));
+    let grades_arr = grades.as_array().expect("grades response is an array");
+    assert_eq!(
+        grades_arr.len(),
+        1,
+        "expected exactly one grade written by the grading run; got {grades:?}"
+    );
+    assert_eq!(grades_arr[0]["dimension"], "tests");
+    assert_eq!(grades_arr[0]["score"], 80.0);
+
+    // Same for eval-runs: the EvalRun the operator persisted is visible
+    // through `data get eval-runs --state-dir X`.
+    let eval_runs = run_json(support::newton().args([
+        "data",
+        "get",
+        "eval-runs",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--json",
+    ]));
+    let eval_runs_arr = eval_runs
+        .as_array()
+        .expect("eval-runs response is an array");
+    assert_eq!(eval_runs_arr.len(), 1);
+    assert_eq!(eval_runs_arr[0]["scopeId"], repo_id);
+    assert_eq!(eval_runs_arr[0]["score"], 80.0);
+}
+
+/// `newton workflow runs list` honors `--state-dir` the same way `run` does:
+/// a run executed with `--state-dir X` is visible via `runs list --state-dir
+/// X` and invisible via the workspace-default `runs list` (no split brain).
+#[test]
+fn runs_list_with_state_dir_sees_run_executed_with_state_dir() {
+    let ws = support::TempWorkspace::new();
+    let ws_path = ws.path().to_string_lossy().to_string();
+
+    let override_dir = tempfile::tempdir().expect("override state dir");
+    let override_path = override_dir.path().to_string_lossy().to_string();
+
+    let workflow_yaml = r#"version: "2.0"
+mode: workflow_graph
+metadata:
+  name: "runs list state-dir test"
+workflow:
+  settings:
+    entry_task: start
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 1
+    max_workflow_iterations: 10
+  tasks:
+    - id: start
+      operator: NoOpOperator
+      terminal: success
+      params: {}
+"#;
+    let workflow_path = ws.write_workflow("noop_state_dir.yaml", workflow_yaml);
+
+    let envelope = run_json(
+        support::newton()
+            .arg("workflow")
+            .arg("run")
+            .arg(&workflow_path)
+            .arg("--workspace")
+            .arg(&ws_path)
+            .arg("--state-dir")
+            .arg(&override_path)
+            .arg("--emit-completion-json"),
+    );
+    let execution_id = envelope["execution_id"]
+        .as_str()
+        .expect("completion envelope has execution_id")
+        .to_string();
+
+    // Visible with the same --state-dir override...
+    let listed = run_json(support::newton().args([
+        "workflow",
+        "runs",
+        "list",
+        "--workspace",
+        &ws_path,
+        "--state-dir",
+        &override_path,
+        "--json",
+    ]));
+    let listed_arr = listed.as_array().expect("runs list is an array");
+    assert!(
+        listed_arr.iter().any(|e| e["execution_id"] == execution_id),
+        "expected execution {execution_id} in --state-dir listing; got {listed_arr:?}"
+    );
+
+    // `runs show` also honors the override.
+    support::newton()
+        .args([
+            "workflow",
+            "runs",
+            "show",
+            "--run-id",
+            &execution_id,
+            "--workspace",
+            &ws_path,
+            "--state-dir",
+            &override_path,
+        ])
+        .assert()
+        .success();
+
+    // ...invisible from the workspace-default listing (no --state-dir): the
+    // run must not have split-brained into <ws>/.newton/state/workflows.
+    let default_listed = run_json(support::newton().args([
+        "workflow",
+        "runs",
+        "list",
+        "--workspace",
+        &ws_path,
+        "--json",
+    ]));
+    let default_arr = default_listed
+        .as_array()
+        .expect("default runs list is an array");
+    assert!(
+        !default_arr
+            .iter()
+            .any(|e| e["execution_id"] == execution_id),
+        "execution {execution_id} must NOT appear in the workspace-default runs list \
+         (would indicate the run split-brained into the default state dir)"
+    );
+}

--- a/crates/cli/tests/integration/test_workflow_scenarios.rs
+++ b/crates/cli/tests/integration/test_workflow_scenarios.rs
@@ -265,6 +265,7 @@ impl WorkflowTestHarness {
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
         )
         .await
@@ -1465,6 +1466,7 @@ async fn test_scenario_39_nested_depth_limit_enforced() {
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
         )
         .await
@@ -1861,6 +1863,7 @@ async fn test_scenario_47_gh_operator_branch_push() {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
     )
     .await

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -67,6 +67,9 @@ jsonschema = { workspace = true }
 schemars = { workspace = true }
 flate2 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 insta = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -188,6 +188,10 @@ name = "test_persistence_parity"
 path = "tests/integration/test_persistence_parity.rs"
 
 [[test]]
+name = "test_lag_tolerant_streams"
+path = "tests/integration/test_lag_tolerant_streams.rs"
+
+[[test]]
 name = "test_magic_tools"
 path = "tests/integration/test_magic_tools.rs"
 

--- a/crates/core/src/api/openapi.rs
+++ b/crates/core/src/api/openapi.rs
@@ -44,7 +44,6 @@ use utoipa::OpenApi;
         crate::api::persistence::get_persistence,
         crate::api::persistence::put_persistence,
         crate::api::persistence::delete_persistence,
-        crate::api::testing_reset::reset_testing,
         crate::api::workflow_files::list_workflow_files,
         crate::api::workflow_files::get_workflow_file,
         crate::api::workflow_files::put_workflow_file,
@@ -166,7 +165,6 @@ use utoipa::OpenApi;
         (name = "operators", description = "Operator catalog endpoint"),
         (name = "persistence", description = "Key-value persistence endpoints"),
         (name = "catalog", description = "Catalog entity CRUD endpoints"),
-        (name = "testing", description = "Test-only maintenance endpoints"),
         (name = "workflow-files", description = "Workflow definition file CRUD endpoints"),
         (name = "optimize", description = "Optimization loop run and cycle endpoints")
     ),

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -151,6 +151,12 @@ async fn handle_workflow_socket(
     filters: StreamFilters,
 ) {
     let mut rx = state.events_tx.subscribe();
+    // Not used again below: drop the AppState/Sender reference this task
+    // holds so the receive loop's `RecvError::Closed` arm is actually
+    // reachable once every *other* reference (router, other connections)
+    // also drops, instead of this task itself being the last one keeping
+    // the shared broadcast channel open forever.
+    drop(state);
 
     if let Ok(json) = serde_json::to_string(&BroadcastEvent::WorkflowInstanceUpdated {
         instance_id: instance_id.clone(),
@@ -256,6 +262,13 @@ async fn handle_logs_socket(
             }
         }
     }
+
+    // Not used again below: drop the AppState/Sender reference this task
+    // holds so the receive loop's `RecvError::Closed` arm is actually
+    // reachable once every *other* reference (router, other connections)
+    // also drops, instead of this task itself being the last one keeping
+    // the shared broadcast channel open forever.
+    drop(state);
 
     // Forward live broadcast events
     loop {

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -25,6 +25,16 @@ use uuid::Uuid;
 const HEARTBEAT_PING_INTERVAL: Duration = Duration::from_secs(30);
 const WELCOME_FRAME: &str = r#"{"type":"welcome"}"#;
 
+/// Builds the JSON payload sent to a stream consumer when the shared broadcast
+/// channel overflowed and this consumer missed `skipped` events. Same shape is
+/// used for both WS text frames and SSE `data:` payloads: `{"type":"lagged","skipped":<n>}`.
+/// The client should treat this as a signal to re-fetch a snapshot before
+/// resuming incremental updates (it is a per-connection condition, not a wire
+/// event from the engine, so it deliberately is not a `BroadcastEvent` variant).
+fn lagged_frame_json(skipped: u64) -> String {
+    serde_json::json!({"type": "lagged", "skipped": skipped}).to_string()
+}
+
 #[derive(Debug, Deserialize, Clone)]
 /// Optional query-string filters applied to workflow event streams.
 ///
@@ -150,13 +160,24 @@ async fn handle_workflow_socket(
         }
     }
 
-    while let Ok(event) = rx.recv().await {
-        if should_send_event(&event, &instance_id, &filters) {
-            if let Ok(json) = serde_json::to_string(&event) {
-                if socket.send(Message::Text(json.into())).await.is_err() {
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                if should_send_event(&event, &instance_id, &filters) {
+                    if let Ok(json) = serde_json::to_string(&event) {
+                        if socket.send(Message::Text(json.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                let frame = lagged_frame_json(n);
+                if socket.send(Message::Text(frame.into())).await.is_err() {
                     break;
                 }
             }
+            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }
@@ -237,22 +258,33 @@ async fn handle_logs_socket(
     }
 
     // Forward live broadcast events
-    while let Ok(event) = rx.recv().await {
-        if should_send_event(&event, &instance_id, &filters) {
-            if let BroadcastEvent::LogMessage {
-                instance_id: ref evt_inst,
-                node_id: ref evt_node,
-                ..
-            } = event
-            {
-                if evt_inst == &instance_id && evt_node == &node_id {
-                    if let Ok(json) = serde_json::to_string(&event) {
-                        if socket.send(Message::Text(json.into())).await.is_err() {
-                            break;
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                if should_send_event(&event, &instance_id, &filters) {
+                    if let BroadcastEvent::LogMessage {
+                        instance_id: ref evt_inst,
+                        node_id: ref evt_node,
+                        ..
+                    } = event
+                    {
+                        if evt_inst == &instance_id && evt_node == &node_id {
+                            if let Ok(json) = serde_json::to_string(&event) {
+                                if socket.send(Message::Text(json.into())).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
             }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                let frame = lagged_frame_json(n);
+                if socket.send(Message::Text(frame.into())).await.is_err() {
+                    break;
+                }
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }
@@ -315,12 +347,22 @@ async fn workflow_sse(
             yield Ok::<_, Infallible>(sse_event);
         }
         let mut rx = rx;
-        while let Ok(event) = rx.recv().await {
-            if should_send_event(&event, &id_clone, &filters_clone) {
-                if let Ok(json) = serde_json::to_string(&event) {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if should_send_event(&event, &id_clone, &filters_clone) {
+                        if let Ok(json) = serde_json::to_string(&event) {
+                            let sse_event = axum::response::sse::Event::default().data(json);
+                            yield Ok::<_, Infallible>(sse_event);
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    let json = lagged_frame_json(n);
                     let sse_event = axum::response::sse::Event::default().data(json);
                     yield Ok::<_, Infallible>(sse_event);
                 }
+                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
     };

--- a/crates/core/src/api/testing_reset.rs
+++ b/crates/core/src/api/testing_reset.rs
@@ -6,9 +6,14 @@ use axum::{
     routing::post,
     Router,
 };
-use newton_types::ApiError;
 use serde_json::json;
 use std::sync::Arc;
+
+/// Environment variable that must be set to `1` for `POST /testing/reset` to be
+/// reachable. Deliberately not documented in the OpenAPI surface (see
+/// `crates/core/src/api/openapi.rs`): this endpoint wipes the entire backend
+/// store and is intended only for test harnesses that explicitly opt in.
+const NEWTON_ENABLE_TESTING_RESET: &str = "NEWTON_ENABLE_TESTING_RESET";
 
 pub fn routes(state: Arc<AppState>) -> Router {
     Router::new()
@@ -16,23 +21,17 @@ pub fn routes(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
-#[utoipa::path(
-    post,
-    path = "/testing/reset",
-    tag = "testing",
-    responses(
-        (status = 200, description = "Reset result", body = serde_json::Value),
-        (status = 403, description = "Forbidden in production", body = ApiError),
-        (status = 500, description = "Internal error", body = ApiError)
-    )
-)]
+/// Wipes the entire backend store. Gated behind `NEWTON_ENABLE_TESTING_RESET=1`
+/// (absent or any other value ⇒ 403) and deliberately excluded from the
+/// generated OpenAPI document — this is a test-harness-only maintenance
+/// endpoint, not part of the public API surface.
 pub(crate) async fn reset_testing(State(state): State<Arc<AppState>>) -> Response {
-    if std::env::var("NEWTON_ENV").as_deref() == Ok("production") {
+    if std::env::var(NEWTON_ENABLE_TESTING_RESET).as_deref() != Ok("1") {
         return (
             StatusCode::FORBIDDEN,
-            Json(newton_backend::err_forbidden_in_prod(
-                "Testing reset is not available in production",
-            )),
+            Json(newton_backend::err_testing_reset_disabled(&format!(
+                "Testing reset is disabled; set {NEWTON_ENABLE_TESTING_RESET}=1 to enable this endpoint"
+            ))),
         )
             .into_response();
     }

--- a/crates/core/src/fs_util.rs
+++ b/crates/core/src/fs_util.rs
@@ -1,0 +1,171 @@
+//! Filesystem helpers shared across Newton's state-writing code paths.
+//!
+//! Newton persists several kinds of state to disk as it runs — workflow
+//! checkpoints, execution records, artifacts, and run completion envelopes —
+//! and a half-written file for any of them (from a crash or a full disk
+//! mid-write) is worse than a missing one: downstream tooling parses it as
+//! garbage instead of noticing the run failed. [`atomic_write`] is the single
+//! shared primitive all of those call sites use so that durability behavior
+//! cannot drift between copies (spec 074, PR-3 / "B1 + S1").
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Atomically writes `bytes` to `path`.
+///
+/// The sequence is: ensure the parent directory exists, write `bytes` to a
+/// temporary file in that SAME directory (so the final rename is a same-
+/// filesystem, same-directory rename and therefore atomic), `fsync` the
+/// temporary file so its contents are durable on disk, `rename` it over
+/// `path`, then — on unix — best-effort `fsync` the parent directory so the
+/// renamed directory entry itself survives a crash, not just the file's
+/// bytes.
+///
+/// A reader of `path` therefore only ever observes either the previous
+/// complete contents or the new complete contents; it can never observe a
+/// truncated or partially written file.
+///
+/// The parent-directory fsync is `#[cfg(unix)]` and best-effort (its result
+/// is not propagated) for two reasons: opening a directory with
+/// [`File::open`] and calling [`File::sync_all`] on it is not a portable
+/// operation — Windows does not support fsync-ing a directory handle this
+/// way — and on unix the extra step only closes a narrow crash window around
+/// the rename's directory-entry update, not the file-content durability
+/// guarantee above, which already holds on every platform once this function
+/// returns `Ok`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the parent directory cannot be created, the
+/// temporary file cannot be written or synced, or the rename fails (for
+/// example because the containing directory is not writable, or the target
+/// path is occupied by something the rename cannot replace).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let parent: &Path = match parent {
+        Some(p) => p,
+        None => Path::new("."),
+    };
+    fs::create_dir_all(parent)?;
+
+    let tmp_path = temp_path_for(path);
+
+    let write_result = write_temp_file(&tmp_path, bytes);
+    if let Err(err) = write_result {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+
+    if let Err(err) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+
+    fsync_parent_dir(parent);
+
+    Ok(())
+}
+
+fn write_temp_file(tmp_path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut file = File::create(tmp_path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
+}
+
+/// Deterministic temp-file name colocated with `path`, in the same
+/// directory, so the subsequent rename never crosses a filesystem boundary.
+fn temp_path_for(path: &Path) -> PathBuf {
+    path.with_extension("tmp")
+}
+
+#[cfg(unix)]
+fn fsync_parent_dir(parent: &Path) {
+    // Best-effort: failures here (e.g. a filesystem that rejects opening
+    // directories, or a permissions edge case) are deliberately swallowed.
+    // The file-content durability guarantee documented on `atomic_write`
+    // already holds without this step; it only narrows the crash window
+    // around the rename's directory-entry update.
+    if let Ok(dir) = File::open(parent) {
+        let _ = dir.sync_all();
+    }
+}
+
+#[cfg(not(unix))]
+fn fsync_parent_dir(_parent: &Path) {
+    // Opening a directory as a `File` purely to fsync it is not a portable
+    // operation: Windows' `CreateFileW` refuses directory handles unless
+    // `FILE_FLAG_BACKUP_SEMANTICS` is set, which `std::fs::File::open` does
+    // not set, so the call would simply fail every time. The rename above is
+    // still durable per the target platform's own filesystem guarantees;
+    // only the extra POSIX directory-entry durability margin is unavailable
+    // here, and it is not worth a platform-specific syscall shim for a
+    // best-effort step.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_write_then_read() {
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("state.json");
+
+        atomic_write(&target, b"hello world").expect("atomic_write should succeed");
+
+        let read_back = fs::read(&target).expect("read back written file");
+        assert_eq!(read_back, b"hello world");
+
+        // No leftover temp file.
+        assert!(!target.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn overwrite_existing_file_replaces_contents() {
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("state.json");
+
+        atomic_write(&target, b"first").expect("first write should succeed");
+        atomic_write(&target, b"second-and-longer").expect("second write should succeed");
+
+        let read_back = fs::read(&target).expect("read back written file");
+        assert_eq!(read_back, b"second-and-longer");
+    }
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("nested").join("deeper").join("state.json");
+
+        atomic_write(&target, b"payload").expect("should create parent dirs and write");
+
+        assert_eq!(fs::read(&target).unwrap(), b"payload");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn unwritable_directory_returns_err() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("state.json");
+
+        let mut perms = fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o500); // r-x: no write permission, so no new entries.
+        fs::set_permissions(dir.path(), perms).unwrap();
+
+        let result = atomic_write(&target, b"payload");
+
+        // Restore write permission so the tempdir can clean itself up.
+        let mut restore = fs::metadata(dir.path()).unwrap().permissions();
+        restore.set_mode(0o700);
+        fs::set_permissions(dir.path(), restore).unwrap();
+
+        assert!(
+            result.is_err(),
+            "writing into a read-only directory must fail, not silently succeed"
+        );
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Newton core library.
 pub mod api;
 pub mod core;
+pub mod fs_util;
 pub mod integrations;
 pub mod logging;
 pub mod utils;

--- a/crates/core/src/workflow/artifacts.rs
+++ b/crates/core/src/workflow/artifacts.rs
@@ -212,34 +212,18 @@ impl ArtifactStore {
     }
 }
 
+/// Durably persists `data` to `path` via the shared
+/// [`crate::fs_util::atomic_write`] helper (write-temp, fsync, rename, fsync
+/// parent dir), mapping any I/O failure into this module's [`AppError`]
+/// shape so callers keep the diagnostics they had before the write was
+/// consolidated into the shared helper.
 fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            AppError::new(
-                ErrorCategory::IoError,
-                format!("failed to create {}: {}", parent.display(), err),
-            )
-        })?;
-    }
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, data).map_err(|err| {
+    crate::fs_util::atomic_write(path, data).map_err(|err| {
         AppError::new(
             ErrorCategory::IoError,
-            format!("failed to write {}: {}", tmp.display(), err),
+            format!("failed to atomically write {}: {}", path.display(), err),
         )
-    })?;
-    fs::rename(&tmp, path).map_err(|err| {
-        AppError::new(
-            ErrorCategory::IoError,
-            format!(
-                "failed to rename {} -> {}: {}",
-                tmp.display(),
-                path.display(),
-                err
-            ),
-        )
-    })?;
-    Ok(())
+    })
 }
 
 struct ArtifactFile {

--- a/crates/core/src/workflow/artifacts.rs
+++ b/crates/core/src/workflow/artifacts.rs
@@ -278,3 +278,41 @@ fn internal_serialization_error(target: &str, err: serde_json::Error) -> AppErro
         format!("failed to serialize {target}: {err}"),
     )
 }
+
+#[cfg(test)]
+mod atomic_write_tests {
+    use super::*;
+
+    /// Mirrors `crate::fs_util::tests::unwritable_directory_returns_err`:
+    /// this module's `atomic_write` wraps the shared helper's `io::Error`
+    /// into this module's own `AppError` shape (spec 074, PR-3 / B1 + S1) —
+    /// exercise that mapping directly rather than only via the higher-level
+    /// artifact-persistence callers.
+    #[test]
+    #[cfg(unix)]
+    fn unwritable_directory_returns_app_error() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("artifact.json");
+
+        let mut perms = fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o500); // r-x: no write permission.
+        fs::set_permissions(dir.path(), perms).unwrap();
+
+        let result = atomic_write(&target, b"payload");
+
+        let mut restore = fs::metadata(dir.path()).unwrap().permissions();
+        restore.set_mode(0o700);
+        fs::set_permissions(dir.path(), restore).unwrap();
+
+        let err = result.expect_err("writing into a read-only directory must fail");
+        assert_eq!(err.category, ErrorCategory::IoError);
+        assert!(
+            err.message.contains("failed to atomically write"),
+            "err={}",
+            err.message
+        );
+    }
+}

--- a/crates/core/src/workflow/checkpoint.rs
+++ b/crates/core/src/workflow/checkpoint.rs
@@ -353,3 +353,41 @@ pub fn collect_live_artifact_paths_from_base(
     }
     Ok(live)
 }
+
+#[cfg(test)]
+mod atomic_write_tests {
+    use super::*;
+
+    /// Mirrors `crate::fs_util::tests::unwritable_directory_returns_err`:
+    /// this module's `atomic_write` wraps the shared helper's `io::Error`
+    /// into this module's own `AppError` shape (spec 074, PR-3 / B1 + S1) —
+    /// exercise that mapping directly rather than only via the higher-level
+    /// checkpoint-persistence callers.
+    #[test]
+    #[cfg(unix)]
+    fn unwritable_directory_returns_app_error() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("checkpoint.json");
+
+        let mut perms = fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o500); // r-x: no write permission.
+        fs::set_permissions(dir.path(), perms).unwrap();
+
+        let result = atomic_write(&target, b"payload");
+
+        let mut restore = fs::metadata(dir.path()).unwrap().permissions();
+        restore.set_mode(0o700);
+        fs::set_permissions(dir.path(), restore).unwrap();
+
+        let err = result.expect_err("writing into a read-only directory must fail");
+        assert_eq!(err.category, crate::core::types::ErrorCategory::IoError);
+        assert!(
+            err.message.contains("failed to atomically write"),
+            "err={}",
+            err.message
+        );
+    }
+}

--- a/crates/core/src/workflow/checkpoint.rs
+++ b/crates/core/src/workflow/checkpoint.rs
@@ -46,34 +46,18 @@ impl WorkflowStatePaths {
     }
 }
 
+/// Durably persists `data` to `path` via the shared
+/// [`crate::fs_util::atomic_write`] helper (write-temp, fsync, rename, fsync
+/// parent dir), mapping any I/O failure into this module's [`AppError`]
+/// shape so callers keep the diagnostics they had before the write was
+/// consolidated into the shared helper.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            AppError::new(
-                crate::core::types::ErrorCategory::IoError,
-                format!("failed to create directory {}: {}", parent.display(), err),
-            )
-        })?;
-    }
-    let tmp_path = path.with_extension("tmp");
-    fs::write(&tmp_path, data).map_err(|err| {
+    crate::fs_util::atomic_write(path, data).map_err(|err| {
         AppError::new(
             crate::core::types::ErrorCategory::IoError,
-            format!("failed to write {}: {}", tmp_path.display(), err),
+            format!("failed to atomically write {}: {}", path.display(), err),
         )
-    })?;
-    fs::rename(&tmp_path, path).map_err(|err| {
-        AppError::new(
-            crate::core::types::ErrorCategory::IoError,
-            format!(
-                "failed to rename {} -> {}: {}",
-                tmp_path.display(),
-                path.display(),
-                err
-            ),
-        )
-    })?;
-    Ok(())
+    })
 }
 
 pub fn save_execution(

--- a/crates/core/src/workflow/executor/runtime.rs
+++ b/crates/core/src/workflow/executor/runtime.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::result_large_err)]
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -410,9 +409,25 @@ impl WorkflowRuntime {
                         error_payload: None,
                     },
                 );
-                if let Ok(json) = serde_json::to_string_pretty(&failure_envelope) {
-                    let _ = fs::write(&completion_path, json);
-                }
+                let json = serde_json::to_string_pretty(&failure_envelope).map_err(|err| {
+                    AppError::new(
+                        ErrorCategory::SerializationError,
+                        format!("failed to serialize failure completion envelope: {err}"),
+                    )
+                    .with_context(format!("original run failure: {e}"))
+                })?;
+                crate::fs_util::atomic_write(&completion_path, json.as_bytes()).map_err(|err| {
+                    AppError::new(
+                        ErrorCategory::IoError,
+                        format!(
+                            "failed to persist failure completion envelope {}: {}",
+                            completion_path.display(),
+                            err
+                        ),
+                    )
+                    .with_code("WFG-COMPLETION-001")
+                    .with_context(format!("original run failure: {e}"))
+                })?;
             }
             return Err(e);
         }
@@ -495,9 +510,26 @@ impl WorkflowRuntime {
                 self.workflow_execution.execution_id,
                 result.clone(),
             );
-            if let Ok(json) = serde_json::to_string_pretty(&envelope) {
-                let _ = fs::write(&completion_path, json);
-            }
+            let json = serde_json::to_string_pretty(&envelope).map_err(|err| {
+                AppError::new(
+                    ErrorCategory::SerializationError,
+                    format!("failed to serialize success completion envelope: {err}"),
+                )
+            })?;
+            // A run whose result cannot be durably persisted must not be
+            // reported as succeeded: "succeeded" only ever means the result
+            // is actually on disk (spec 074, PR-3 / S1).
+            crate::fs_util::atomic_write(&completion_path, json.as_bytes()).map_err(|err| {
+                AppError::new(
+                    ErrorCategory::IoError,
+                    format!(
+                        "failed to persist success completion envelope {}: {}",
+                        completion_path.display(),
+                        err
+                    ),
+                )
+                .with_code("WFG-COMPLETION-001")
+            })?;
         }
 
         Ok(ExecutionSummary {

--- a/crates/core/src/workflow/executor/types.rs
+++ b/crates/core/src/workflow/executor/types.rs
@@ -21,6 +21,12 @@ pub struct ExecutionOverrides {
     pub verbose: bool,
     pub sink: Option<Arc<dyn WorkflowSink>>,
     pub pre_seed_nodes: bool,
+    /// Resolved state root, injected as `NEWTON_STATE_DIR` into operator
+    /// subprocess environments so child `newton` invocations (e.g. `newton
+    /// data get/post` shelled out from workflow YAML) resolve the same state
+    /// root as the in-process executor (spec 074 decision 2: one state
+    /// root).
+    pub state_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/core/src/workflow/file_store.rs
+++ b/crates/core/src/workflow/file_store.rs
@@ -133,33 +133,18 @@ fn system_time_to_datetime(t: SystemTime) -> DateTime<Utc> {
     DateTime::from_timestamp(duration.as_secs() as i64, duration.subsec_nanos()).unwrap_or_default()
 }
 
+/// Durably persists `data` to `path` via the shared
+/// [`crate::fs_util::atomic_write`] helper (write-temp, fsync, rename, fsync
+/// parent dir), mapping any I/O failure into this module's [`AppError`]
+/// shape so callers keep the diagnostics they had before the write was
+/// consolidated into the shared helper.
 fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| {
-            AppError::new(
-                ErrorCategory::IoError,
-                format!("failed to create directory {}: {e}", parent.display()),
-            )
-        })?;
-    }
-    let tmp_path = path.with_extension("tmp");
-    fs::write(&tmp_path, data).map_err(|e| {
+    crate::fs_util::atomic_write(path, data).map_err(|e| {
         AppError::new(
             ErrorCategory::IoError,
-            format!("failed to write {}: {e}", tmp_path.display()),
+            format!("failed to atomically write {}: {e}", path.display()),
         )
-    })?;
-    fs::rename(&tmp_path, path).map_err(|e| {
-        AppError::new(
-            ErrorCategory::IoError,
-            format!(
-                "failed to rename {} -> {}: {e}",
-                tmp_path.display(),
-                path.display()
-            ),
-        )
-    })?;
-    Ok(())
+    })
 }
 
 impl WorkflowFileStore for FsWorkflowFileStore {

--- a/crates/core/src/workflow/file_store.rs
+++ b/crates/core/src/workflow/file_store.rs
@@ -439,4 +439,36 @@ mod tests {
         let records = store.list().unwrap();
         assert!(records.is_empty());
     }
+
+    /// Mirrors `crate::fs_util::tests::unwritable_directory_returns_err`:
+    /// this module's `atomic_write` wraps the shared helper's `io::Error`
+    /// into this module's own `AppError` shape (spec 074, PR-3 / B1 + S1) —
+    /// exercise that mapping directly rather than only via the higher-level
+    /// workflow-file-persistence callers.
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_unwritable_directory_returns_app_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("flow.yaml");
+
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o500); // r-x: no write permission.
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+
+        let result = atomic_write(&target, b"payload");
+
+        let mut restore = std::fs::metadata(dir.path()).unwrap().permissions();
+        restore.set_mode(0o700);
+        std::fs::set_permissions(dir.path(), restore).unwrap();
+
+        let err = result.expect_err("writing into a read-only directory must fail");
+        assert_eq!(err.category, ErrorCategory::IoError);
+        assert!(
+            err.message.contains("failed to atomically write"),
+            "err={}",
+            err.message
+        );
+    }
 }

--- a/crates/core/src/workflow/operators/agent.rs
+++ b/crates/core/src/workflow/operators/agent.rs
@@ -139,7 +139,7 @@ impl Operator for AgentOperator {
 
         let eval_ctx = ctx.state_view.evaluation_context();
 
-        let interpolated_env = command::interpolate_env(&config.env, &eval_ctx)?;
+        let mut interpolated_env = command::interpolate_env(&config.env, &eval_ctx)?;
 
         let paths = artifacts::setup_artifact_paths(&self.workspace_root, &self.settings, &ctx)?;
 
@@ -173,6 +173,23 @@ impl Operator for AgentOperator {
                 engine_command: Some(&resolved_engine_command),
             };
             let invocation = driver.build_invocation(&driver_config, &self.workspace_root)?;
+
+            // Inject NEWTON_STATE_DIR only if neither the explicit workflow
+            // YAML `env` nor the driver-built invocation env already set it —
+            // explicit config always wins. `build_command` (command.rs)
+            // applies `invocation.env` first and `extra_env` second, so an
+            // unconditional insert here would silently override an explicit
+            // `invocation.env` entry.
+            if let Some(state_dir) = &ctx.execution_overrides.state_dir {
+                let already_set = interpolated_env.contains_key("NEWTON_STATE_DIR")
+                    || invocation.env.iter().any(|(k, _)| k == "NEWTON_STATE_DIR");
+                if !already_set {
+                    interpolated_env.insert(
+                        "NEWTON_STATE_DIR".to_string(),
+                        state_dir.display().to_string(),
+                    );
+                }
+            }
 
             let timeout_duration = config.timeout_seconds.map_or_else(
                 || Duration::from_secs(self.settings.max_time_seconds),

--- a/crates/core/src/workflow/operators/agent/command.rs
+++ b/crates/core/src/workflow/operators/agent/command.rs
@@ -23,6 +23,87 @@ use tokio::process::Command;
 pub(super) const OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1_048_576;
 const CMD_LOG_ARG_MAX_LEN: usize = 200;
 
+/// Group-wide kill guard for a spawned engine child, owned by the
+/// child-execution future (i.e. a plain local in `execute_single`'s async
+/// call chain, never detached via `tokio::spawn`).
+///
+/// Newton spawns engine children with `process_group(0)` (unix), making the
+/// child the leader of its own new process group. Grandchildren the child
+/// spawns (e.g. a background `sleep &`) inherit that group. `kill_on_drop`
+/// alone only reaps the *direct* child on drop — grandchildren are orphaned.
+/// This guard closes that gap: on `Drop`, while still armed, it sends
+/// `SIGKILL` to the whole process group via `killpg`, so it fires:
+///
+/// - when the operator's own `stream_and_process_output` timeout
+///   (`timeout_seconds`) returns early with an error (the guard, still
+///   armed, drops at the end of `execute_single`'s early return), and
+/// - when the *outer* per-task `timeout_ms` fires in
+///   `task_execution::execute_with_timeout`, which drops the whole operator
+///   future — including this guard's stack frame — without ever calling
+///   `Child::kill`.
+///
+/// Both paths converge on the same `Drop` impl, so the mechanism is
+/// cancellation-safe by construction: it does not depend on any code path
+/// explicitly running to completion.
+///
+/// Call [`ProcessGroupKillGuard::disarm`] only after `Child::wait()` has
+/// returned successfully (a "clean wait") — at that point the direct child
+/// is confirmed reaped and killing the group is no longer this guard's job.
+///
+/// Non-unix: `process_group`/`killpg` have no portable equivalent, so this
+/// is a documented no-op there; `kill_on_drop(true)` (set unconditionally in
+/// [`build_command`]) still reaps the direct child, but grandchildren can
+/// leak on non-unix platforms.
+struct ProcessGroupKillGuard {
+    #[cfg(unix)]
+    pgid: libc::pid_t,
+    #[cfg(unix)]
+    armed: bool,
+}
+
+impl ProcessGroupKillGuard {
+    /// `pid` is the freshly spawned child's pid. Because the child is
+    /// spawned with `process_group(0)`, it is its own process group leader,
+    /// so `pgid == pid`.
+    #[cfg(unix)]
+    fn new(pid: u32) -> Self {
+        Self {
+            pgid: pid as libc::pid_t,
+            armed: true,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn new(_pid: u32) -> Self {
+        Self {}
+    }
+
+    /// Disarm after a clean wait/exit so `Drop` becomes a no-op. Must not be
+    /// called before the direct child is confirmed reaped.
+    fn disarm(&mut self) {
+        #[cfg(unix)]
+        {
+            self.armed = false;
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ProcessGroupKillGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // SAFETY: plain FFI call with a pgid/signal pair, no pointers
+            // involved. If the group is already gone (process exited and was
+            // reaped, e.g. via the belt-and-braces `kill_on_drop`) `killpg`
+            // just returns ESRCH; cleanup here is intentionally best-effort
+            // and errors are not actionable in a `Drop` impl.
+            unsafe {
+                libc::killpg(self.pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
 /// Result from a single engine execution.
 pub(super) struct SingleExecResult {
     pub(super) signal: Option<String>,
@@ -88,6 +169,7 @@ async fn spawn_engine_process(
         tokio::process::Child,
         tokio::process::ChildStdout,
         tokio::task::JoinHandle<()>,
+        ProcessGroupKillGuard,
     ),
     AppError,
 > {
@@ -125,6 +207,12 @@ async fn spawn_engine_process(
         .with_code("WFG-AGENT-002")
     })?;
 
+    // Armed immediately after spawn, before any await point that could be
+    // cancelled by the outer per-task timeout. See `ProcessGroupKillGuard`
+    // docs for why this must be created here rather than deferred.
+    let kill_guard =
+        ProcessGroupKillGuard::new(child.id().expect("freshly spawned child must have a pid"));
+
     let stdout = child.stdout.take().expect("stdout must be piped");
     let stderr = child.stderr.take().expect("stderr must be piped");
 
@@ -139,7 +227,7 @@ async fn spawn_engine_process(
         }
     });
 
-    Ok((child, stdout, stderr_task))
+    Ok((child, stdout, stderr_task, kill_guard))
 }
 
 /// Stream and process stdout from the engine process.
@@ -248,13 +336,20 @@ async fn wait_for_process_completion(
 pub(super) async fn execute_single(params: &ExecParams<'_>) -> Result<SingleExecResult, AppError> {
     check_timeout_before_execution(params)?;
 
-    let (mut child, stdout, stderr_task) = spawn_engine_process(params).await?;
+    let (mut child, stdout, stderr_task, mut kill_guard) = spawn_engine_process(params).await?;
     let mut stdout_file = super::artifacts::open_stdout_artifact_file(params.paths.stdout_path)?;
 
+    // If either of the two calls below returns early (internal
+    // `timeout_seconds` expiry, or this whole future getting dropped because
+    // the outer per-task `timeout_ms` fired), `kill_guard` is still armed
+    // and its `Drop` sends SIGKILL to the process group.
     let streaming_result =
         stream_and_process_output(stdout, &mut stdout_file, &mut child, params).await?;
 
     let exit_code = wait_for_process_completion(child, stderr_task).await?;
+    // Clean wait: the direct child is confirmed reaped. Disarm so the guard's
+    // Drop at the end of this scope is a no-op.
+    kill_guard.disarm();
 
     Ok(SingleExecResult {
         signal: streaming_result.signal,
@@ -328,6 +423,17 @@ fn build_command(
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
 
+    // Belt-and-braces: reap the direct child if the `Child` handle itself is
+    // dropped without an explicit kill/wait. This alone does NOT reach
+    // grandchildren — that's `ProcessGroupKillGuard`'s job.
+    cmd.kill_on_drop(true);
+    // Make the child the leader of its own process group so grandchildren it
+    // spawns (e.g. `sleep 300 &`) share a group we can kill as a unit via
+    // `killpg`. Non-unix: no portable equivalent; grandchildren gap is
+    // documented on `ProcessGroupKillGuard`.
+    #[cfg(unix)]
+    cmd.process_group(0);
+
     for (k, v) in &invocation.env {
         cmd.env(k, v);
     }
@@ -348,6 +454,9 @@ mod tests {
     use serde_json::json;
     use serde_json::Value;
     use std::collections::HashMap;
+    #[cfg(unix)]
+    use std::path::Path;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     fn make_ctx(workspace: &TempDir) -> ExecutionContext {
@@ -679,5 +788,273 @@ fi"#,
         assert!(err.context.contains_key("stdout_artifact"));
         assert!(err.context.contains_key("engine"));
         assert!(err.context.contains_key("model"));
+    }
+
+    // ── B7: process-tree cleanup on timeout ──────────────────────────────
+    //
+    // Fixture: a shell script that backgrounds a `sleep 300` grandchild
+    // (writing its pid to a file so the test can find it), then loops
+    // forever appending a byte to a "heartbeat" file — the direct child's
+    // portable "still alive" signal. The script never exits on its own; each
+    // scenario below relies entirely on the kill-guard mechanism under test
+    // to end it.
+    //
+    // Two convergent kill paths are exercised separately, per the spec:
+    //   (a) the outer per-task `timeout_ms`, which drops the operator future
+    //       without ever calling `Child::kill` (`task_execution.rs:247`);
+    //   (b) the operator-internal `timeout_seconds`, which does call
+    //       `Child::kill` on the direct child only (`command.rs:215`).
+    // Both must leave the direct child AND the grandchild dead.
+
+    #[cfg(unix)]
+    fn grandchild_leak_script(heartbeat: &Path, grandchild_pid_file: &Path) -> String {
+        format!(
+            r#"( sleep 300 & echo $! > "{grandchild_pid}" )
+while true; do printf x >> "{heartbeat}"; sleep 0.02; done"#,
+            grandchild_pid = grandchild_pid_file.display(),
+            heartbeat = heartbeat.display(),
+        )
+    }
+
+    /// Polls `path`'s size until it stops growing for a full `quiet` window
+    /// (bounded by `max_wait`). This is the direct-child-dead check: it uses
+    /// only filesystem polling, no OS process APIs, so it is portable to any
+    /// platform even though the fixture script above is unix-only.
+    #[cfg(unix)]
+    async fn wait_for_heartbeat_to_stop(path: &Path, quiet: Duration, max_wait: Duration) -> bool {
+        let poll = Duration::from_millis(20);
+        let deadline = Instant::now() + max_wait;
+        let mut last_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        let mut quiet_since = Instant::now();
+        loop {
+            tokio::time::sleep(poll).await;
+            let size = std::fs::metadata(path)
+                .map(|m| m.len())
+                .unwrap_or(last_size);
+            if size != last_size {
+                last_size = size;
+                quiet_since = Instant::now();
+            } else if quiet_since.elapsed() >= quiet {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+        }
+    }
+
+    /// Polls for `path` to exist and be non-empty, bounded by `max_wait`.
+    #[cfg(unix)]
+    async fn wait_for_file_nonempty(path: &Path, max_wait: Duration) -> bool {
+        let poll = Duration::from_millis(20);
+        let deadline = Instant::now() + max_wait;
+        loop {
+            if std::fs::metadata(path)
+                .map(|m| m.len() > 0)
+                .unwrap_or(false)
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(poll).await;
+        }
+    }
+
+    #[cfg(unix)]
+    fn read_pid_file(path: &Path) -> libc::pid_t {
+        std::fs::read_to_string(path)
+            .expect("read pid file")
+            .trim()
+            .parse()
+            .expect("pid file contains a valid pid")
+    }
+
+    /// Grandchild-dead assertion: unix-only, per spec, since it relies on
+    /// `kill(pid, 0)` (a pure liveness probe — no signal is actually
+    /// delivered) to determine whether the process-group kill reached the
+    /// grandchild too.
+    #[cfg(unix)]
+    async fn wait_for_pid_death(pid: libc::pid_t, max_wait: Duration) -> bool {
+        let poll = Duration::from_millis(20);
+        let deadline = Instant::now() + max_wait;
+        loop {
+            // SAFETY: signal 0 touches no memory; it only probes whether the
+            // pid exists and is signalable by us.
+            let alive = unsafe { libc::kill(pid, 0) == 0 };
+            if !alive {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(poll).await;
+        }
+    }
+
+    /// Scenario (b): a small operator-internal `timeout_seconds` triggers the
+    /// existing direct-child `Child::kill` (command.rs:215-221) AND, via the
+    /// kill guard converging on the same `Drop`, a `killpg` that reaches the
+    /// grandchild too.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn execute_agent_timeout_seconds_kills_process_group() {
+        let tmp = TempDir::new().unwrap();
+        let heartbeat = tmp.path().join("heartbeat");
+        let grandchild_pid_file = tmp.path().join("grandchild.pid");
+        let script = grandchild_leak_script(&heartbeat, &grandchild_pid_file);
+
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["sh", "-c", script],
+            "timeout_seconds": 1,
+        });
+
+        let err = op.execute(params, ctx).await.unwrap_err();
+        assert_eq!(err.code, "WFG-AGENT-005");
+
+        assert!(
+            wait_for_file_nonempty(&grandchild_pid_file, Duration::from_secs(2)).await,
+            "grandchild pid file was never written"
+        );
+        let grandchild_pid = read_pid_file(&grandchild_pid_file);
+
+        assert!(
+            wait_for_heartbeat_to_stop(
+                &heartbeat,
+                Duration::from_millis(200),
+                Duration::from_secs(3)
+            )
+            .await,
+            "direct child kept writing to heartbeat after internal timeout; not killed"
+        );
+        assert!(
+            wait_for_pid_death(grandchild_pid, Duration::from_secs(3)).await,
+            "grandchild process survived the process-group kill (internal timeout path)"
+        );
+    }
+
+    /// Fast-success companion to the timeout scenarios: proves that arming
+    /// (and disarming) the kill guard on a normal completion has zero effect
+    /// on the operator's success behavior — a regression here would mean
+    /// dropping the guard after a clean wait still kills something.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn execute_fast_success_unaffected_by_kill_guard() {
+        let tmp = TempDir::new().unwrap();
+        let settings = WorkflowSettings::default();
+        let op = AgentOperator::with_default_registry(tmp.path().to_path_buf(), settings);
+        let ctx = make_ctx(&tmp);
+        let params = json!({
+            "engine": "command",
+            "engine_command": ["sh", "-c", "echo ok"],
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(result["signal"], json!("exited"));
+        assert_eq!(result["exit_code"], json!(0));
+    }
+
+    /// Scenario (a): a small task-level `timeout_ms` makes
+    /// `task_execution::execute_with_timeout` drop the whole operator future
+    /// without ever calling `Child::kill` — the outer future-drop path. The
+    /// kill guard living inside that dropped future's stack must still reach
+    /// the process group.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn task_level_timeout_ms_kills_process_group_via_future_drop() {
+        use crate::workflow::executor::ExecutionOverrides;
+        use crate::workflow::expression::ExpressionEngine;
+        use crate::workflow::operators::register_builtins;
+        use crate::workflow::schema::WorkflowTask;
+        use crate::workflow::task_execution::run_task;
+        use std::sync::Arc;
+
+        let tmp = TempDir::new().unwrap();
+        let heartbeat = tmp.path().join("heartbeat");
+        let grandchild_pid_file = tmp.path().join("grandchild.pid");
+        let script = grandchild_leak_script(&heartbeat, &grandchild_pid_file);
+
+        // Default max_time_seconds (3600) is far above timeout_ms below, so
+        // the operator's own internal timeout cannot be the thing that fires
+        // first — only the outer task-level timeout can.
+        let settings = WorkflowSettings::default();
+        let mut builder = OperatorRegistry::builder();
+        register_builtins(&mut builder, tmp.path().to_path_buf(), settings);
+        let registry = builder.build();
+
+        let task: WorkflowTask = serde_json::from_value(json!({
+            "id": "leaky",
+            "operator": "AgentOperator",
+            "params": {
+                "engine": "command",
+                "engine_command": ["sh", "-c", script],
+            },
+            "name": null,
+            "classes": [],
+            "timeout_ms": 200,
+            "retry": null,
+            "max_iterations": null,
+            "parallel_group": null,
+            "transitions": [],
+            "goal_gate": false,
+            "terminal": null
+        }))
+        .expect("construct WorkflowTask");
+
+        let outcome = run_task(
+            task,
+            registry,
+            Arc::new(ExpressionEngine::default()),
+            tmp.path().to_path_buf(),
+            StateView::new(json!({}), json!({}), json!({})),
+            "test-exec-b7".to_string(),
+            1,
+            Arc::new(Vec::new()),
+            GraphHandle::new(HashMap::new()),
+            tmp.path().join("workflow.yaml"),
+            0,
+            ExecutionOverrides {
+                parallel_limit: None,
+                max_time_seconds: None,
+                checkpoint_base_path: None,
+                artifact_base_path: None,
+                max_nesting_depth: None,
+                verbose: false,
+                sink: None,
+                pre_seed_nodes: true,
+            },
+        )
+        .await
+        .expect("run_task itself must not error");
+
+        assert!(
+            outcome.failed,
+            "expected timed-out task to be marked failed"
+        );
+        assert_eq!(outcome.record.error_code.as_deref(), Some("WFG-TIME-002"));
+
+        assert!(
+            wait_for_file_nonempty(&grandchild_pid_file, Duration::from_secs(2)).await,
+            "grandchild pid file was never written"
+        );
+        let grandchild_pid = read_pid_file(&grandchild_pid_file);
+
+        assert!(
+            wait_for_heartbeat_to_stop(
+                &heartbeat,
+                Duration::from_millis(200),
+                Duration::from_secs(3)
+            )
+            .await,
+            "direct child kept writing to heartbeat after outer timeout dropped the future"
+        );
+        assert!(
+            wait_for_pid_death(grandchild_pid, Duration::from_secs(3)).await,
+            "grandchild process survived the process-group kill (future-drop path)"
+        );
     }
 }

--- a/crates/core/src/workflow/operators/agent/command.rs
+++ b/crates/core/src/workflow/operators/agent/command.rs
@@ -316,9 +316,29 @@ async fn stream_and_process_output(
 }
 
 /// Wait for the process to complete and return the exit code.
+///
+/// Disarms `kill_guard` IMMEDIATELY after a successful `child.wait()` —
+/// before awaiting `stderr_task`. `stderr_task.await` is itself an await
+/// point; if it were reached while the guard was still armed, the *outer*
+/// per-task timeout could drop this whole future there, and the guard's
+/// `Drop` would `killpg()` a pgid whose leader was already reaped by the
+/// `child.wait()` above. If the rest of the group had also already exited,
+/// that pgid could have been recycled by the OS for an unrelated process
+/// group, which the drop would then SIGKILL.
+///
+/// Trade-off accepted deliberately: disarming here means a future-drop
+/// during the `stderr_task` await no longer group-kills any leftover
+/// grandchildren of *this* child. That window is narrow (stderr draining is
+/// just reading the pipe to EOF, which is fast once the process has already
+/// exited) and is judged acceptable in exchange for eliminating the
+/// kill-innocent-pgid risk described above.
+///
+/// On a failed `wait()` the child's process/group state is unknown, so the
+/// guard is deliberately left armed — its `Drop` remains the safety net.
 async fn wait_for_process_completion(
     mut child: tokio::process::Child,
     stderr_task: tokio::task::JoinHandle<()>,
+    kill_guard: &mut ProcessGroupKillGuard,
 ) -> Result<i32, AppError> {
     let exit_status = child.wait().await.map_err(|err| {
         AppError::new(
@@ -326,6 +346,10 @@ async fn wait_for_process_completion(
             format!("failed to wait for engine process: {err}"),
         )
     })?;
+
+    // Clean wait: the direct child is confirmed reaped. Disarm before the
+    // stderr await below so a drop during that await is a no-op.
+    kill_guard.disarm();
 
     let _ = stderr_task.await;
 
@@ -346,10 +370,11 @@ pub(super) async fn execute_single(params: &ExecParams<'_>) -> Result<SingleExec
     let streaming_result =
         stream_and_process_output(stdout, &mut stdout_file, &mut child, params).await?;
 
-    let exit_code = wait_for_process_completion(child, stderr_task).await?;
-    // Clean wait: the direct child is confirmed reaped. Disarm so the guard's
-    // Drop at the end of this scope is a no-op.
-    kill_guard.disarm();
+    // `wait_for_process_completion` disarms `kill_guard` itself, right after
+    // its internal `child.wait()` succeeds and before it awaits
+    // `stderr_task` — see that function's doc comment for why the disarm
+    // can't be deferred to here.
+    let exit_code = wait_for_process_completion(child, stderr_task, &mut kill_guard).await?;
 
     Ok(SingleExecResult {
         signal: streaming_result.signal,
@@ -478,6 +503,7 @@ mod tests {
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
             operator_registry: OperatorRegistry::new(),
         }
@@ -1026,6 +1052,7 @@ while true; do printf x >> "{heartbeat}"; sleep 0.02; done"#,
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
         )
         .await

--- a/crates/core/src/workflow/operators/command.rs
+++ b/crates/core/src/workflow/operators/command.rs
@@ -95,7 +95,7 @@ impl Operator for CommandOperator {
         schemars::schema_for!(CommandOutput)
     }
 
-    async fn execute(&self, params: Value, _ctx: ExecutionContext) -> Result<Value, AppError> {
+    async fn execute(&self, params: Value, ctx: ExecutionContext) -> Result<Value, AppError> {
         let parsed: CommandParams = serde_json::from_value(params.clone()).map_err(|e| {
             AppError::new(
                 ErrorCategory::ValidationError,
@@ -116,13 +116,34 @@ impl Operator for CommandOperator {
             "executing command"
         );
 
+        // Start from the resolved state root (if any) so child `newton`
+        // invocations shelled out by this command resolve the same state
+        // root as the in-process executor (spec 074 decision 2). Explicit
+        // `env` set in the workflow YAML always wins, so overlay it second.
+        let env = match (&ctx.execution_overrides.state_dir, &parsed.env) {
+            (None, None) => None,
+            (state_dir, explicit) => {
+                let mut merged = HashMap::new();
+                if let Some(state_dir) = state_dir {
+                    merged.insert(
+                        "NEWTON_STATE_DIR".to_string(),
+                        state_dir.display().to_string(),
+                    );
+                }
+                if let Some(explicit) = explicit {
+                    merged.extend(explicit.clone());
+                }
+                Some(merged)
+            }
+        };
+
         let start = Instant::now();
         let output = self
             .runner
             .run(&CommandExecutionRequest {
                 cmd: parsed.cmd.clone(),
                 cwd: resolved_cwd,
-                env: parsed.env.clone(),
+                env,
                 capture_stdout: parsed.capture_stdout,
                 capture_stderr: parsed.capture_stderr,
                 shell: parsed.shell,
@@ -320,4 +341,85 @@ pub struct CommandOutput {
 fn limit_bytes(bytes: &[u8]) -> String {
     let limit = OUTPUT_CAPTURE_LIMIT_BYTES.min(bytes.len());
     String::from_utf8_lossy(&bytes[..limit]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::executor::GraphHandle;
+    use crate::workflow::operator::{OperatorRegistry, StateView};
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn make_ctx(state_dir: Option<PathBuf>, workspace: &TempDir) -> ExecutionContext {
+        ExecutionContext {
+            workspace_path: workspace.path().to_path_buf(),
+            execution_id: "test-exec-cmd-001".to_string(),
+            task_id: "cmd".to_string(),
+            iteration: 1,
+            state_view: StateView::new(json!({}), json!({}), json!({})),
+            graph: GraphHandle::new(HashMap::new()),
+            workflow_file: workspace.path().join("workflow.yaml"),
+            nesting_depth: 0,
+            execution_overrides: crate::workflow::executor::ExecutionOverrides {
+                parallel_limit: None,
+                max_time_seconds: None,
+                checkpoint_base_path: None,
+                artifact_base_path: None,
+                max_nesting_depth: None,
+                verbose: false,
+                sink: None,
+                pre_seed_nodes: true,
+                state_dir,
+            },
+            operator_registry: OperatorRegistry::new(),
+        }
+    }
+
+    // ── Fix 2: NEWTON_STATE_DIR propagation to CommandOperator subprocesses ──
+
+    #[tokio::test]
+    async fn execute_injects_newton_state_dir_from_overrides() {
+        let workspace = TempDir::new().unwrap();
+        let state_dir = TempDir::new().unwrap();
+        let op = CommandOperator::new(workspace.path().to_path_buf());
+        let ctx = make_ctx(Some(state_dir.path().to_path_buf()), &workspace);
+        let params = json!({
+            "cmd": "printf '%s' \"$NEWTON_STATE_DIR\"",
+            "shell": true,
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(
+            result["stdout"],
+            json!(state_dir.path().display().to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_explicit_env_wins_over_newton_state_dir_override() {
+        let workspace = TempDir::new().unwrap();
+        let state_dir = TempDir::new().unwrap();
+        let op = CommandOperator::new(workspace.path().to_path_buf());
+        let ctx = make_ctx(Some(state_dir.path().to_path_buf()), &workspace);
+        let params = json!({
+            "cmd": "printf '%s' \"$NEWTON_STATE_DIR\"",
+            "shell": true,
+            "env": { "NEWTON_STATE_DIR": "/explicit" }
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(result["stdout"], json!("/explicit"));
+    }
+
+    #[tokio::test]
+    async fn execute_no_overrides_state_dir_leaves_var_absent() {
+        let workspace = TempDir::new().unwrap();
+        let op = CommandOperator::new(workspace.path().to_path_buf());
+        let ctx = make_ctx(None, &workspace);
+        let params = json!({
+            "cmd": "printf '%s' \"${NEWTON_STATE_DIR:-unset}\"",
+            "shell": true,
+        });
+        let result = op.execute(params, ctx).await.unwrap();
+        assert_eq!(result["stdout"], json!("unset"));
+    }
 }

--- a/crates/core/src/workflow/operators/reconcile.rs
+++ b/crates/core/src/workflow/operators/reconcile.rs
@@ -345,6 +345,13 @@ impl Operator for ReconcileOperator {
             })
             .collect();
 
+        // NOTE (Fuzziness is not failure tolerance — CONTEXT.md "Reconciliation"):
+        // the fuzzy-optimizer tolerance below covers Observation<->Finding
+        // mis-matches, not a Reconciliation running without its semantic-matching
+        // half. If adjudication itself fails, we must `?` out of `execute` here,
+        // BEFORE any store mutation (Phase 1/2/3 below), so that a transient LLM
+        // outage can never create duplicate Findings or wrongly auto-resolve real
+        // ones (including `blocked` Findings, which only a human may clear).
         let adj_plan: Option<AdjudicationPlan> = if !unmatched_owned.is_empty()
             && !candidates_owned.is_empty()
         {
@@ -374,7 +381,7 @@ impl Operator for ReconcileOperator {
             let obs_str = serde_json::to_string_pretty(&obs_json).unwrap_or_default();
             let findings_str = serde_json::to_string_pretty(&findings_json).unwrap_or_default();
 
-            let result = tokio::task::spawn_blocking(move || {
+            let join_result = tokio::task::spawn_blocking(move || {
                 let template = "You are a semantic matching agent. Your job is ONLY to judge whether observations from a grader run match existing findings by meaning — not to evaluate quality or add new analysis.\n\n## Unmatched observations (this run)\n{{observations}}\n\n## Candidate open findings (existing)\n{{findings}}\n\n## Task\nFor each observation, decide:\n- Does it semantically describe the same issue as an existing finding? If so, record the match.\n- Is it genuinely new? Record its index in `new`.\n- Are any candidate findings NOT covered by any observation (resolved)? Record their IDs in `resolved`.\n\nReturn a JSON object matching the schema. Keep temperature low — judge sameness strictly.";
 
                 let runner = aikit_sdk::AgentRunner::new()
@@ -391,18 +398,40 @@ impl Operator for ReconcileOperator {
                     .max_retries(1);
 
                 match pipeline.run(&[("observations", &obs_str), ("findings", &findings_str)], runner) {
-                    Ok(pr) => serde_json::from_value::<AdjudicationPlan>(pr.data).ok(),
-                    Err(e) => {
-                        tracing::warn!(
-                            "ReconcileOperator: LLM adjudication failed, treating unmatched as new: {e}"
-                        );
-                        None
-                    }
+                    Ok(pr) => serde_json::from_value::<AdjudicationPlan>(pr.data)
+                        .map_err(|e| format!("failed to parse adjudication plan: {e}")),
+                    Err(e) => Err(format!("LLM adjudication failed: {e}")),
                 }
             })
-            .await
-            .unwrap_or(None);
-            result
+            .await;
+
+            // Adjudication failure (LLM error, unparseable plan, or a panicked
+            // blocking task) fails the whole operator BEFORE any store mutation —
+            // see the "Fuzziness is not failure tolerance" note above. This is
+            // NOT a ValidationError (which task_execution::is_retryable treats as
+            // hard-non-retryable): it is a ToolExecutionError so the normal
+            // transient-failure retry/backoff applies, and only a persistent
+            // failure fails the task/cycle.
+            let plan = match join_result {
+                Ok(Ok(plan)) => plan,
+                Ok(Err(msg)) => {
+                    return Err(AppError::new(
+                        ErrorCategory::ToolExecutionError,
+                        format!("ReconcileOperator: adjudication failed: {msg}"),
+                    )
+                    .with_code("WFG-RECONCILE-ADJ-001"));
+                }
+                Err(join_err) => {
+                    return Err(AppError::new(
+                        ErrorCategory::ToolExecutionError,
+                        format!(
+                            "ReconcileOperator: adjudication task did not complete: {join_err}"
+                        ),
+                    )
+                    .with_code("WFG-RECONCILE-ADJ-001"));
+                }
+            };
+            Some(plan)
         } else {
             None
         };
@@ -637,7 +666,7 @@ mod tests {
     use super::*;
     use crate::workflow::executor::{ExecutionOverrides, GraphHandle};
     use crate::workflow::operator::{OperatorRegistry, StateView};
-    use newton_backend::{BackendStore, SqliteBackendStore};
+    use newton_backend::{BackendStore, PatchFindingBody, SqliteBackendStore};
     use serde_json::json;
 
     fn make_ctx() -> crate::workflow::operator::ExecutionContext {
@@ -840,6 +869,141 @@ mod tests {
             findings.len(),
             2,
             "both findings must be stored and retrievable"
+        );
+    }
+
+    /// PR-4 / B2 — "Reconciliation fails closed". When the LLM adjudicator
+    /// fails, `execute` must return an `Err` with code `WFG-RECONCILE-ADJ-001`
+    /// and must not mutate the Finding store at all: no new Findings, no
+    /// `resolved` transitions, and `blocked` Findings must be left completely
+    /// untouched (they are cleared only by a human — CONTEXT.md "Finding").
+    ///
+    /// The adjudicator is forced to fail deterministically and without any
+    /// subprocess/network I/O by passing an `engine` name that is not in
+    /// aikit-sdk's runnable-agent allow-list (`codex|claude|gemini|opencode|
+    /// agent|aikit`); `AgentRunner`/`Pipeline::run` fails fast with
+    /// `RunError::AgentNotRunnable` before spawning anything — the same seam
+    /// `AgentOperator`'s `execute_non_runnable_ai_engine_returns_sdk_002` test
+    /// uses.
+    #[tokio::test]
+    async fn adjudication_failure_fails_closed_with_zero_mutations() {
+        let store: Arc<dyn BackendStore> =
+            Arc::new(SqliteBackendStore::new_in_memory().await.unwrap());
+        let op = ReconcileOperator::new(std::path::PathBuf::from("/tmp"), store.clone());
+
+        // Seed run: no existing findings yet, so no adjudication candidates exist
+        // and this call succeeds without needing any LLM call at all.
+        //   - F1 (location-based "tests" observation): will get a stable fp and
+        //     is later flipped to `blocked` to prove blocked Findings survive.
+        //   - F2 (location-less "security" observation): location-less
+        //     observations never match deterministically, so a repeat run always
+        //     routes them to the LLM adjudicator.
+        let seed_assessment = make_assessment(vec![
+            make_obs("tests", "Coverage is below threshold", Some("src/main.rs")),
+            make_obs("security", "Dependency has known CVE", None),
+        ]);
+        let seed_params = json!({
+            "scope": "module",
+            "scope_id": "mod-adj-001",
+            "grader": "adj-grader",
+            "assessment": seed_assessment,
+        });
+        let seed_result = op.execute(seed_params, make_ctx()).await.unwrap();
+        assert_eq!(seed_result["created"], 2, "seed run creates both findings");
+
+        let seeded = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-adj-001".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(seeded.len(), 2);
+        let f1_id = seeded
+            .iter()
+            .find(|f| f.dimension == "tests")
+            .unwrap()
+            .id
+            .clone();
+
+        // Simulate the loop having auto-blocked F1 (a Plan implementing it
+        // failed develop after the retry budget) — only a human may clear this.
+        store
+            .patch_finding(
+                &f1_id,
+                PatchFindingBody {
+                    status: Some("blocked".to_string()),
+                    last_seen_at: None,
+                    expected_value: None,
+                    effort: None,
+                    risk: None,
+                    blocked_by_plan_id: Some("plan-x".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let before = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-adj-001".to_string()),
+            )
+            .await
+            .unwrap();
+        let before_json: Vec<serde_json::Value> = before
+            .iter()
+            .map(|f| serde_json::to_value(f).unwrap())
+            .collect();
+
+        // Second run: repeats the location-less "security" observation (F2 is
+        // therefore an open, unmatched adjudication candidate) with an engine
+        // that aikit-sdk refuses to run — this must trigger adjudication and
+        // fail it before any Phase 1/2/3 store mutation runs.
+        let rerun_assessment =
+            make_assessment(vec![make_obs("security", "Dependency has known CVE", None)]);
+        let rerun_params = json!({
+            "scope": "module",
+            "scope_id": "mod-adj-001",
+            "grader": "adj-grader",
+            "assessment": rerun_assessment,
+            "engine": "not-a-real-agent",
+        });
+
+        let err = op
+            .execute(rerun_params, make_ctx())
+            .await
+            .expect_err("adjudication failure must fail the operator");
+        assert_eq!(err.code, "WFG-RECONCILE-ADJ-001");
+        assert_eq!(err.category, ErrorCategory::ToolExecutionError);
+
+        let after = store
+            .list_findings(
+                None,
+                Some("module".to_string()),
+                Some("mod-adj-001".to_string()),
+            )
+            .await
+            .unwrap();
+        let after_json: Vec<serde_json::Value> = after
+            .iter()
+            .map(|f| serde_json::to_value(f).unwrap())
+            .collect();
+
+        assert_eq!(
+            after.len(),
+            2,
+            "no Finding may be created or removed on the failure path"
+        );
+        assert_eq!(
+            before_json, after_json,
+            "Finding store must be byte-identical before/after a failed adjudication"
+        );
+        let f1_after = after.iter().find(|f| f.id == f1_id).unwrap();
+        assert_eq!(
+            f1_after.status, "blocked",
+            "blocked Findings must be untouched by the failure path"
         );
     }
 }

--- a/crates/core/src/workflow/operators/reconcile.rs
+++ b/crates/core/src/workflow/operators/reconcile.rs
@@ -688,6 +688,7 @@ mod tests {
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
             operator_registry: OperatorRegistry::new(),
         }

--- a/crates/core/src/workflow/operators/workflow.rs
+++ b/crates/core/src/workflow/operators/workflow.rs
@@ -266,6 +266,7 @@ mod tests {
                 verbose: false,
                 sink: None,
                 pre_seed_nodes: true,
+                state_dir: None,
             },
             operator_registry: crate::workflow::operator::OperatorRegistry::new(),
         }

--- a/crates/core/src/workflow/task_execution.rs
+++ b/crates/core/src/workflow/task_execution.rs
@@ -486,6 +486,27 @@ mod retry_classification_tests {
         assert!(is_retryable(&e));
     }
 
+    /// Pins retryability for ReconcileOperator's adjudication-failure code
+    /// (spec 074 PR-4 / B2 — "Reconciliation fails closed"). Today this passes
+    /// only because unknown codes default to retryable (see
+    /// `unknown_codes_default_to_retryable` above); it is deliberately its own
+    /// test — not folded into that one — so that when tranche-2's S14 flips the
+    /// unknown-code default to non-retryable, `WFG-RECONCILE-ADJ-001` must be
+    /// added to an explicit "transient" allow-list rather than silently
+    /// regressing to non-retryable. A transient LLM adjudication outage must
+    /// keep retrying with backoff, per CONTEXT.md's "Fuzziness is not failure
+    /// tolerance" — it must NOT be treated as hard-non-retryable the way
+    /// `ValidationError` is.
+    #[test]
+    fn reconcile_adjudication_failure_is_retryable() {
+        let e = err(
+            ErrorCategory::ToolExecutionError,
+            "WFG-RECONCILE-ADJ-001",
+            "adjudication failed",
+        );
+        assert!(is_retryable(&e));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn backoff_clamped_to_max() {
         let mut state = RetryState {

--- a/crates/core/tests/integration/test_human_ailoop.rs
+++ b/crates/core/tests/integration/test_human_ailoop.rs
@@ -85,6 +85,7 @@ fn build_execution_context(workspace: &TempDir, execution_id: String) -> Executi
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }

--- a/crates/core/tests/integration/test_lag_tolerant_streams.rs
+++ b/crates/core/tests/integration/test_lag_tolerant_streams.rs
@@ -1,0 +1,302 @@
+/// PR-5 / B6 — lag-tolerant streams (router seam).
+///
+/// One test per stream endpoint (workflow WS, logs WS, workflow SSE), matching
+/// the tranche-1 PRD acceptance for spec 074 (`specs/draft/074-tranche1-prd.md`
+/// §PR-5): flood the shared broadcast channel past its capacity before the
+/// client reads, and assert the client receives a `{"type":"lagged","skipped":N}`
+/// frame (N >= 1) followed by subsequent live events, rather than the stream
+/// dying silently.
+use futures::StreamExt;
+use newton_backend::BackendStore;
+use newton_core::api::state::{AppState, BROADCAST_CAPACITY};
+use newton_types::{BroadcastEvent, OperatorDescriptor, WorkflowInstance, WorkflowStatus};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use uuid::Uuid;
+
+async fn make_backend() -> Arc<dyn BackendStore> {
+    let store = newton_backend::SqliteBackendStore::new_in_memory()
+        .await
+        .expect("in-memory backend init");
+    Arc::new(store)
+}
+
+fn make_state(backend: Arc<dyn BackendStore>) -> AppState {
+    let operators = vec![OperatorDescriptor {
+        operator_type: "noop".to_string(),
+        description: "No-op".to_string(),
+        params_schema: json!({}),
+    }];
+    AppState::new(operators, backend)
+}
+
+/// Spawn the router on an ephemeral loopback port; returns the port.
+async fn spawn_router(app: axum::Router) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    port
+}
+
+/// Flood `events_tx` with `n` events that do NOT match `target_instance_id`, so
+/// they overflow the channel's ring buffer without producing any forwarded
+/// frames to a WS/SSE client filtered on `target_instance_id`. This is a tight,
+/// non-yielding loop (no `.await`), so under the current-thread test runtime
+/// the connection-handling task cannot interleave and drain any of it first —
+/// the overflow is deterministic.
+fn flood_noise(events_tx: &broadcast::Sender<BroadcastEvent>, n: usize) {
+    for _ in 0..n {
+        let _ = events_tx.send(BroadcastEvent::WorkflowInstanceUpdated {
+            instance_id: "flood-noise-instance".to_string(),
+        });
+    }
+}
+
+async fn insert_instance(backend: &Arc<dyn BackendStore>, instance_id: &str) {
+    backend
+        .upsert_workflow_instance(&WorkflowInstance {
+            instance_id: instance_id.to_string(),
+            workflow_id: "wf-lag".to_string(),
+            status: WorkflowStatus::Running,
+            nodes: vec![],
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+            definition: None,
+            linked_plan_id: None,
+        })
+        .await
+        .unwrap();
+}
+
+/// Test 1: `/stream/workflow/{id}/ws` — flood past capacity, then assert a
+/// `lagged` frame arrives followed by a live marker event.
+#[tokio::test]
+async fn test_workflow_ws_delivers_lagged_frame_then_resumes() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    // First frame is the connect-time `workflowInstanceUpdated` snapshot. Its
+    // arrival proves the handler has already subscribed to events_tx (the
+    // subscribe() call precedes the snapshot send in handle_workflow_socket),
+    // so flooding after this point is guaranteed to overflow this connection's
+    // receiver rather than racing its setup.
+    let snapshot = ws_stream.next().await.unwrap().unwrap();
+    let snapshot: serde_json::Value =
+        serde_json::from_str(snapshot.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(snapshot["type"], "workflowInstanceUpdated");
+
+    // Flood well past the channel capacity with events that don't match this
+    // connection's instance filter, then publish one matching marker event.
+    flood_noise(&events_tx, BROADCAST_CAPACITY + 50);
+    let _ = events_tx.send(BroadcastEvent::NodeStateChanged {
+        instance_id: instance_id.clone(),
+        node_id: "marker-node".to_string(),
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut saw_lagged = false;
+        loop {
+            let msg = ws_stream.next().await.unwrap().unwrap();
+            let WsMessage::Text(text) = msg else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            if !saw_lagged {
+                assert_eq!(value["type"], "lagged", "expected lagged frame first");
+                let skipped = value["skipped"].as_u64().expect("skipped is a number");
+                assert!(skipped >= 1, "expected skipped >= 1, got {skipped}");
+                saw_lagged = true;
+                continue;
+            }
+            // First frame after `lagged` must be the live marker — the stream
+            // kept going instead of dying.
+            assert_eq!(value["type"], "nodeStateChanged");
+            assert_eq!(value["instance_id"], instance_id);
+            assert_eq!(value["node_id"], "marker-node");
+            break;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for lagged frame + resumed live event on workflow WS"
+    );
+}
+
+/// Test 2: `/stream/logs/{id}/{node_id}/ws` — same overflow/resume contract.
+#[tokio::test]
+async fn test_logs_ws_delivers_lagged_frame_then_resumes() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "lag-task";
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    // First frame is the synthetic "Connected to ..." logMessage, sent after
+    // handle_logs_socket's initial (unconditional, pre-await) subscribe().
+    let connect_frame = ws_stream.next().await.unwrap().unwrap();
+    let connect_frame: serde_json::Value =
+        serde_json::from_str(connect_frame.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(connect_frame["type"], "logMessage");
+
+    // Flood with LogMessage events for a different instance/node (filtered
+    // out, never forwarded), then one matching marker line.
+    for _ in 0..(BROADCAST_CAPACITY + 50) {
+        let _ = events_tx.send(BroadcastEvent::LogMessage {
+            instance_id: "flood-noise-instance".to_string(),
+            node_id: "flood-noise-node".to_string(),
+            message: "noise".to_string(),
+        });
+    }
+    let _ = events_tx.send(BroadcastEvent::LogMessage {
+        instance_id: instance_id.clone(),
+        node_id: node_id.to_string(),
+        message: "marker-line".to_string(),
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut saw_lagged = false;
+        loop {
+            let msg = ws_stream.next().await.unwrap().unwrap();
+            let WsMessage::Text(text) = msg else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            if !saw_lagged {
+                assert_eq!(value["type"], "lagged", "expected lagged frame first");
+                let skipped = value["skipped"].as_u64().expect("skipped is a number");
+                assert!(skipped >= 1, "expected skipped >= 1, got {skipped}");
+                saw_lagged = true;
+                continue;
+            }
+            assert_eq!(value["type"], "logMessage");
+            assert_eq!(value["message"], "marker-line");
+            break;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for lagged frame + resumed live event on logs WS"
+    );
+}
+
+/// Test 3: `/stream/workflow/{id}/sse` — same overflow/resume contract, over
+/// SSE `data:` payloads instead of WS text frames.
+#[tokio::test]
+async fn test_workflow_sse_delivers_lagged_frame_then_resumes() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let client = reqwest::Client::new();
+    let mut resp = client
+        .get(format!(
+            "http://127.0.0.1:{port}/stream/workflow/{instance_id}/sse"
+        ))
+        .send()
+        .await
+        .expect("SSE connect");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let mut buf = String::new();
+
+    // Read the connect-time snapshot event. `events_tx.subscribe()` in
+    // workflow_sse() runs synchronously before the handler returns the
+    // streaming Response, so by the time we have *any* response (let alone a
+    // body chunk) the subscription already exists.
+    let snapshot = next_sse_json(&mut resp, &mut buf)
+        .await
+        .expect("snapshot event");
+    assert_eq!(snapshot["type"], "workflowInstanceUpdated");
+
+    flood_noise(&events_tx, BROADCAST_CAPACITY + 50);
+    let _ = events_tx.send(BroadcastEvent::NodeStateChanged {
+        instance_id: instance_id.clone(),
+        node_id: "marker-node".to_string(),
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let lagged = next_sse_json(&mut resp, &mut buf)
+            .await
+            .expect("lagged event");
+        assert_eq!(lagged["type"], "lagged");
+        let skipped = lagged["skipped"].as_u64().expect("skipped is a number");
+        assert!(skipped >= 1, "expected skipped >= 1, got {skipped}");
+
+        let marker = next_sse_json(&mut resp, &mut buf)
+            .await
+            .expect("marker event after lagged");
+        assert_eq!(marker["type"], "nodeStateChanged");
+        assert_eq!(marker["instance_id"], instance_id);
+        assert_eq!(marker["node_id"], "marker-node");
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for lagged frame + resumed live event on workflow SSE"
+    );
+}
+
+/// Reads from an in-flight SSE response until a complete `data: <json>\n\n`
+/// event block is found, decodes its payload, and returns it. Skips non-data
+/// blocks (e.g. the ": keepalive" comment frame).
+async fn next_sse_json(
+    resp: &mut reqwest::Response,
+    buf: &mut String,
+) -> Option<serde_json::Value> {
+    loop {
+        if let Some(idx) = buf.find("\n\n") {
+            let block: String = buf.drain(..idx + 2).collect();
+            for line in block.lines() {
+                if let Some(payload) = line.strip_prefix("data: ") {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
+                        return Some(value);
+                    }
+                }
+            }
+            continue;
+        }
+        match resp.chunk().await.ok()? {
+            Some(bytes) => buf.push_str(&String::from_utf8_lossy(&bytes)),
+            None => return None,
+        }
+    }
+}

--- a/crates/core/tests/integration/test_lag_tolerant_streams.rs
+++ b/crates/core/tests/integration/test_lag_tolerant_streams.rs
@@ -275,6 +275,167 @@ async fn test_workflow_sse_delivers_lagged_frame_then_resumes() {
     );
 }
 
+/// Spec 074 PR-5's companion to the lagged-frame tests above: the *other*
+/// non-happy-path branch of the same `match rx.recv().await` — `Err(RecvError::Closed)`,
+/// reached when every `broadcast::Sender<BroadcastEvent>` clone (there is
+/// exactly one, embedded once in the single `AppState` the router is built
+/// from — `AppState::new` never clones it, and `Arc<AppState>` clones taken
+/// by axum's `State` extractor are pointer refcounts, not `Sender` clones)
+/// has been dropped. Aborting the `axum::serve` accept-loop task, letting
+/// the per-connection HTTP task exit after handing the raw IO off to the
+/// upgraded WS task, leaves the *WS handler task itself* as the only
+/// remaining owner of the shared `AppState`/`Sender` — this test's existence
+/// (rather than a hang) is itself evidence that this is enough to close the
+/// channel out from under it.
+#[tokio::test]
+async fn test_workflow_ws_ends_cleanly_when_broadcast_channel_closes() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let app = newton_core::api::api_v1_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app.into_make_service()).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let snapshot = ws_stream.next().await.unwrap().unwrap();
+    let snapshot: serde_json::Value =
+        serde_json::from_str(snapshot.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(snapshot["type"], "workflowInstanceUpdated");
+
+    // Nothing else in this test holds a Sender or AppState clone (unlike the
+    // lagged-frame tests above, which deliberately keep `events_tx` alive to
+    // flood it). Killing the accept loop is the last push needed to drop the
+    // router's own state reference.
+    server.abort();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws_stream.next().await {
+                None => return,
+                Some(Ok(WsMessage::Close(_))) => return,
+                Some(Ok(_)) => continue,
+                Some(Err(_)) => return,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for the WS stream to end after the broadcast channel closed"
+    );
+}
+
+/// Best-effort coverage of the *send-failure* sibling of the Closed branch
+/// (`if socket.send(...).await.is_err() { break; }` inside the `Ok(event)`
+/// arm): abruptly drop the client's TCP connection (no WS close handshake)
+/// so the next server-side write to it fails, then publish a live event.
+/// This is inherently racy (there is no direct hook to observe which arm the
+/// server took), so this test only asserts the server keeps functioning
+/// normally for a fresh connection afterward — it does not itself assert the
+/// send-failure branch was hit.
+#[tokio::test]
+async fn test_workflow_ws_server_survives_client_disconnect_mid_broadcast() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+    let snapshot = ws_stream.next().await.unwrap().unwrap();
+    let snapshot: serde_json::Value =
+        serde_json::from_str(snapshot.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(snapshot["type"], "workflowInstanceUpdated");
+
+    // Abrupt drop: no WS close handshake, just the underlying TCP stream
+    // going away, so a subsequent server-side write observes a broken pipe.
+    drop(ws_stream);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let _ = events_tx.send(BroadcastEvent::NodeStateChanged {
+        instance_id: instance_id.clone(),
+        node_id: "marker-node".to_string(),
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The server must still be healthy: a fresh connection works normally.
+    let (mut ws_stream2, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("second WebSocket connect should still succeed");
+    let snapshot2 = tokio::time::timeout(Duration::from_secs(5), ws_stream2.next())
+        .await
+        .expect("no timeout")
+        .unwrap()
+        .unwrap();
+    let snapshot2: serde_json::Value =
+        serde_json::from_str(snapshot2.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(snapshot2["type"], "workflowInstanceUpdated");
+}
+
+/// Same contract as above for `/stream/logs/{id}/{node_id}/ws`
+/// (`handle_logs_socket`'s identical `Err(RecvError::Closed) => break` arm).
+#[tokio::test]
+async fn test_logs_ws_ends_cleanly_when_broadcast_channel_closes() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "closed-branch-task";
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend));
+    let app = newton_core::api::api_v1_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app.into_make_service()).await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let connect_frame = ws_stream.next().await.unwrap().unwrap();
+    let connect_frame: serde_json::Value =
+        serde_json::from_str(connect_frame.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(connect_frame["type"], "logMessage");
+
+    server.abort();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws_stream.next().await {
+                None => return,
+                Some(Ok(WsMessage::Close(_))) => return,
+                Some(Ok(_)) => continue,
+                Some(Err(_)) => return,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "timed out waiting for the WS stream to end after the broadcast channel closed"
+    );
+}
+
 /// Reads from an in-flight SSE response until a complete `data: <json>\n\n`
 /// event block is found, decodes its payload, and returns it. Skips non-data
 /// blocks (e.g. the ": keepalive" comment frame).

--- a/crates/core/tests/integration/test_parity_endpoints.rs
+++ b/crates/core/tests/integration/test_parity_endpoints.rs
@@ -2,7 +2,7 @@ use axum::{
     body::Body,
     http::{header, method::Method, Request, StatusCode},
 };
-use newton_backend::{BackendStore, SqliteBackendStore};
+use newton_backend::{BackendStore, CreateFindingBody, SqliteBackendStore};
 use newton_core::api::state::AppState;
 use newton_types::OperatorDescriptor;
 use serde_json::json;
@@ -389,11 +389,61 @@ async fn test_patch_opportunity_invalid_status() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+/// A finding id that is not part of the embedded fixtures, so its
+/// presence/absence unambiguously reflects the seed step and the reset call
+/// (reset reloads fixtures, it doesn't merely truncate — see
+/// `crates/backend/src/store/plan.rs::reset_db`).
+const RESET_TEST_FINDING_ID: &str = "testing-reset-seed-finding";
+
+fn seed_finding_body() -> CreateFindingBody {
+    CreateFindingBody {
+        id: RESET_TEST_FINDING_ID.to_string(),
+        source: "reset-test-seed".to_string(),
+        origin: "system".to_string(),
+        component_id: None,
+        module: None,
+        repo_id: None,
+        kpi_id: None,
+        dimension: "quality".to_string(),
+        location: None,
+        fingerprint: RESET_TEST_FINDING_ID.to_string(),
+        title: "seed finding for testing-reset gate test".to_string(),
+        why_it_matters: "proves reset does/doesn't run".to_string(),
+        recommended_action: "n/a".to_string(),
+        severity: "low".to_string(),
+        risk: "low".to_string(),
+        confidence: None,
+        evidence: None,
+        expected_value: None,
+        effort: None,
+        status: "awaiting_triage".to_string(),
+        last_seen_at: None,
+        depends_on: vec![],
+        blocks: vec![],
+    }
+}
+
+async fn seed_finding_present(backend: &Arc<dyn BackendStore>) -> bool {
+    backend
+        .list_findings(None, None, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .any(|f| f.id == RESET_TEST_FINDING_ID)
+}
+
 #[serial_test::serial]
 #[tokio::test]
-async fn test_testing_reset_success() {
-    std::env::remove_var("NEWTON_ENV");
+async fn test_testing_reset_without_env_var_is_forbidden_and_data_intact() {
+    std::env::remove_var("NEWTON_ENABLE_TESTING_RESET");
     let state = create_parity_test_state().await;
+    let backend = state.backend.clone();
+    backend.create_finding(seed_finding_body()).await.unwrap();
+    assert!(
+        seed_finding_present(&backend).await,
+        "seed finding must be present before the reset attempt"
+    );
+
     let app = newton_core::api::api_v1_router(state);
     let req = Request::builder()
         .method(Method::POST)
@@ -401,33 +451,57 @@ async fn test_testing_reset_success() {
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let err: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(err["code"], "ERR_TESTING_RESET_DISABLED");
+    assert!(
+        err["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("NEWTON_ENABLE_TESTING_RESET"),
+        "error body should name the gating env var: {err}"
+    );
+
+    assert!(
+        seed_finding_present(&backend).await,
+        "data must be untouched when the reset gate refuses the request"
+    );
+}
+
+#[serial_test::serial]
+#[tokio::test]
+async fn test_testing_reset_with_env_var_succeeds_and_empties_seed_data() {
+    std::env::set_var("NEWTON_ENABLE_TESTING_RESET", "1");
+    let state = create_parity_test_state().await;
+    let backend = state.backend.clone();
+    backend.create_finding(seed_finding_body()).await.unwrap();
+    assert!(
+        seed_finding_present(&backend).await,
+        "seed finding must be present before reset"
+    );
+
+    let app = newton_core::api::api_v1_router(state);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/testing/reset")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    std::env::remove_var("NEWTON_ENABLE_TESTING_RESET");
     assert_eq!(resp.status(), StatusCode::OK);
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
     let ok: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(ok["ok"], true);
-}
 
-#[serial_test::serial]
-#[tokio::test]
-async fn test_testing_reset_forbidden_in_prod() {
-    std::env::set_var("NEWTON_ENV", "production");
-    let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
-    let req = Request::builder()
-        .method(Method::POST)
-        .uri("/testing/reset")
-        .body(Body::empty())
-        .unwrap();
-    let resp = app.oneshot(req).await.unwrap();
-    std::env::remove_var("NEWTON_ENV");
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let err: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(err["code"], "ERR_FORBIDDEN_IN_PROD");
+    assert!(
+        !seed_finding_present(&backend).await,
+        "seed finding must be gone after an enabled reset"
+    );
 }
 
 #[tokio::test]

--- a/crates/core/tests/workflow_graph/_archive/test_webhook.rs
+++ b/crates/core/tests/workflow_graph/_archive/test_webhook.rs
@@ -121,6 +121,7 @@ async fn spawn_webhook_server(
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
     let (addr_tx, addr_rx) = oneshot::channel();
     let handle = tokio::spawn(async move {
@@ -185,6 +186,7 @@ async fn manual_trigger_payload_available() -> Result<()> {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
     let summary = executor::execute_workflow(
         document,

--- a/crates/core/tests/workflow_graph/test_agent_operator.rs
+++ b/crates/core/tests/workflow_graph/test_agent_operator.rs
@@ -435,6 +435,7 @@ async fn run_workflow_yaml(
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
     )
     .await

--- a/crates/core/tests/workflow_graph/test_checkpoints.rs
+++ b/crates/core/tests/workflow_graph/test_checkpoints.rs
@@ -109,6 +109,7 @@ async fn resume_skips_completed_tasks() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -208,6 +209,7 @@ async fn resume_hash_mismatch_blocks_resume() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -253,6 +255,7 @@ async fn checkpoint_records_goal_gate_group() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -296,6 +299,7 @@ async fn checkpoints_list_output_format_and_sort_order() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     // Run workflow twice to create multiple checkpoints
@@ -386,6 +390,7 @@ workflow:
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -539,6 +544,7 @@ workflow:
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -640,6 +646,7 @@ workflow:
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -766,6 +773,7 @@ workflow:
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let result = executor::execute_workflow(
@@ -840,6 +848,7 @@ async fn test_workflow_definition_snapshot_written() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -877,6 +886,7 @@ async fn test_workflow_definition_snapshot_hash_matches_execution() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -939,6 +949,7 @@ async fn test_workflow_instance_definition_non_null_for_cli_run() {
         verbose: false,
         sink: Some(Arc::new(notifier)),
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     executor::execute_workflow(

--- a/crates/core/tests/workflow_graph/test_gh_operator.rs
+++ b/crates/core/tests/workflow_graph/test_gh_operator.rs
@@ -175,6 +175,7 @@ async fn execute_yaml_with_gh_runner(
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
     )
     .await
@@ -778,6 +779,7 @@ fn build_ctx(workspace: &TempDir) -> ExecutionContext {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }
@@ -1208,6 +1210,7 @@ fn pr_approve_ctx(workspace: &TempDir) -> ExecutionContext {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }
@@ -1816,6 +1819,7 @@ async fn pr_create_exponential_backoff_and_single_approval() {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: registry,
     };
@@ -1924,6 +1928,7 @@ fn make_exec_ctx(workspace: &std::path::Path) -> ExecutionContext {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: registry,
     }
@@ -2438,6 +2443,7 @@ async fn branch_push_fixture_runs_to_success() {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
     )
     .await

--- a/crates/core/tests/workflow_graph/test_goal_gates.rs
+++ b/crates/core/tests/workflow_graph/test_goal_gates.rs
@@ -88,6 +88,7 @@ fn default_overrides() -> ExecutionOverrides {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     }
 }
 
@@ -536,6 +537,7 @@ async fn e8_terminal_success_stops_executor_queued_tasks_not_run() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
     let registry = build_registry(workspace.clone(), document.workflow.settings.clone());
 

--- a/crates/core/tests/workflow_graph/test_human_ops.rs
+++ b/crates/core/tests/workflow_graph/test_human_ops.rs
@@ -46,6 +46,7 @@ fn build_execution_context(workspace: &TempDir, execution_id: String) -> Executi
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }

--- a/crates/core/tests/workflow_graph/test_io_contract.rs
+++ b/crates/core/tests/workflow_graph/test_io_contract.rs
@@ -858,3 +858,186 @@ workflow:
         "run() must fail when the completion envelope cannot be persisted, got Ok"
     );
 }
+
+/// Sibling to `completion_envelope_persist_failure_fails_the_run`, covering
+/// the FAILURE side of the same PR-3 hardening: when a task fails (with
+/// `continue_on_error: false`) AND `io.result_map` is configured, the
+/// runtime must also durably persist a *failure* completion envelope before
+/// returning the run's error — this is the "happy write inside the failure
+/// branch" path (`runtime.rs`, the `if self.graph_settings.io.result_map.is_some()`
+/// block reached from the `fail_workflow` arm), which no prior test reached
+/// because no existing test combined "task fails" with "result_map set".
+#[tokio::test]
+async fn failing_task_with_result_map_persists_failure_completion_envelope() {
+    let workspace = tempdir().expect("workspace");
+
+    // `continue_on_error: true` (and the default `success_requires_no_task_failures:
+    // true`) matter here: a task failure under `continue_on_error: false` is
+    // detected and returned mid-loop, inside `process_frontier`, which never
+    // reaches this function's own end-of-run finalization code (the block
+    // under test). Only a failure detected by `compute_final_status` *after*
+    // the loop otherwise completes — as when the failing task's own
+    // transition routes around it and a later task reaches a `terminal:
+    // success` node — reaches the finalization `if let Some(err) = maybe_err`
+    // branch this test targets. Mirrors the shape of the
+    // `14_error_fallback.yaml` CLI fixture, minus its
+    // `success_requires_no_task_failures: false` override (we want the
+    // overall run to still fail).
+    let workflow_yaml = r#"
+version: "2.0"
+mode: workflow_graph
+workflow:
+  settings:
+    entry_task: fail_cmd
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: true
+    max_task_iterations: 3
+    max_workflow_iterations: 10
+    command_operator:
+      allow_shell: true
+    io:
+      result_map:
+        status: failed
+  tasks:
+    - id: fail_cmd
+      operator: CommandOperator
+      params:
+        cmd: "false"
+        shell: true
+      transitions:
+        - to: fallback
+          when: { $expr: 'tasks.fail_cmd.status == "failed"' }
+    - id: fallback
+      operator: NoOpOperator
+      terminal: success
+"#;
+    let workflow_file = write_workflow(workflow_yaml);
+
+    let document = schema::load_workflow(workflow_file.path()).expect("parse workflow");
+    let settings = document.workflow.settings.clone();
+    let registry = build_registry(workspace.path().to_path_buf(), settings);
+
+    let (execution_id, handle) = executor::spawn_workflow_execution(
+        document,
+        workflow_file.path().to_path_buf(),
+        registry,
+        workspace.path().to_path_buf(),
+        default_overrides(),
+    )
+    .expect("spawn workflow execution");
+
+    let result = handle.await.expect("spawned run task should not panic");
+    assert!(
+        result.is_err(),
+        "run() must fail when the task fails, got Ok"
+    );
+
+    let completion_path = workspace
+        .path()
+        .join(".newton")
+        .join("state")
+        .join("workflows")
+        .join(execution_id.to_string())
+        .join("completion.json");
+    assert!(
+        completion_path.exists(),
+        "a failure completion envelope must be persisted even though the run failed"
+    );
+    let envelope = read_json(&completion_path);
+    assert_eq!(
+        envelope["status"], "failure",
+        "envelope must record status=failure; envelope={envelope}"
+    );
+    assert!(
+        envelope["error"].is_object(),
+        "envelope must carry the original run error; envelope={envelope}"
+    );
+}
+
+/// The other half of PR-3's failure-branch hardening: when the failure
+/// completion envelope itself cannot be durably persisted (its path is
+/// occupied by a directory, mirroring
+/// `completion_envelope_persist_failure_fails_the_run`'s technique), that
+/// persistence error must surface (`WFG-COMPLETION-001`) instead of being
+/// swallowed — the run still fails, but for the *right* reason, and the
+/// persistence failure is not silently dropped on the floor.
+#[tokio::test]
+async fn failing_task_with_result_map_surfaces_failure_envelope_persist_error() {
+    let workspace = tempdir().expect("workspace");
+
+    // `continue_on_error: true` (and the default `success_requires_no_task_failures:
+    // true`) matter here: a task failure under `continue_on_error: false` is
+    // detected and returned mid-loop, inside `process_frontier`, which never
+    // reaches this function's own end-of-run finalization code (the block
+    // under test). Only a failure detected by `compute_final_status` *after*
+    // the loop otherwise completes — as when the failing task's own
+    // transition routes around it and a later task reaches a `terminal:
+    // success` node — reaches the finalization `if let Some(err) = maybe_err`
+    // branch this test targets. Mirrors the shape of the
+    // `14_error_fallback.yaml` CLI fixture, minus its
+    // `success_requires_no_task_failures: false` override (we want the
+    // overall run to still fail).
+    let workflow_yaml = r#"
+version: "2.0"
+mode: workflow_graph
+workflow:
+  settings:
+    entry_task: fail_cmd
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: true
+    max_task_iterations: 3
+    max_workflow_iterations: 10
+    command_operator:
+      allow_shell: true
+    io:
+      result_map:
+        status: failed
+  tasks:
+    - id: fail_cmd
+      operator: CommandOperator
+      params:
+        cmd: "false"
+        shell: true
+      transitions:
+        - to: fallback
+          when: { $expr: 'tasks.fail_cmd.status == "failed"' }
+    - id: fallback
+      operator: NoOpOperator
+      terminal: success
+"#;
+    let workflow_file = write_workflow(workflow_yaml);
+
+    let document = schema::load_workflow(workflow_file.path()).expect("parse workflow");
+    let settings = document.workflow.settings.clone();
+    let registry = build_registry(workspace.path().to_path_buf(), settings);
+
+    let (execution_id, handle) = executor::spawn_workflow_execution(
+        document,
+        workflow_file.path().to_path_buf(),
+        registry,
+        workspace.path().to_path_buf(),
+        default_overrides(),
+    )
+    .expect("spawn workflow execution");
+
+    // Same current-thread-runtime trick as `completion_envelope_persist_failure_fails_the_run`:
+    // pre-create "completion.json" as a directory before the spawned task can
+    // make progress, so its final rename collides and fails.
+    let exec_dir = workspace
+        .path()
+        .join(".newton")
+        .join("state")
+        .join("workflows")
+        .join(execution_id.to_string());
+    fs::create_dir_all(exec_dir.join("completion.json")).expect("pre-create collision directory");
+
+    let result = handle.await.expect("spawned run task should not panic");
+    let err = result.expect_err("run() must fail; the task itself also failed");
+    assert_eq!(
+        err.code, "WFG-COMPLETION-001",
+        "a failure envelope persist error must surface as WFG-COMPLETION-001, not the original \
+         task failure; got {err:?}"
+    );
+}

--- a/crates/core/tests/workflow_graph/test_io_contract.rs
+++ b/crates/core/tests/workflow_graph/test_io_contract.rs
@@ -41,6 +41,7 @@ fn default_overrides() -> ExecutionOverrides {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     }
 }
 

--- a/crates/core/tests/workflow_graph/test_io_contract.rs
+++ b/crates/core/tests/workflow_graph/test_io_contract.rs
@@ -786,3 +786,75 @@ async fn ac27_resume_old_checkpoint_without_io_snapshot_succeeds() {
         result.err()
     );
 }
+
+// ─── PR-3 (spec 074, B1 + S1): completion envelope persist failure fails the run ──
+
+/// If the completion envelope's path is occupied by a directory, the shared
+/// atomic-write helper's rename must fail, and that failure must propagate
+/// as a run error instead of being silently swallowed behind
+/// `let _ = fs::write(...)`. Per the PRD's acceptance criteria: "an
+/// unpersistable completion fails the run".
+#[tokio::test]
+async fn completion_envelope_persist_failure_fails_the_run() {
+    let workspace = tempdir().expect("workspace");
+
+    let workflow_yaml = r#"
+version: "2.0"
+mode: workflow_graph
+workflow:
+  settings:
+    entry_task: only
+    max_time_seconds: 30
+    parallel_limit: 1
+    continue_on_error: false
+    max_task_iterations: 3
+    max_workflow_iterations: 10
+    io:
+      result_map:
+        status: ok
+  tasks:
+    - id: only
+      operator: NoOpOperator
+      params: {}
+      terminal: success
+"#;
+    let workflow_file = write_workflow(workflow_yaml);
+
+    let document = schema::load_workflow(workflow_file.path()).expect("parse workflow");
+    let settings = document.workflow.settings.clone();
+    let registry = build_registry(workspace.path().to_path_buf(), settings);
+
+    let (execution_id, handle) = executor::spawn_workflow_execution(
+        document,
+        workflow_file.path().to_path_buf(),
+        registry,
+        workspace.path().to_path_buf(),
+        default_overrides(),
+    )
+    .expect("spawn workflow execution");
+
+    // `spawn_workflow_execution` builds the runtime (and its execution_id)
+    // synchronously before handing `run()` to `tokio::spawn`; with the
+    // current-thread runtime `#[tokio::test]` uses, the spawned task cannot
+    // make any progress until this test task hits an `.await`. So we can
+    // deterministically pre-create "completion.json" as a directory in the
+    // execution's state dir before the run ever starts. The runtime's own
+    // checkpoint.json/execution.json writes use different filenames and
+    // succeed normally; only the final rename onto "completion.json"
+    // collides with the pre-existing directory entry and fails — isolating
+    // the completion-envelope write specifically.
+    let exec_dir = workspace
+        .path()
+        .join(".newton")
+        .join("state")
+        .join("workflows")
+        .join(execution_id.to_string());
+    fs::create_dir_all(exec_dir.join("completion.json")).expect("pre-create collision directory");
+
+    let result = handle.await.expect("spawned run task should not panic");
+
+    assert!(
+        result.is_err(),
+        "run() must fail when the completion envelope cannot be persisted, got Ok"
+    );
+}

--- a/crates/core/tests/workflow_graph/test_read_control_file_operator.rs
+++ b/crates/core/tests/workflow_graph/test_read_control_file_operator.rs
@@ -26,6 +26,7 @@ fn execution_context(workspace: std::path::PathBuf) -> ExecutionContext {
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }
@@ -55,6 +56,7 @@ fn execution_context_with_triggers(
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
         operator_registry: OperatorRegistry::new(),
     }

--- a/crates/core/tests/workflow_graph/test_resume_settings.rs
+++ b/crates/core/tests/workflow_graph/test_resume_settings.rs
@@ -48,6 +48,7 @@ fn default_overrides() -> ExecutionOverrides {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     }
 }
 

--- a/crates/core/tests/workflow_graph/test_scheduler.rs
+++ b/crates/core/tests/workflow_graph/test_scheduler.rs
@@ -162,6 +162,7 @@ async fn transitions_deduplicate_targets_per_tick() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -196,6 +197,7 @@ async fn loop_exhausts_iteration_limit() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let result = executor::execute_workflow(
@@ -226,6 +228,7 @@ async fn higher_priority_transition_wins() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let summary = executor::execute_workflow(
@@ -258,6 +261,7 @@ async fn workflow_exhausts_global_iteration_limit() {
         verbose: false,
         sink: None,
         pre_seed_nodes: true,
+        state_dir: None,
     };
 
     let result = executor::execute_workflow(

--- a/crates/core/tests/workflow_graph/test_workflow_comprehensive_matrix.rs
+++ b/crates/core/tests/workflow_graph/test_workflow_comprehensive_matrix.rs
@@ -205,6 +205,7 @@ async fn execute_yaml(
             verbose: false,
             sink: None,
             pre_seed_nodes: true,
+            state_dir: None,
         },
     )
     .await

--- a/openapi/newton-api.yaml
+++ b/openapi/newton-api.yaml
@@ -2143,29 +2143,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-  /testing/reset:
-    post:
-      tags:
-      - testing
-      operationId: reset_testing
-      responses:
-        '200':
-          description: Reset result
-          content:
-            application/json:
-              schema: {}
-        '403':
-          description: Forbidden in production
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        '500':
-          description: Internal error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
   /workflow-files:
     get:
       tags:
@@ -4273,8 +4250,6 @@ tags:
   description: Key-value persistence endpoints
 - name: catalog
   description: Catalog entity CRUD endpoints
-- name: testing
-  description: Test-only maintenance endpoints
 - name: workflow-files
   description: Workflow definition file CRUD endpoints
 - name: optimize

--- a/openapi/newton-realtime.asyncapi.yaml
+++ b/openapi/newton-realtime.asyncapi.yaml
@@ -14,13 +14,16 @@ x-connection-lifecycle:
   workflow_ws:
     snapshot_on_connect: workflowInstanceUpdated
     close_codes: [1000, 1001]
+    lag_handling: 'on broadcast Lagged(n), emits lagged then continues (never closes)'
   workflow_sse:
     snapshot_on_connect: workflowInstanceUpdated
     keepalive_text: keepalive
     keepalive_interval_seconds: 10
+    lag_handling: 'on broadcast Lagged(n), emits lagged then continues (never closes)'
   logs_ws:
     connect_confirmation: 'logMessage "Connected to <task_name>"'
     close_codes: [1000, 1001]
+    lag_handling: 'on broadcast Lagged(n), emits lagged then continues (never closes)'
 
 channels:
   heartbeat:
@@ -84,6 +87,8 @@ channels:
         $ref: '#/components/messages/PlanUpdate'
       executionUpdate:
         $ref: '#/components/messages/ExecutionUpdate'
+      lagged:
+        $ref: '#/components/messages/Lagged'
 
   logsWs:
     address: /api/v1/stream/logs/{instanceId}/{nodeId}/ws
@@ -114,6 +119,8 @@ channels:
         $ref: '#/components/messages/LogMessage'
       logMessage:
         $ref: '#/components/messages/LogMessage'
+      lagged:
+        $ref: '#/components/messages/Lagged'
 
   workflowInstanceSse:
     address: /api/v1/stream/workflow/{instanceId}/sse
@@ -150,6 +157,8 @@ channels:
         $ref: '#/components/messages/PlanUpdate'
       executionUpdate:
         $ref: '#/components/messages/ExecutionUpdate'
+      lagged:
+        $ref: '#/components/messages/Lagged'
 
 components:
   messages:
@@ -212,6 +221,19 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ExecutionUpdatePayload'
+
+    Lagged:
+      name: Lagged
+      title: Lagged
+      description: |
+        Sent when this consumer's broadcast subscription overflowed the shared
+        1024-slot channel and `skipped` events were dropped before they could
+        be delivered. The stream is NOT closed: the client should re-fetch a
+        state snapshot and then keep consuming subsequent live events on the
+        same connection.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/LaggedPayload'
 
   schemas:
     WelcomePayload:
@@ -328,3 +350,19 @@ components:
         plan_id: null
         status: running
         created_at: "2026-01-01T00:00:00Z"
+
+    LaggedPayload:
+      type: object
+      required: [type, skipped]
+      properties:
+        type:
+          type: string
+          enum: [lagged]
+        skipped:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Number of broadcast events dropped before this consumer could receive them.
+      example:
+        type: lagged
+        skipped: 42


### PR DESCRIPTION
Implements Tranche 1 ("running-system killers") of the audit remediation spec (074, local): seven hardening fixes for bugs that corrupt state or kill live deployments, plus a review pass and diff-coverage gate.

## Changes

- **No `process::exit` in handlers** — new `CliExit` error type; all 21 exit sites in `data`/`workflow`/`doctor` return errors, only `main.rs` maps them to exit codes. A malformed MCP tool call now yields an error frame instead of killing `newton serve` (exit codes preserved and pinned by tests).
- **One state root** — `--state-dir`/`NEWTON_STATE_DIR`/config now thread one resolved root to the executor sink, grading operators, `data`, `runs`, and `optimize` (env::set_var dance deleted). `ExecutionOverrides.state_dir` additionally injects `NEWTON_STATE_DIR` into command/agent subprocess environments so child `newton` invocations resolve the same root (explicit YAML env wins).
- **Durable completion envelope** — one shared fsyncing `atomic_write` (tmp → fsync → rename → dir-fsync) replaces three duplicate implementations; `completion.json` goes through it and persistence failure fails the run on both success and failure paths.
- **Reconciliation fails closed** — LLM adjudication failure returns `WFG-RECONCILE-ADJ-001` (retryable) before any Finding mutation; no more duplicate-and-mass-resolve corruption. Implements the "fuzziness is not failure tolerance" clause added to CONTEXT.md.
- **Lag-tolerant streams** — workflow WS, logs WS, and workflow SSE survive broadcast overflow with a `{"type":"lagged","skipped":n}` frame then continue (documented in the AsyncAPI catalog; per-endpoint tests).
- **Exposure hardening** — non-loopback `--host` prints an UNAUTHENTICATED warning banner; `POST /testing/reset` now requires `NEWTON_ENABLE_TESTING_RESET=1` (replaces the NEWTON_ENV opt-out) and is removed from the OpenAPI document (regenerated per NEWTON-0028).
- **Process-tree cleanup on timeout** — agent children spawn with `kill_on_drop` + own process group and a cancellation-safe kill guard owned by the execution future; both timeout paths kill the whole group (unix), with the guard disarmed immediately after a clean reap to avoid killing reused pgids.
- **Bonus fix** — pre-existing `SQLITE_BUSY` fault under two pools on one SQLite file (present on `main`): WAL journal mode + `BEGIN IMMEDIATE` on all write transactions.

## Verification

- All suites green: `cargo test` across newton-core / newton-cli / newton-backend (500+ tests incl. ~30 new); fmt + clippy `-D warnings` clean; pre-commit and pre-push hooks passed on every commit.
- **Diff coverage 95.74%** (1124/1174 instrumented added lines, cargo-llvm-cov vs `main`); remaining uncovered lines are documented-unreachable defensive arms and spawned-binary-only paths.
- Full 8-angle review pass with adversarial verification; 3 findings fixed on this branch (kill-guard pgid-reuse window, `NEWTON_STATE_DIR` subprocess propagation, missing doc comment).

## Known follow-ups (documented, out of tranche scope)

- git/gh/shell command operators still orphan subprocesses on outer timeout (same class PR-7 fixed for agents) — candidate for tranche 2.
- `resume` doesn't route through `build_execution_setup`, so state-dir subprocess propagation doesn't apply on resume — part of the known run/resume parity item (spec P6, tranche 2).
- fsync now runs on the per-tick checkpoint path synchronously on tokio workers — accepted durability/latency trade-off; revisit with spawn_blocking or terminal-only fsync if profiling warrants.
- Minor cleanups noted in review: dedupe the five io::Error→AppError wrappers, share the stream-handler recv loop, derive the exposure warning from the parsed bind address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
