### PR TITLE
fix: tranche 3 audit remediation — realtime & DSL parity (spec 074)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,16 @@ jobs:
           path: /usr/local/bin
       - run: chmod +x /usr/local/bin/newton
 
+      # tests/roundtrip/conftest.py resolves the binary at
+      # $CARGO_TARGET_DIR/debug/newton (or target/debug/newton by default,
+      # relative to the repo root) — not from PATH — so it needs a copy
+      # there too, independent of the /usr/local/bin install used by the
+      # "Validate emitted YAML" step below.
+      - name: Stage newton binary for DSL roundtrip tests
+        run: |
+          mkdir -p "${{ github.workspace }}/target/debug"
+          cp /usr/local/bin/newton "${{ github.workspace }}/target/debug/newton"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -148,6 +158,12 @@ jobs:
         run: uv sync
 
       - name: Run tests
+        env:
+          # Turn roundtrip-suite skips (missing newton binary) into hard
+          # failures in CI (spec 074 P15) — defense in depth even though
+          # the binary should always be present here via the staging step
+          # above.
+          NEWTON_REQUIRE_BINARY: "1"
         run: uv run pytest
 
       - name: Check codegen drift

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,7 +1878,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2513,6 +2526,7 @@ dependencies = [
  "dirs-next",
  "flate2",
  "futures",
+ "globset",
  "hex",
  "humantime",
  "indexmap",
@@ -3156,7 +3170,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3194,7 +3208,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5601,7 +5615,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rhai = { version = "1.11", features = ["sync"] }
 petgraph = "0.7"
 async-trait = "0.1"
 regex = "1"
+globset = "0.4"
 indexmap = "2"
 sha2 = "0.10"
 hex = "0.4.3"

--- a/crates/backend/src/store/mod.rs
+++ b/crates/backend/src/store/mod.rs
@@ -487,6 +487,15 @@ impl BackendStore for SqliteBackendStore {
         self.list_log_lines_db(instance_id, node_id, since_seq)
             .await
     }
+    async fn list_log_lines_tail(
+        &self,
+        instance_id: &str,
+        node_id: &str,
+        limit: i64,
+    ) -> Result<Vec<newton_types::LogLine>, ApiError> {
+        self.list_log_lines_tail_db(instance_id, node_id, limit)
+            .await
+    }
 }
 
 #[cfg(test)]
@@ -543,6 +552,9 @@ mod store_tests {
             level: "info".to_string(),
             message: msg.to_string(),
             timestamp: Utc::now(),
+            // append_log_line_db assigns the real seq; this placeholder is
+            // never read on the write path.
+            seq: 0,
         }
     }
 
@@ -650,6 +662,47 @@ mod store_tests {
         assert_eq!(tail.len(), 5);
         assert_eq!(tail[0].message, "line-5");
         assert_eq!(tail[4].message, "line-9");
+    }
+
+    /// Spec 074 B18: `list_log_lines_tail` returns the last N lines in
+    /// ascending seq order, not a full replay — proves both the slicing
+    /// (last N, not first N) and the ordering (oldest-of-the-tail first).
+    #[tokio::test]
+    async fn list_log_lines_tail_returns_last_n_in_ascending_order() {
+        let store = SqliteBackendStore::new_in_memory().await.unwrap();
+        let inst = make_instance("inst-6");
+        store.upsert_workflow_instance(&inst).await.unwrap();
+
+        for i in 0..10 {
+            let line = make_log("inst-6", "node-y", &format!("line-{i}"));
+            store
+                .append_log_line("inst-6", "node-y", &line)
+                .await
+                .unwrap();
+        }
+
+        let tail = store
+            .list_log_lines_tail("inst-6", "node-y", 3)
+            .await
+            .unwrap();
+        assert_eq!(tail.len(), 3, "tail must be exactly `limit` lines");
+        assert_eq!(
+            tail.iter().map(|l| l.message.as_str()).collect::<Vec<_>>(),
+            vec!["line-7", "line-8", "line-9"],
+            "tail must be the last 3 lines, in ascending seq order"
+        );
+        assert_eq!(tail[0].seq, 8);
+        assert_eq!(tail[2].seq, 10);
+
+        // A limit larger than the available rows returns everything, still
+        // ascending, with no error and no padding.
+        let full = store
+            .list_log_lines_tail("inst-6", "node-y", 500)
+            .await
+            .unwrap();
+        assert_eq!(full.len(), 10);
+        assert_eq!(full[0].message, "line-0");
+        assert_eq!(full[9].message, "line-9");
     }
 }
 

--- a/crates/backend/src/store/plan.rs
+++ b/crates/backend/src/store/plan.rs
@@ -464,6 +464,11 @@ impl super::SqliteBackendStore {
         let plan_item = self.fetch_plan_item(id).await?;
         Ok(ApprovedPlan {
             plan: plan_item,
+            // No workflow instance is attached to the just-inserted
+            // ExecutionRecord yet (its instanceId column is NULL), so this
+            // falls back to the execution's own id — same convention as
+            // `list_executions_db`'s `ExecutionItem::instance_id` mapping.
+            instance_id: exec_id.clone(),
             execution_id: exec_id,
             created_at: now,
         })

--- a/crates/backend/src/store/rows.rs
+++ b/crates/backend/src/store/rows.rs
@@ -439,7 +439,6 @@ pub(super) struct HilEventRow {
 
 #[derive(Debug, FromRow)]
 pub(super) struct WorkflowLogRow {
-    #[allow(dead_code)]
     pub seq: i64,
     #[sqlx(rename = "instanceId")]
     pub instance_id: String,

--- a/crates/backend/src/store/workflow_runtime.rs
+++ b/crates/backend/src/store/workflow_runtime.rs
@@ -356,6 +356,41 @@ impl super::SqliteBackendStore {
                     level: r.level,
                     message: r.message,
                     timestamp: parse_dt(&r.ts)?,
+                    seq: r.seq,
+                })
+            })
+            .collect()
+    }
+
+    pub(super) async fn list_log_lines_tail_db(
+        &self,
+        instance_id: &str,
+        node_id: &str,
+        limit: i64,
+    ) -> Result<Vec<newton_types::LogLine>, ApiError> {
+        // Fetch the last `limit` rows in seq DESC order, then reverse in Rust
+        // to hand back ascending order (matching list_log_lines_db).
+        let mut rows: Vec<WorkflowLogRow> = sqlx::query_as::<_, WorkflowLogRow>(
+            "SELECT seq, instanceId, nodeId, ts, level, message FROM WorkflowLog WHERE instanceId = ? AND nodeId = ? ORDER BY seq DESC LIMIT ?"
+        )
+        .bind(instance_id)
+        .bind(node_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(query_err)?;
+
+        rows.reverse();
+
+        rows.into_iter()
+            .map(|r| {
+                Ok(newton_types::LogLine {
+                    instance_id: r.instance_id,
+                    node_id: r.node_id,
+                    level: r.level,
+                    message: r.message,
+                    timestamp: parse_dt(&r.ts)?,
+                    seq: r.seq,
                 })
             })
             .collect()

--- a/crates/cli/src/cli/args.rs
+++ b/crates/cli/src/cli/args.rs
@@ -418,6 +418,13 @@ pub struct ServeArgs {
     /// Run import scan of existing file-based runs before the HTTP listener binds.
     #[arg(long, default_value_t = false)]
     pub import_existing: bool,
+
+    /// Mount the magic-tool router (`/aitools/...`). Off by default: today it
+    /// registers only a `newton/ping` smoke-test tool, with real tool
+    /// definitions landing in a future release (spec 074 P9). Not reflected
+    /// in the OpenAPI doc until then.
+    #[arg(long = "with-magic-tools", default_value_t = false)]
+    pub with_magic_tools: bool,
 }
 
 // ── Data ─────────────────────────────────────────────────────────────────────
@@ -463,16 +470,21 @@ pub struct DataArgs {
     /// Defaults to auto-resolved from workspace root (flag > NEWTON_STATE_DIR
     /// > newton.toml [workflow].state_dir > workspace default).
     pub state_dir: Option<PathBuf>,
-    /// Optional filter: restrict grade listings to a single evaluation run.
+    /// Optional filter: restrict grade listings to a single evaluation run,
+    /// or restrict an `optimize-cycle` GET to the cycle's owning run.
     pub run_id: Option<String>,
     /// Optional filter: restrict grade listings to a single KPI.
     pub kpi_id: Option<String>,
-    /// Optional filter: restrict eval run listings by scope.
+    /// Optional filter: restrict eval-run/finding/plan listings by scope.
     pub scope: Option<String>,
-    /// Optional filter: restrict eval run listings by scope id.
+    /// Optional filter: restrict eval-run/finding/plan listings by scope id.
     pub scope_id: Option<String>,
     /// Optional filter: restrict eval run listings by source.
     pub source: Option<String>,
     /// Optional filter: restrict eval run listings to N results.
     pub limit: Option<u32>,
+    /// Optional filter: restrict finding/change-request/plan listings by
+    /// status (spec 074 P12 — these `Option`s already existed in the store
+    /// API; this is the CLI flag that plumbs them through).
+    pub status: Option<String>,
 }

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -61,24 +61,34 @@ pub async fn data(args: DataArgs) -> anyhow::Result<()> {
     let resource = args.resource.as_str();
 
     if (args.run_id.is_some() || args.kpi_id.is_some())
-        && resource != "grades"
-        && resource != "optimize-cycles"
+        && !matches!(resource, "grades" | "optimize-cycles" | "optimize-cycle")
     {
         return Err(CliExit::new(
             1,
-            "DATA-006: --run-id/--kpi-id are only supported with: resource=grades, optimize-cycles",
+            "DATA-006: --run-id/--kpi-id are only supported with: resource=grades, optimize-cycles, optimize-cycle",
         )
         .into());
     }
-    if (args.scope.is_some()
-        || args.scope_id.is_some()
-        || args.source.is_some()
-        || args.limit.is_some())
-        && resource != "eval-runs"
+    if (args.scope.is_some() || args.scope_id.is_some())
+        && !matches!(resource, "eval-runs" | "findings" | "plans")
     {
         return Err(CliExit::new(
             1,
-            "DATA-008: --scope/--scope-id/--source/--limit are only supported with: resource=eval-runs",
+            "DATA-008: --scope/--scope-id are only supported with: resource=eval-runs, findings, plans",
+        )
+        .into());
+    }
+    if (args.source.is_some() || args.limit.is_some()) && resource != "eval-runs" {
+        return Err(CliExit::new(
+            1,
+            "DATA-008: --source/--limit are only supported with: resource=eval-runs",
+        )
+        .into());
+    }
+    if args.status.is_some() && !matches!(resource, "findings" | "change-requests" | "plans") {
+        return Err(CliExit::new(
+            1,
+            "DATA-009: --status is only supported with: resource=findings, change-requests, plans",
         )
         .into());
     }
@@ -307,10 +317,15 @@ async fn dispatch_data(
     let id = args.id.as_deref().unwrap_or("");
     let grade_run_id = args.run_id.as_deref();
     let grade_kpi_id = args.kpi_id.as_deref();
+    // Shared by eval-runs (scope/scope-id/source/limit) and, per spec 074
+    // P12, findings/plans (status/scope/scope-id) — the CLI-level validation
+    // gate above already restricts which resource each combination is
+    // accepted for.
     let eval_scope = args.scope.as_deref();
     let eval_scope_id = args.scope_id.as_deref();
     let eval_source = args.source.as_deref();
     let eval_limit = args.limit;
+    let list_status = args.status.as_deref();
 
     match (verb, resource) {
         (DataVerb::Get, "products") => store
@@ -531,7 +546,11 @@ async fn dispatch_data(
                 .and_then(to_json)
         }
         (DataVerb::Get, "findings") => store
-            .list_findings(None, None, None)
+            .list_findings(
+                list_status.map(str::to_string),
+                eval_scope.map(str::to_string),
+                eval_scope_id.map(str::to_string),
+            )
             .await
             .map_err(api_err)
             .and_then(to_json),
@@ -557,7 +576,7 @@ async fn dispatch_data(
                 .and_then(to_json)
         }
         (DataVerb::Get, "change-requests") => store
-            .list_change_requests(None)
+            .list_change_requests(list_status.map(str::to_string))
             .await
             .map_err(api_err)
             .and_then(to_json),
@@ -583,7 +602,11 @@ async fn dispatch_data(
                 .and_then(to_json)
         }
         (DataVerb::Get, "plans") => store
-            .list_plans(None, None, None)
+            .list_plans(
+                list_status.map(str::to_string),
+                eval_scope.map(str::to_string),
+                eval_scope_id.map(str::to_string),
+            )
             .await
             .map_err(api_err)
             .and_then(to_json),
@@ -639,8 +662,26 @@ async fn dispatch_data(
                 .and_then(to_json)
         }
         (DataVerb::Get, "optimize-cycle") => {
-            // For single cycle GET we reuse get_optimize_run by run_id + trajectory; use list and filter by id
-            Err("use 'optimize-cycles --run-id <run_id>' to list cycles; single cycle GET not supported".to_string())
+            // A Cycle's natural lookup path is via its owning Optimize Run's
+            // Trajectory (`list_optimize_cycles(run_id)`) — there is no
+            // standalone get-by-id in the store API — so fetch that list and
+            // filter by the cycle's own id (spec 074 P12; this replaces the
+            // old always-Err dead path).
+            let Some(run_id) = grade_run_id else {
+                return Err(
+                    "DATA-011: --run-id is required for 'data get optimize-cycle <id>'".to_string(),
+                );
+            };
+            let cycles = store.list_optimize_cycles(run_id).await.map_err(api_err)?;
+            cycles
+                .into_iter()
+                .find(|c| c.id == id)
+                .ok_or_else(|| {
+                    api_err(newton_backend::err_not_found(&format!(
+                        "optimize cycle '{id}' not found in run '{run_id}'"
+                    )))
+                })
+                .and_then(to_json)
         }
         (DataVerb::Post, "optimize-cycle" | "optimize-cycles") => {
             let b = parse_body::<newton_backend::CreateOptimizeCycleBody>(body)?;
@@ -650,6 +691,70 @@ async fn dispatch_data(
                 .map_err(api_err)
                 .and_then(to_json)
         }
+
+        // ── DELETE: documented-unsupported combos (spec 074 P12) ───────────
+        //
+        // These resources are either lifecycle-managed (retired via a status
+        // transition — DELETE would destroy the audit trail CONTEXT.md's
+        // lifecycles depend on) or genuinely append-only. Rather than fall
+        // through to the generic "unsupported combination" error, each
+        // rejection names the resource and points at the correct operation.
+        (DataVerb::Delete, "finding" | "findings") => Err(
+            "DATA-009: findings have no DELETE — they are retired via status transitions, \
+             not removal. PATCH status to 'rejected' or 'deferred' to close one by hand \
+             (`newton data patch finding <id> --body '{\"status\":\"rejected\"}'`); a Finding \
+             also auto-resolves on a clean re-grade and auto-blocks when its Plan's retries \
+             exhaust. See CONTEXT.md's Finding lifecycle."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "change-request" | "change-requests") => Err(
+            "DATA-009: change requests have no DELETE — they move through \
+             `proposed → approved → planned → rejected`, not removal. PATCH status to \
+             'rejected' to close one (`newton data patch change-request <id> --body \
+             '{\"status\":\"rejected\"}'`). See CONTEXT.md's Change Request lifecycle."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "plan" | "plans") => Err(
+            "DATA-009: plans have no DELETE — the plan queue is retired via status \
+             transitions (`draft → ready → running → complete | failed`, plus \
+             'abandoned' for a human-shelved/rejected plan), not removal. PATCH status to \
+             'abandoned' to close one (`newton data patch plan <id> --body \
+             '{\"status\":\"abandoned\"}'`). See CONTEXT.md's Plan queue."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "optimize-run" | "optimize-runs") => Err(
+            "DATA-009: optimize runs have no DELETE — a Run is the durable audit record \
+             of one loop invocation (status: running | converged | stalled_on_blocked | \
+             max_cycles | regressed | no_progress). PATCH status if it needs to be \
+             force-closed (`newton data patch optimize-run <id> --body '{\"status\":...}'`). \
+             See CONTEXT.md's Optimize Run."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "optimize-cycle" | "optimize-cycles") => Err(
+            "DATA-009: optimize cycles have no DELETE — a Cycle is an immutable Trajectory \
+             entry within its Optimize Run's audit trail and is never retired individually. \
+             See CONTEXT.md's Cycle / Trajectory."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "kpi" | "kpis") => Err(
+            "DATA-009: kpis have no DELETE — a KPI is a governance/reporting catalog entry \
+             (there is currently no update operation for it either, only create/get/list); \
+             retiring one requires an out-of-band catalog edit. See CONTEXT.md's KPI."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "eval-run" | "eval-runs") => Err(
+            "DATA-009: eval-runs have no DELETE — each is an append-only historical record \
+             of one completed evaluation and cannot be modified or removed. \
+             See CONTEXT.md's Evaluation model."
+                .to_string(),
+        ),
+        (DataVerb::Delete, "grade" | "grades") => Err(
+            "DATA-009: grades have no DELETE — Grade is explicitly append-only \
+             (the score history a run is judged against) and cannot be removed. \
+             See CONTEXT.md's Grade."
+                .to_string(),
+        ),
+
         (v, r) => Err(format!("unsupported combination: {v} {r}")),
     }
 }
@@ -693,6 +798,7 @@ mod cli_exit_path_tests {
             scope_id: None,
             source: None,
             limit: None,
+            status: None,
         }
     }
 
@@ -943,5 +1049,424 @@ mod cli_exit_path_tests {
             "{}",
             exit.message
         );
+    }
+}
+
+/// Tests for spec 074 P12: the `data` verb/resource asymmetry fixes —
+/// documented delete rejections (instead of the generic "unsupported
+/// combination" error), the `optimize-cycle` single-GET fix, and the new
+/// findings/change-requests/plans list-filter flags. Uses the same
+/// in-process `data()`/`dispatch_data` seam as `cli_exit_path_tests` above.
+#[cfg(test)]
+mod p12_data_matrix_tests {
+    use super::*;
+    use crate::cli::args::DataVerb;
+    use tempfile::TempDir;
+
+    fn setup_workspace() -> TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".newton/state")).expect("create state dir");
+        dir
+    }
+
+    fn base_args(ws: &TempDir, verb: DataVerb, resource: &str) -> DataArgs {
+        DataArgs {
+            verb,
+            resource: resource.to_string(),
+            id: None,
+            file: None,
+            body: None,
+            json: false,
+            dry_run: false,
+            workspace: Some(ws.path().to_path_buf()),
+            state_dir: None,
+            run_id: None,
+            kpi_id: None,
+            scope: None,
+            scope_id: None,
+            source: None,
+            limit: None,
+            status: None,
+        }
+    }
+
+    async fn open_store(ws: &TempDir) -> newton_backend::SqliteBackendStore {
+        let state_dir = crate::cli::workspace_paths::resolve_state_dir(ws.path(), None);
+        let workspace_paths = WorkspacePaths::with_state_dir(ws.path().to_path_buf(), state_dir);
+        let db_url = workspace_paths.backend_sqlite_url();
+        newton_backend::SqliteBackendStore::new(&db_url)
+            .await
+            .expect("open store")
+    }
+
+    fn expect_cli_exit(err: anyhow::Error) -> CliExit {
+        err.downcast::<CliExit>()
+            .unwrap_or_else(|e| panic!("expected a CliExit, got: {e}"))
+    }
+
+    async fn assert_delete_documented(resource: &str, expect_substr: &str) {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Delete, resource);
+        args.id = Some("some-id".to_string());
+        let err = data(args)
+            .await
+            .expect_err(&format!("delete {resource} must be rejected"));
+        let exit = expect_cli_exit(err);
+        assert!(
+            exit.message.contains("DATA-009"),
+            "resource={resource} msg={}",
+            exit.message
+        );
+        assert!(
+            exit.message.contains(expect_substr),
+            "resource={resource} msg={}",
+            exit.message
+        );
+        assert!(
+            !exit.message.contains("unsupported combination"),
+            "resource={resource} must not fall through to the generic error: {}",
+            exit.message
+        );
+    }
+
+    // ── DELETE matrix: documented, resource-specific rejections ────────────
+
+    #[tokio::test]
+    async fn delete_finding_points_at_patch_status() {
+        assert_delete_documented("finding", "PATCH status").await;
+        assert_delete_documented("findings", "PATCH status").await;
+    }
+
+    #[tokio::test]
+    async fn delete_change_request_points_at_patch_status() {
+        assert_delete_documented("change-request", "PATCH status").await;
+        assert_delete_documented("change-requests", "PATCH status").await;
+    }
+
+    #[tokio::test]
+    async fn delete_plan_points_at_patch_status() {
+        assert_delete_documented("plan", "abandoned").await;
+        assert_delete_documented("plans", "abandoned").await;
+    }
+
+    #[tokio::test]
+    async fn delete_optimize_run_points_at_patch_status() {
+        assert_delete_documented("optimize-run", "PATCH status").await;
+        assert_delete_documented("optimize-runs", "PATCH status").await;
+    }
+
+    #[tokio::test]
+    async fn delete_optimize_cycle_is_documented_immutable() {
+        assert_delete_documented("optimize-cycle", "Trajectory").await;
+        assert_delete_documented("optimize-cycles", "Trajectory").await;
+    }
+
+    #[tokio::test]
+    async fn delete_kpi_is_documented_append_only() {
+        assert_delete_documented("kpi", "governance").await;
+        assert_delete_documented("kpis", "governance").await;
+    }
+
+    #[tokio::test]
+    async fn delete_eval_run_is_documented_append_only() {
+        assert_delete_documented("eval-run", "append-only").await;
+        assert_delete_documented("eval-runs", "append-only").await;
+    }
+
+    #[tokio::test]
+    async fn delete_grade_is_documented_append_only() {
+        assert_delete_documented("grade", "append-only").await;
+        assert_delete_documented("grades", "append-only").await;
+    }
+
+    // ── optimize-cycle single GET: was a dead error path, now real ─────────
+
+    #[tokio::test]
+    async fn optimize_cycle_get_requires_run_id() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Get, "optimize-cycle");
+        args.id = Some("cycle-1".to_string());
+        let err = data(args).await.expect_err("must require --run-id");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-011"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn optimize_cycle_get_not_found_in_run() {
+        let ws = setup_workspace();
+        let store = open_store(&ws).await;
+        store
+            .create_optimize_run(newton_backend::CreateOptimizeRunBody {
+                id: "run-1".to_string(),
+                project_id: "proj-1".to_string(),
+                scope: "repo".to_string(),
+                scope_id: "gonewton/newton".to_string(),
+                max_cycles: 8,
+                graders: vec![],
+            })
+            .await
+            .expect("seed optimize-run");
+
+        let mut args = base_args(&ws, DataVerb::Get, "optimize-cycle");
+        args.id = Some("ghost-cycle".to_string());
+        args.run_id = Some("run-1".to_string());
+        let err = data(args).await.expect_err("cycle must not be found");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("ERR_NOT_FOUND"), "{}", exit.message);
+        assert!(exit.message.contains("ghost-cycle"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn optimize_cycle_get_returns_matching_cycle() {
+        let ws = setup_workspace();
+        let store = open_store(&ws).await;
+        store
+            .create_optimize_run(newton_backend::CreateOptimizeRunBody {
+                id: "run-2".to_string(),
+                project_id: "proj-1".to_string(),
+                scope: "repo".to_string(),
+                scope_id: "gonewton/newton".to_string(),
+                max_cycles: 8,
+                graders: vec![],
+            })
+            .await
+            .expect("seed optimize-run");
+        store
+            .create_optimize_cycle(newton_backend::CreateOptimizeCycleBody {
+                id: "cycle-a".to_string(),
+                run_id: "run-2".to_string(),
+                cycle: 1,
+                grades: serde_json::json!({}),
+                grade_min: None,
+                decision: "none".to_string(),
+                change_request_id: None,
+                plan_id: None,
+                execution_id: None,
+                develop_status: None,
+                open_findings: 0,
+                resolved_this_cycle: 0,
+            })
+            .await
+            .expect("seed optimize-cycle");
+
+        let args = DataArgs {
+            id: Some("cycle-a".to_string()),
+            run_id: Some("run-2".to_string()),
+            ..base_args(&ws, DataVerb::Get, "optimize-cycle")
+        };
+        let value = dispatch_data(&store, &args, None)
+            .await
+            .expect("optimize-cycle GET must succeed");
+        assert_eq!(value["id"], "cycle-a");
+        assert_eq!(value["runId"], "run-2");
+    }
+
+    // ── List filter flags actually filter (findings/change-requests/plans) ─
+
+    fn finding_body(id: &str, status: &str) -> newton_backend::CreateFindingBody {
+        newton_backend::CreateFindingBody {
+            id: id.to_string(),
+            source: "test".to_string(),
+            origin: "system".to_string(),
+            component_id: None,
+            module: None,
+            repo_id: None,
+            kpi_id: None,
+            dimension: "tests".to_string(),
+            location: None,
+            fingerprint: format!("fp-{id}"),
+            title: format!("finding {id}"),
+            why_it_matters: "because".to_string(),
+            recommended_action: "fix it".to_string(),
+            severity: "low".to_string(),
+            risk: "low".to_string(),
+            confidence: None,
+            evidence: None,
+            expected_value: None,
+            effort: None,
+            status: status.to_string(),
+            last_seen_at: None,
+            depends_on: vec![],
+            blocks: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn findings_status_flag_filters_listing() {
+        let ws = setup_workspace();
+        let store = open_store(&ws).await;
+        store
+            .create_finding(finding_body("f-triaged", "triaged"))
+            .await
+            .expect("seed triaged finding");
+        store
+            .create_finding(finding_body("f-resolved", "resolved"))
+            .await
+            .expect("seed resolved finding");
+
+        let args = DataArgs {
+            status: Some("triaged".to_string()),
+            ..base_args(&ws, DataVerb::Get, "findings")
+        };
+        let value = dispatch_data(&store, &args, None)
+            .await
+            .expect("filtered list must succeed");
+        let items = value.as_array().expect("array response");
+        assert_eq!(
+            items.len(),
+            1,
+            "expected exactly one triaged finding: {value}"
+        );
+        assert_eq!(items[0]["id"], "f-triaged");
+    }
+
+    #[tokio::test]
+    async fn change_requests_status_flag_filters_listing() {
+        let ws = setup_workspace();
+        let store = open_store(&ws).await;
+        store
+            .create_change_request(newton_backend::CreateChangeRequestBody {
+                id: "cr-proposed".to_string(),
+                title: "proposed CR".to_string(),
+                body: None,
+                origin: "system".to_string(),
+                author: None,
+                component_id: None,
+                repo_id: None,
+                finding_ids: vec![],
+                risk: "low".to_string(),
+                confidence: None,
+            })
+            .await
+            .expect("seed proposed CR");
+        store
+            .patch_change_request(
+                "cr-proposed",
+                newton_backend::PatchChangeRequestBody {
+                    status: Some("approved".to_string()),
+                },
+            )
+            .await
+            .expect("patch CR to approved");
+        store
+            .create_change_request(newton_backend::CreateChangeRequestBody {
+                id: "cr-proposed-2".to_string(),
+                title: "still proposed CR".to_string(),
+                body: None,
+                origin: "system".to_string(),
+                author: None,
+                component_id: None,
+                repo_id: None,
+                finding_ids: vec![],
+                risk: "low".to_string(),
+                confidence: None,
+            })
+            .await
+            .expect("seed second proposed CR");
+
+        let args = DataArgs {
+            status: Some("approved".to_string()),
+            ..base_args(&ws, DataVerb::Get, "change-requests")
+        };
+        let value = dispatch_data(&store, &args, None)
+            .await
+            .expect("filtered list must succeed");
+        let items = value.as_array().expect("array response");
+        assert_eq!(items.len(), 1, "expected exactly one approved CR: {value}");
+        assert_eq!(items[0]["id"], "cr-proposed");
+    }
+
+    #[tokio::test]
+    async fn plans_status_flag_filters_listing() {
+        let ws = setup_workspace();
+        let store = open_store(&ws).await;
+        // Plan.linkedChangeRequestId is a real FK — seed the ChangeRequests
+        // it points at first.
+        for cr_id in ["cr-x", "cr-y"] {
+            store
+                .create_change_request(newton_backend::CreateChangeRequestBody {
+                    id: cr_id.to_string(),
+                    title: format!("{cr_id} title"),
+                    body: None,
+                    origin: "system".to_string(),
+                    author: None,
+                    component_id: None,
+                    repo_id: None,
+                    finding_ids: vec![],
+                    risk: "low".to_string(),
+                    confidence: None,
+                })
+                .await
+                .unwrap_or_else(|e| panic!("seed {cr_id}: {e:?}"));
+        }
+        store
+            .create_plan(newton_backend::CreatePlanBody {
+                id: "plan-draft".to_string(),
+                title: "draft plan".to_string(),
+                linked_change_request_id: "cr-x".to_string(),
+                body: None,
+                status: "draft".to_string(),
+                component_id: None,
+                repo_id: None,
+                module: None,
+                confidence: 50,
+                risk: "low".to_string(),
+                expected_value: None,
+                expected_delta: None,
+            })
+            .await
+            .expect("seed draft plan");
+        store
+            .create_plan(newton_backend::CreatePlanBody {
+                id: "plan-ready".to_string(),
+                title: "ready plan".to_string(),
+                linked_change_request_id: "cr-y".to_string(),
+                body: None,
+                status: "ready".to_string(),
+                component_id: None,
+                repo_id: None,
+                module: None,
+                confidence: 50,
+                risk: "low".to_string(),
+                expected_value: None,
+                expected_delta: None,
+            })
+            .await
+            .expect("seed ready plan");
+
+        let args = DataArgs {
+            status: Some("ready".to_string()),
+            ..base_args(&ws, DataVerb::Get, "plans")
+        };
+        let value = dispatch_data(&store, &args, None)
+            .await
+            .expect("filtered list must succeed");
+        let items = value.as_array().expect("array response");
+        assert_eq!(items.len(), 1, "expected exactly one ready plan: {value}");
+        assert_eq!(items[0]["id"], "plan-ready");
+    }
+
+    // ── CLI-level validation gates for the new/widened filter flags ────────
+
+    #[tokio::test]
+    async fn status_flag_rejected_for_unsupported_resource() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Get, "products");
+        args.status = Some("triaged".to_string());
+        let err = data(args).await.expect_err("must fail");
+        let exit = expect_cli_exit(err);
+        assert!(exit.message.contains("DATA-009"), "{}", exit.message);
+    }
+
+    #[tokio::test]
+    async fn scope_flag_now_allowed_for_findings_and_plans() {
+        let ws = setup_workspace();
+        let mut args = base_args(&ws, DataVerb::Get, "findings");
+        args.scope = Some("component".to_string());
+        args.scope_id = Some("does-not-matter".to_string());
+        // Must reach the store call (and succeed with an empty list), not
+        // the CLI-level DATA-008 validation gate.
+        let result = data(args).await;
+        assert!(result.is_ok(), "{result:?}");
     }
 }

--- a/crates/cli/src/cli/commands/data.rs
+++ b/crates/cli/src/cli/commands/data.rs
@@ -700,7 +700,7 @@ async fn dispatch_data(
         // through to the generic "unsupported combination" error, each
         // rejection names the resource and points at the correct operation.
         (DataVerb::Delete, "finding" | "findings") => Err(
-            "DATA-009: findings have no DELETE — they are retired via status transitions, \
+            "DATA-010: findings have no DELETE — they are retired via status transitions, \
              not removal. PATCH status to 'rejected' or 'deferred' to close one by hand \
              (`newton data patch finding <id> --body '{\"status\":\"rejected\"}'`); a Finding \
              also auto-resolves on a clean re-grade and auto-blocks when its Plan's retries \
@@ -708,14 +708,14 @@ async fn dispatch_data(
                 .to_string(),
         ),
         (DataVerb::Delete, "change-request" | "change-requests") => Err(
-            "DATA-009: change requests have no DELETE — they move through \
+            "DATA-010: change requests have no DELETE — they move through \
              `proposed → approved → planned → rejected`, not removal. PATCH status to \
              'rejected' to close one (`newton data patch change-request <id> --body \
              '{\"status\":\"rejected\"}'`). See CONTEXT.md's Change Request lifecycle."
                 .to_string(),
         ),
         (DataVerb::Delete, "plan" | "plans") => Err(
-            "DATA-009: plans have no DELETE — the plan queue is retired via status \
+            "DATA-010: plans have no DELETE — the plan queue is retired via status \
              transitions (`draft → ready → running → complete | failed`, plus \
              'abandoned' for a human-shelved/rejected plan), not removal. PATCH status to \
              'abandoned' to close one (`newton data patch plan <id> --body \
@@ -723,7 +723,7 @@ async fn dispatch_data(
                 .to_string(),
         ),
         (DataVerb::Delete, "optimize-run" | "optimize-runs") => Err(
-            "DATA-009: optimize runs have no DELETE — a Run is the durable audit record \
+            "DATA-010: optimize runs have no DELETE — a Run is the durable audit record \
              of one loop invocation (status: running | converged | stalled_on_blocked | \
              max_cycles | regressed | no_progress). PATCH status if it needs to be \
              force-closed (`newton data patch optimize-run <id> --body '{\"status\":...}'`). \
@@ -731,25 +731,25 @@ async fn dispatch_data(
                 .to_string(),
         ),
         (DataVerb::Delete, "optimize-cycle" | "optimize-cycles") => Err(
-            "DATA-009: optimize cycles have no DELETE — a Cycle is an immutable Trajectory \
+            "DATA-010: optimize cycles have no DELETE — a Cycle is an immutable Trajectory \
              entry within its Optimize Run's audit trail and is never retired individually. \
              See CONTEXT.md's Cycle / Trajectory."
                 .to_string(),
         ),
         (DataVerb::Delete, "kpi" | "kpis") => Err(
-            "DATA-009: kpis have no DELETE — a KPI is a governance/reporting catalog entry \
+            "DATA-010: kpis have no DELETE — a KPI is a governance/reporting catalog entry \
              (there is currently no update operation for it either, only create/get/list); \
              retiring one requires an out-of-band catalog edit. See CONTEXT.md's KPI."
                 .to_string(),
         ),
         (DataVerb::Delete, "eval-run" | "eval-runs") => Err(
-            "DATA-009: eval-runs have no DELETE — each is an append-only historical record \
+            "DATA-010: eval-runs have no DELETE — each is an append-only historical record \
              of one completed evaluation and cannot be modified or removed. \
              See CONTEXT.md's Evaluation model."
                 .to_string(),
         ),
         (DataVerb::Delete, "grade" | "grades") => Err(
-            "DATA-009: grades have no DELETE — Grade is explicitly append-only \
+            "DATA-010: grades have no DELETE — Grade is explicitly append-only \
              (the score history a run is judged against) and cannot be removed. \
              See CONTEXT.md's Grade."
                 .to_string(),
@@ -1113,7 +1113,7 @@ mod p12_data_matrix_tests {
             .expect_err(&format!("delete {resource} must be rejected"));
         let exit = expect_cli_exit(err);
         assert!(
-            exit.message.contains("DATA-009"),
+            exit.message.contains("DATA-010"),
             "resource={resource} msg={}",
             exit.message
         );

--- a/crates/cli/src/cli/commands/serve.rs
+++ b/crates/cli/src/cli/commands/serve.rs
@@ -261,7 +261,7 @@ pub async fn serve(args: ServeArgs) -> StdResult<(), AppError> {
     );
     let state = state.with_workflow_files(std::sync::Arc::new(file_store));
 
-    let v1 = api::api_v1_router(state);
+    let v1 = api::api_v1_router(state, args.with_magic_tools);
 
     let openapi_value = api::openapi_json();
 

--- a/crates/cli/src/cli/framework_setup/commands/data.rs
+++ b/crates/cli/src/cli/framework_setup/commands/data.rs
@@ -19,7 +19,7 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             "Retrieve catalog entities (list or single-item)",
             DATA_GET_LONG_ABOUT,
             vec!["newton data get products", "newton data get product <id> --json"],
-            "get <resource> [ID] [--run-id RUNID] [--kpi-id KPIID] [--scope SCOPE] [--scope-id SCOPEID] [--source SOURCE] [--limit N] [--json] [--output-format FORMAT] [--workspace PATH]",
+            "get <resource> [ID] [--run-id RUNID] [--kpi-id KPIID] [--scope SCOPE] [--scope-id SCOPEID] [--source SOURCE] [--limit N] [--status STATUS] [--json] [--output-format FORMAT] [--workspace PATH]",
             false,
         ),
         DataVerb::Post => (
@@ -53,7 +53,10 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             "delete",
             "Delete a catalog entity",
             DATA_DELETE_LONG_ABOUT,
-            vec!["newton data delete product <id>"],
+            vec![
+                "newton data delete product <id>",
+                "newton data patch finding <id> --body '{\"status\":\"rejected\"}'  # findings have no DELETE; see --help",
+            ],
             "delete <resource> <ID> [--json] [--workspace PATH]",
             false,
         ),
@@ -67,7 +70,12 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             cardinality: Cardinality::Required,
             help: "Resource token (product, products, component, components, \
                    repo, repos, module, modules, module-dependency, module-dependencies, \
-                   kpi, kpis, eval-run, eval-runs, grade, grades)",
+                   kpi, kpis, eval-run, eval-runs, grade, grades, finding, findings, \
+                   change-request, change-requests, plan, plans, optimize-run, \
+                   optimize-runs, optimize-cycle, optimize-cycles). DELETE is only \
+                   implemented for product/component/repo/module/module-dependency — \
+                   the remaining resources are lifecycle-managed (retired via PATCH \
+                   status) or append-only; see `newton data delete --help`.",
             ..Default::default()
         },
         ArgSpec {
@@ -124,7 +132,7 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             long: Some("run-id"),
             value_type: ArgValueType::String,
             cardinality: Cardinality::Optional,
-            help: "Filter grade listings by EvalRun id (only used with: resource=grades)",
+            help: "Filter grade listings by EvalRun id, or select the owning Optimize Run for an optimize-cycle/optimize-cycles lookup (only used with: resource=grades, optimize-cycle, optimize-cycles)",
             ..Default::default()
         });
         args.push(ArgSpec {
@@ -142,7 +150,7 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             long: Some("scope"),
             value_type: ArgValueType::String,
             cardinality: Cardinality::Optional,
-            help: "Filter EvalRun listings by scope (only used with: resource=eval-runs)",
+            help: "Filter listings by scope, e.g. component|repo|module (only used with: resource=eval-runs, findings, plans)",
             ..Default::default()
         });
         args.push(ArgSpec {
@@ -151,7 +159,8 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             long: Some("scope-id"),
             value_type: ArgValueType::String,
             cardinality: Cardinality::Optional,
-            help: "Filter EvalRun listings by scope id (only used with: resource=eval-runs)",
+            help:
+                "Filter listings by scope id (only used with: resource=eval-runs, findings, plans)",
             ..Default::default()
         });
         args.push(ArgSpec {
@@ -170,6 +179,15 @@ pub(crate) fn data_verb_command(verb: DataVerb) -> Command {
             value_type: ArgValueType::String,
             cardinality: Cardinality::Optional,
             help: "Limit EvalRun listings (only used with: resource=eval-runs)",
+            ..Default::default()
+        });
+        args.push(ArgSpec {
+            name: "status",
+            kind: ArgKind::Option,
+            long: Some("status"),
+            value_type: ArgValueType::String,
+            cardinality: Cardinality::Optional,
+            help: "Filter listings by status (only used with: resource=findings, change-requests, plans)",
             ..Default::default()
         });
     }

--- a/crates/cli/src/cli/framework_setup/commands/serve.rs
+++ b/crates/cli/src/cli/framework_setup/commands/serve.rs
@@ -22,6 +22,7 @@ pub(crate) fn serve_command() -> Command {
                 "newton serve",
                 "newton serve --host 0.0.0.0 --port 9000",
                 "newton serve --no-web",
+                "newton serve --with-magic-tools",
             ],
             args: vec![
                 ArgSpec {
@@ -94,6 +95,15 @@ pub(crate) fn serve_command() -> Command {
                     value_type: ArgValueType::Bool,
                     cardinality: Cardinality::Optional,
                     help: "Run import scan of existing file-based runs before the HTTP listener binds",
+                    ..Default::default()
+                },
+                ArgSpec {
+                    name: "with-magic-tools",
+                    kind: ArgKind::Flag,
+                    long: Some("with-magic-tools"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    help: "Mount the magic-tool router (/aitools/...). Off by default: only a newton/ping smoke-test tool is registered until real tool definitions land",
                     ..Default::default()
                 },
             ],

--- a/crates/cli/src/cli/framework_setup/mod.rs
+++ b/crates/cli/src/cli/framework_setup/mod.rs
@@ -339,6 +339,7 @@ impl FromArgValueMap for ServeArgs {
             ailoop_base_path,
             state_dir: get_opt_path(map, "state-dir"),
             import_existing: get_bool(map, "import-existing"),
+            with_magic_tools: get_bool(map, "with-magic-tools"),
         }
     }
 }
@@ -393,6 +394,7 @@ impl DataArgs {
         let scope = get_opt_str(map, "scope");
         let scope_id = get_opt_str(map, "scope-id");
         let source = get_opt_str(map, "source");
+        let status = get_opt_str(map, "status");
         let limit = if let Some(ArgValue::Str(s)) = map.get("limit") {
             Some(
                 s.parse::<u32>()
@@ -424,6 +426,7 @@ impl DataArgs {
             scope_id,
             source,
             limit,
+            status,
         })
     }
 }

--- a/crates/cli/src/cli/help_text.rs
+++ b/crates/cli/src/cli/help_text.rs
@@ -112,7 +112,13 @@ pub(super) const DATA_GET_LONG_ABOUT: &str =
      newton data get grades\n  \
      newton data get grades --run-id <runId>\n  \
      newton data get grades --kpi-id <kpiId>\n  \
-     newton data get grade <id>";
+     newton data get grade <id>\n  \
+     newton data get findings --status triaged\n  \
+     newton data get findings --scope component --scope-id auth-service\n  \
+     newton data get change-requests --status proposed\n  \
+     newton data get plans --status ready\n  \
+     newton data get optimize-cycles --run-id <runId>\n  \
+     newton data get optimize-cycle <cycleId> --run-id <runId>";
 
 pub(super) const DATA_POST_LONG_ABOUT: &str =
     "Create a new catalog entity. For EvalRun and Grade, the caller MUST provide a stable `id`.\n\n\
@@ -133,5 +139,17 @@ pub(super) const DATA_PATCH_LONG_ABOUT: &str =
      newton data patch product <id> --body '{\"name\":\"X\"}'";
 
 pub(super) const DATA_DELETE_LONG_ABOUT: &str = "Delete a catalog entity by id.\n\n\
+     DELETE is only implemented for: product, component, repo, module, \
+     module-dependency. The remaining resources are lifecycle-managed \
+     (retired via `newton data patch <resource> <id> --body '{\"status\":...}'`) \
+     or append-only historical records, and reject DELETE with a message \
+     naming the correct operation instead of a generic error:\n  \
+     - finding: PATCH status to `rejected`/`deferred` (or let it auto-resolve/auto-block)\n  \
+     - change-request: PATCH status to `rejected`\n  \
+     - plan: PATCH status to `abandoned`\n  \
+     - optimize-run: PATCH status if it needs to be force-closed\n  \
+     - optimize-cycle: immutable Trajectory entry, never deletable\n  \
+     - kpi, eval-run, grade: append-only catalog/history, never deletable\n\n\
      EXAMPLES:\n  \
-     newton data delete product <id>";
+     newton data delete product <id>\n  \
+     newton data patch finding <id> --body '{\"status\":\"rejected\"}'";

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -199,6 +199,10 @@ name = "test_lag_tolerant_streams"
 path = "tests/integration/test_lag_tolerant_streams.rs"
 
 [[test]]
+name = "test_workflow_logs_ws_select"
+path = "tests/integration/test_workflow_logs_ws_select.rs"
+
+[[test]]
 name = "test_magic_tools"
 path = "tests/integration/test_magic_tools.rs"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -203,6 +203,10 @@ name = "test_workflow_logs_ws_select"
 path = "tests/integration/test_workflow_logs_ws_select.rs"
 
 [[test]]
+name = "test_logs_ws_since_seq"
+path = "tests/integration/test_logs_ws_since_seq.rs"
+
+[[test]]
 name = "test_magic_tools"
 path = "tests/integration/test_magic_tools.rs"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -51,6 +51,7 @@ rhai = { workspace = true }
 petgraph = { workspace = true }
 async-trait = { workspace = true }
 regex = { workspace = true }
+globset = { workspace = true }
 indexmap = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/crates/core/src/api/catalog.rs
+++ b/crates/core/src/api/catalog.rs
@@ -7,6 +7,7 @@ use axum::{
     Router,
 };
 use newton_types::ApiError;
+use newton_types::BroadcastEvent;
 use newton_types::{
     CreateComponentBody, CreateEvalRunBody, CreateGradeBody, CreateKpiBody, CreateModuleBody,
     CreateProductBody, CreateRepoBody, DeletedItem, PatchComponentBody, PatchModuleBody,
@@ -74,6 +75,19 @@ pub fn routes(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+/// Publish a `CatalogUpdate` broadcast event after a catalog mutation
+/// succeeds. `resource` names the catalog kind (`"product"`, `"component"`,
+/// `"repo"`, `"module"`, `"module-dependency"`, `"kpi"`, `"eval-run"`,
+/// `"grade"`) so subscribers can route `id` to the matching read endpoint.
+/// Fire-and-forget: no active subscriber is not an error (same pattern as
+/// `plans.rs`).
+fn catalog_event(state: &AppState, resource: &str, id: impl Into<String>) {
+    let _ = state.events_tx.send(BroadcastEvent::CatalogUpdate {
+        resource: resource.to_string(),
+        id: id.into(),
+    });
+}
+
 #[utoipa::path(
     get,
     path = "/kpis",
@@ -121,7 +135,11 @@ pub(crate) async fn create_kpi(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateKpiBody>,
 ) -> Response {
-    created_json(state.backend.create_kpi(body).await)
+    let result = state.backend.create_kpi(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "kpi", item.id.clone());
+    }
+    created_json(result)
 }
 
 // ── EvalRun ───────────────────────────────────────────────────────────────────
@@ -152,7 +170,11 @@ pub(crate) async fn create_eval_run(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateEvalRunBody>,
 ) -> Response {
-    created_json(state.backend.create_eval_run(body).await)
+    let result = state.backend.create_eval_run(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "eval-run", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -256,7 +278,11 @@ pub(crate) async fn create_product(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateProductBody>,
 ) -> Response {
-    created_json(state.backend.create_product(body).await)
+    let result = state.backend.create_product(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "product", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -277,7 +303,11 @@ pub(crate) async fn put_product(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PutProductBody>,
 ) -> Response {
-    ok_json(state.backend.put_product(&id, body).await)
+    let result = state.backend.put_product(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "product", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -297,7 +327,11 @@ pub(crate) async fn patch_product(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchProductBody>,
 ) -> Response {
-    ok_json(state.backend.patch_product(&id, body).await)
+    let result = state.backend.patch_product(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "product", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -316,13 +350,11 @@ pub(crate) async fn delete_product(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(
-        state
-            .backend
-            .delete_product(&id)
-            .await
-            .map(|id| DeletedItem { id }),
-    )
+    let result = state.backend.delete_product(&id).await;
+    if result.is_ok() {
+        catalog_event(&state, "product", id);
+    }
+    ok_json(result.map(|id| DeletedItem { id }))
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -360,7 +392,11 @@ pub(crate) async fn create_component(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateComponentBody>,
 ) -> Response {
-    created_json(state.backend.create_component(body).await)
+    let result = state.backend.create_component(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "component", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -380,7 +416,11 @@ pub(crate) async fn put_component(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PutComponentBody>,
 ) -> Response {
-    ok_json(state.backend.put_component(&id, body).await)
+    let result = state.backend.put_component(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "component", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -400,7 +440,11 @@ pub(crate) async fn patch_component(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchComponentBody>,
 ) -> Response {
-    ok_json(state.backend.patch_component(&id, body).await)
+    let result = state.backend.patch_component(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "component", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -419,13 +463,11 @@ pub(crate) async fn delete_component(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(
-        state
-            .backend
-            .delete_component(&id)
-            .await
-            .map(|id| DeletedItem { id }),
-    )
+    let result = state.backend.delete_component(&id).await;
+    if result.is_ok() {
+        catalog_event(&state, "component", id);
+    }
+    ok_json(result.map(|id| DeletedItem { id }))
 }
 
 // ── Repo ──────────────────────────────────────────────────────────────────────
@@ -464,7 +506,11 @@ pub(crate) async fn create_repo(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateRepoBody>,
 ) -> Response {
-    created_json(state.backend.create_repo(body).await)
+    let result = state.backend.create_repo(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "repo", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -484,7 +530,11 @@ pub(crate) async fn put_repo(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PutRepoBody>,
 ) -> Response {
-    ok_json(state.backend.put_repo(&id, body).await)
+    let result = state.backend.put_repo(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "repo", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -504,7 +554,11 @@ pub(crate) async fn patch_repo(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchRepoBody>,
 ) -> Response {
-    ok_json(state.backend.patch_repo(&id, body).await)
+    let result = state.backend.patch_repo(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "repo", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -523,13 +577,11 @@ pub(crate) async fn delete_repo(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(
-        state
-            .backend
-            .delete_repo(&id)
-            .await
-            .map(|id| DeletedItem { id }),
-    )
+    let result = state.backend.delete_repo(&id).await;
+    if result.is_ok() {
+        catalog_event(&state, "repo", id);
+    }
+    ok_json(result.map(|id| DeletedItem { id }))
 }
 
 // ── Module ────────────────────────────────────────────────────────────────────
@@ -580,7 +632,11 @@ pub(crate) async fn create_module(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateModuleBody>,
 ) -> Response {
-    created_json(state.backend.create_module(body).await)
+    let result = state.backend.create_module(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "module", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -600,7 +656,11 @@ pub(crate) async fn put_module(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PutModuleBody>,
 ) -> Response {
-    ok_json(state.backend.put_module(&id, body).await)
+    let result = state.backend.put_module(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "module", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -620,7 +680,11 @@ pub(crate) async fn patch_module(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchModuleBody>,
 ) -> Response {
-    ok_json(state.backend.patch_module(&id, body).await)
+    let result = state.backend.patch_module(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "module", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -639,13 +703,11 @@ pub(crate) async fn delete_module(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(
-        state
-            .backend
-            .delete_module(&id)
-            .await
-            .map(|id| DeletedItem { id }),
-    )
+    let result = state.backend.delete_module(&id).await;
+    if result.is_ok() {
+        catalog_event(&state, "module", id);
+    }
+    ok_json(result.map(|id| DeletedItem { id }))
 }
 
 // ── ModuleDependency ──────────────────────────────────────────────────────────
@@ -685,7 +747,11 @@ pub(crate) async fn patch_module_dependency(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchModuleDependencyBody>,
 ) -> Response {
-    ok_json(state.backend.patch_module_dependency(&id, body).await)
+    let result = state.backend.patch_module_dependency(&id, body).await;
+    if result.is_ok() {
+        catalog_event(&state, "module-dependency", id);
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -703,13 +769,11 @@ pub(crate) async fn delete_module_dependency(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(
-        state
-            .backend
-            .delete_module_dependency(&id)
-            .await
-            .map(|id| DeletedItem { id }),
-    )
+    let result = state.backend.delete_module_dependency(&id).await;
+    if result.is_ok() {
+        catalog_event(&state, "module-dependency", id);
+    }
+    ok_json(result.map(|id| DeletedItem { id }))
 }
 
 // ── Grade ─────────────────────────────────────────────────────────────────────
@@ -758,7 +822,11 @@ pub(crate) async fn create_grade(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateGradeBody>,
 ) -> Response {
-    created_json(state.backend.create_grade(body).await)
+    let result = state.backend.create_grade(body).await;
+    if let Ok(ref item) = result {
+        catalog_event(&state, "grade", item.id.clone());
+    }
+    created_json(result)
 }
 
 #[utoipa::path(

--- a/crates/core/src/api/change_requests.rs
+++ b/crates/core/src/api/change_requests.rs
@@ -8,6 +8,7 @@ use axum::{
     Router,
 };
 use newton_types::ApiError;
+use newton_types::BroadcastEvent;
 use newton_types::{CreateChangeRequestBody, PatchChangeRequestBody};
 use serde::Deserialize;
 use std::sync::Arc;
@@ -64,7 +65,13 @@ pub(crate) async fn create_change_request(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateChangeRequestBody>,
 ) -> Response {
-    created_json(state.backend.create_change_request(body).await)
+    let result = state.backend.create_change_request(body).await;
+    if let Ok(ref item) = result {
+        let _ = state.events_tx.send(BroadcastEvent::ChangeRequestUpdate {
+            change_request_id: item.id.clone(),
+        });
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -103,5 +110,11 @@ pub(crate) async fn patch_change_request(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchChangeRequestBody>,
 ) -> Response {
-    ok_json(state.backend.patch_change_request(&id, body).await)
+    let result = state.backend.patch_change_request(&id, body).await;
+    if result.is_ok() {
+        let _ = state.events_tx.send(BroadcastEvent::ChangeRequestUpdate {
+            change_request_id: id,
+        });
+    }
+    ok_json(result)
 }

--- a/crates/core/src/api/findings.rs
+++ b/crates/core/src/api/findings.rs
@@ -8,6 +8,7 @@ use axum::{
     Router,
 };
 use newton_types::ApiError;
+use newton_types::BroadcastEvent;
 use newton_types::{CreateFindingBody, PatchFindingBody};
 use serde::Deserialize;
 use std::sync::Arc;
@@ -68,7 +69,13 @@ pub(crate) async fn create_finding(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateFindingBody>,
 ) -> Response {
-    created_json(state.backend.create_finding(body).await)
+    let result = state.backend.create_finding(body).await;
+    if let Ok(ref item) = result {
+        let _ = state.events_tx.send(BroadcastEvent::FindingUpdate {
+            finding_id: item.id.clone(),
+        });
+    }
+    created_json(result)
 }
 
 #[utoipa::path(
@@ -107,7 +114,13 @@ pub(crate) async fn patch_finding(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PatchFindingBody>,
 ) -> Response {
-    ok_json(state.backend.patch_finding(&id, body).await)
+    let result = state.backend.patch_finding(&id, body).await;
+    if result.is_ok() {
+        let _ = state
+            .events_tx
+            .send(BroadcastEvent::FindingUpdate { finding_id: id });
+    }
+    ok_json(result)
 }
 
 #[utoipa::path(
@@ -126,5 +139,11 @@ pub(crate) async fn unblock_finding(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    ok_json(state.backend.unblock_finding(&id).await)
+    let result = state.backend.unblock_finding(&id).await;
+    if result.is_ok() {
+        let _ = state
+            .events_tx
+            .send(BroadcastEvent::FindingUpdate { finding_id: id });
+    }
+    ok_json(result)
 }

--- a/crates/core/src/api/mod.rs
+++ b/crates/core/src/api/mod.rs
@@ -51,9 +51,16 @@ pub(crate) fn created_json<T: Serialize>(r: Result<T, ApiError>) -> Response {
 }
 
 // lockstep: axum major version MUST match cli-framework (both 0.8)
-pub fn api_v1_router(state: AppState) -> Router {
+///
+/// `with_magic_tools` gates the `aikit_magictool` router (spec 074 P9): it
+/// currently registers only a `newton/ping` smoke-test tool, with real
+/// `ToolDef`s landing in a future Part B work item. Until then the router is
+/// mounted only when explicitly opted in (`newton serve --with-magic-tools`)
+/// so the surface isn't live-but-empty by default. Not part of the OpenAPI
+/// doc — that's Part B's job, once the tools are real.
+pub fn api_v1_router(state: AppState, with_magic_tools: bool) -> Router {
     let arc_state = Arc::new(state);
-    Router::new()
+    let mut router = Router::new()
         .merge(workflows::routes(arc_state.clone()))
         .merge(hil::routes(arc_state.clone()))
         .merge(streaming::routes(arc_state.clone()))
@@ -67,8 +74,11 @@ pub fn api_v1_router(state: AppState) -> Router {
         .merge(catalog::routes(arc_state.clone()))
         .merge(optimize_run::routes(arc_state.clone()))
         .merge(testing_reset::routes(arc_state.clone()))
-        .merge(workflow_files::routes(arc_state.clone()))
-        .merge(aikit_magictool::router(magic_tools::build_state()))
+        .merge(workflow_files::routes(arc_state.clone()));
+    if with_magic_tools {
+        router = router.merge(aikit_magictool::router(magic_tools::build_state()));
+    }
+    router
 }
 
 /// The Newton web UI, vendored as a single self-contained, gzip-compressed
@@ -135,6 +145,58 @@ pub fn embedded_web_router() -> Router {
 pub fn openapi_json() -> serde_json::Value {
     use utoipa::OpenApi;
     serde_json::to_value(openapi::ApiDoc::openapi()).expect("OpenAPI doc serialization failed")
+}
+
+#[cfg(test)]
+mod magic_tools_gate_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use newton_types::OperatorDescriptor;
+    use tower::ServiceExt;
+
+    async fn test_state() -> AppState {
+        let operators = vec![OperatorDescriptor {
+            operator_type: "noop".to_string(),
+            description: "No-operation operator".to_string(),
+            params_schema: serde_json::json!({}),
+        }];
+        let store = newton_backend::SqliteBackendStore::new_in_memory()
+            .await
+            .expect("in-memory backend init");
+        let backend: Arc<dyn newton_backend::BackendStore> = Arc::new(store);
+        AppState::new(operators, backend)
+    }
+
+    #[tokio::test]
+    async fn magic_tools_router_absent_by_default() {
+        let app = api_v1_router(test_state().await, false);
+        let req = Request::builder()
+            .uri("/aitools")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "/aitools should be unmounted when with_magic_tools=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn magic_tools_router_present_when_enabled() {
+        let app = api_v1_router(test_state().await, true);
+        let req = Request::builder()
+            .uri("/aitools")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/aitools should be mounted when with_magic_tools=true"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/api/optimize_run.rs
+++ b/crates/core/src/api/optimize_run.rs
@@ -6,6 +6,10 @@ use axum::{
     routing::get,
     Router,
 };
+use newton_types::{
+    ApiError, BroadcastEvent, CreateOptimizeCycleBody, CreateOptimizeRunBody, OptimizeCycleItem,
+    OptimizeRunItem, PatchOptimizeRunBody,
+};
 use std::sync::Arc;
 
 pub fn routes(state: Arc<AppState>) -> Router {
@@ -94,4 +98,216 @@ pub(crate) async fn list_optimize_cycles(
     State(state): State<Arc<AppState>>,
 ) -> Response {
     ok_json(state.backend.list_optimize_cycles(&id).await)
+}
+
+// ── In-process write-and-broadcast primitives (spec 074 P3 / ADR-0013) ────────
+//
+// Deliberately NOT mounted as routes: ADR-0013 is explicit that "the 070 HTTP
+// surface stays read-only ... no write routes are added" (upholding ADR-0004,
+// no external ingress). These are the store-write-then-broadcast primitives
+// the *in-process* `newton optimize` driver (spec 073, still draft/unbuilt)
+// is meant to call directly, in-process, once it exists — mirroring exactly
+// how `plans.rs`'s `approve_plan`/`reject_plan` call `state.backend...` then
+// `state.events_tx.send(...)`.
+//
+// Judgment call (documented per the work-item instructions): as of this
+// change, NO code path in the repository actually calls these. The only
+// current mutator of `OptimizeRun`/`OptimizeCycle` rows is
+// `crates/cli/src/cli/commands/data.rs`'s `dispatch_data()` (invoked via
+// `newton data post/patch optimize-run|optimize-cycle`), which the external
+// `optimize.sh` bash driver shells out to — a separate OS process with no
+// access to `serve`'s `AppState.events_tx`, exactly the limitation ADR-0013
+// describes for the *interim* driver. `crates/cli/src/cli/commands/optimize.rs`
+// (the `newton optimize` command) is a plan-queue executor; it never touches
+// the `OptimizeRun`/`OptimizeCycle` tables at all. The real in-process driver
+// that owns Run/Cycle lifecycle end-to-end in `serve`'s own process is spec
+// 073 (draft, not implemented) — building it is out of this work item's
+// scope. Rather than fabricate a caller (e.g. a process-global broadcast
+// channel bridging the CLI's `data` command into `serve`, or a write HTTP
+// route/DB-polling bridge — both explicitly rejected in ADR-0013 "Considered
+// and rejected"), this change ships the tested write-and-broadcast primitive
+// spec 073 needs, ready to be called the moment that command lands. They are
+// `pub` (not `pub(crate)`) deliberately: the future driver is expected to
+// live in `crates/cli` (a different crate from this one), same as every
+// other CLI command that already calls into `newton_core` today.
+
+/// Create an `OptimizeRun` row and broadcast `OptimizeRunUpdate { cycle: None }`
+/// on `state.events_tx`. See the module-level comment above for the current
+/// (unwired) status of this primitive.
+pub async fn create_optimize_run(
+    state: &AppState,
+    body: CreateOptimizeRunBody,
+) -> Result<OptimizeRunItem, ApiError> {
+    let item = state.backend.create_optimize_run(body).await?;
+    let _ = state.events_tx.send(BroadcastEvent::OptimizeRunUpdate {
+        run_id: item.id.clone(),
+        cycle: None,
+    });
+    Ok(item)
+}
+
+/// Patch an `OptimizeRun` row and broadcast `OptimizeRunUpdate { cycle: None }`
+/// on `state.events_tx`. See the module-level comment above for the current
+/// (unwired) status of this primitive.
+pub async fn patch_optimize_run(
+    state: &AppState,
+    id: &str,
+    body: PatchOptimizeRunBody,
+) -> Result<OptimizeRunItem, ApiError> {
+    let item = state.backend.patch_optimize_run(id, body).await?;
+    let _ = state.events_tx.send(BroadcastEvent::OptimizeRunUpdate {
+        run_id: item.id.clone(),
+        cycle: None,
+    });
+    Ok(item)
+}
+
+/// Append an `OptimizeCycle` row and broadcast
+/// `OptimizeRunUpdate { cycle: Some(cycle_number) }` on `state.events_tx`.
+/// See the module-level comment above for the current (unwired) status of
+/// this primitive.
+pub async fn create_optimize_cycle(
+    state: &AppState,
+    body: CreateOptimizeCycleBody,
+) -> Result<OptimizeCycleItem, ApiError> {
+    let item = state.backend.create_optimize_cycle(body).await?;
+    let _ = state.events_tx.send(BroadcastEvent::OptimizeRunUpdate {
+        run_id: item.run_id.clone(),
+        cycle: Some(item.cycle),
+    });
+    Ok(item)
+}
+
+#[cfg(test)]
+mod optimize_run_update_tests {
+    use super::*;
+    use newton_types::OperatorDescriptor;
+
+    async fn test_state() -> AppState {
+        let store = newton_backend::SqliteBackendStore::new_in_memory()
+            .await
+            .expect("in-memory backend init");
+        let backend: Arc<dyn newton_backend::BackendStore> = Arc::new(store);
+        AppState::new(Vec::<OperatorDescriptor>::new(), backend)
+    }
+
+    #[tokio::test]
+    async fn create_optimize_run_broadcasts_optimize_run_update() {
+        let state = test_state().await;
+        let mut rx = state.events_tx.subscribe();
+
+        let item = create_optimize_run(
+            &state,
+            CreateOptimizeRunBody {
+                id: "run-1".to_string(),
+                project_id: "proj-1".to_string(),
+                scope: "repo".to_string(),
+                scope_id: "repo-1".to_string(),
+                max_cycles: 5,
+                graders: vec![],
+            },
+        )
+        .await
+        .expect("create_optimize_run");
+
+        let event = rx.try_recv().expect("event should be sent");
+        match event {
+            BroadcastEvent::OptimizeRunUpdate { run_id, cycle } => {
+                assert_eq!(run_id, item.id);
+                assert_eq!(cycle, None);
+            }
+            other => panic!("expected OptimizeRunUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn patch_optimize_run_broadcasts_optimize_run_update() {
+        let state = test_state().await;
+        create_optimize_run(
+            &state,
+            CreateOptimizeRunBody {
+                id: "run-2".to_string(),
+                project_id: "proj-1".to_string(),
+                scope: "repo".to_string(),
+                scope_id: "repo-1".to_string(),
+                max_cycles: 5,
+                graders: vec![],
+            },
+        )
+        .await
+        .expect("create_optimize_run");
+
+        let mut rx = state.events_tx.subscribe();
+        patch_optimize_run(
+            &state,
+            "run-2",
+            PatchOptimizeRunBody {
+                status: Some("converged".to_string()),
+                cycle: None,
+                latest_grades: None,
+                open_findings: None,
+                blocked_findings: None,
+                outcome_reason: None,
+            },
+        )
+        .await
+        .expect("patch_optimize_run");
+
+        let event = rx.try_recv().expect("event should be sent");
+        match event {
+            BroadcastEvent::OptimizeRunUpdate { run_id, cycle } => {
+                assert_eq!(run_id, "run-2");
+                assert_eq!(cycle, None);
+            }
+            other => panic!("expected OptimizeRunUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_optimize_cycle_broadcasts_optimize_run_update_with_cycle() {
+        let state = test_state().await;
+        create_optimize_run(
+            &state,
+            CreateOptimizeRunBody {
+                id: "run-3".to_string(),
+                project_id: "proj-1".to_string(),
+                scope: "repo".to_string(),
+                scope_id: "repo-1".to_string(),
+                max_cycles: 5,
+                graders: vec![],
+            },
+        )
+        .await
+        .expect("create_optimize_run");
+
+        let mut rx = state.events_tx.subscribe();
+        let cycle = create_optimize_cycle(
+            &state,
+            CreateOptimizeCycleBody {
+                id: "cycle-1".to_string(),
+                run_id: "run-3".to_string(),
+                cycle: 1,
+                grades: serde_json::json!({}),
+                grade_min: None,
+                decision: "continue".to_string(),
+                change_request_id: None,
+                plan_id: None,
+                execution_id: None,
+                develop_status: None,
+                open_findings: 0,
+                resolved_this_cycle: 0,
+            },
+        )
+        .await
+        .expect("create_optimize_cycle");
+
+        let event = rx.try_recv().expect("event should be sent");
+        match event {
+            BroadcastEvent::OptimizeRunUpdate { run_id, cycle: c } => {
+                assert_eq!(run_id, "run-3");
+                assert_eq!(c, Some(cycle.cycle));
+            }
+            other => panic!("expected OptimizeRunUpdate, got {other:?}"),
+        }
+    }
 }

--- a/crates/core/src/api/plans.rs
+++ b/crates/core/src/api/plans.rs
@@ -85,6 +85,7 @@ pub(crate) async fn approve_plan(
                 .events_tx
                 .send(newton_types::BroadcastEvent::PlanUpdate {
                     plan_id: id.clone(),
+                    instance_id: Some(approved.instance_id.clone()),
                 });
             let _ = state
                 .events_tx
@@ -93,6 +94,7 @@ pub(crate) async fn approve_plan(
                     plan_id: Some(id.clone()),
                     status: "running".to_string(),
                     created_at: approved.created_at.clone(),
+                    instance_id: approved.instance_id.clone(),
                 });
             (StatusCode::OK, Json(approved.plan)).into_response()
         }
@@ -129,6 +131,15 @@ pub(crate) async fn reject_plan(
                 .events_tx
                 .send(newton_types::BroadcastEvent::PlanUpdate {
                     plan_id: id.clone(),
+                    // Rejection is only reachable from `awaiting_approval` /
+                    // `needs_revision` (see `reject_plan_db`) — states in
+                    // which this plan has no *currently owning* execution
+                    // instance. Even if `execution_ids` holds ids from a
+                    // prior failed approve/run cycle, none of them own this
+                    // rejection, so `None` is the honest value (and the safe
+                    // one: instance-scoped streams drop it rather than
+                    // routing it to a stale instance).
+                    instance_id: None,
                 });
             (StatusCode::OK, Json(plan)).into_response()
         }

--- a/crates/core/src/api/state.rs
+++ b/crates/core/src/api/state.rs
@@ -1,9 +1,23 @@
 use crate::workflow::file_store::WorkflowFileStore;
 use newton_types::{BroadcastEvent, OperatorDescriptor};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::broadcast;
 
 pub const BROADCAST_CAPACITY: usize = 1024;
+
+/// Default interval between server-initiated WebSocket `Ping` frames on the
+/// streaming endpoints (`/ws`, `/stream/workflow/{id}/ws`,
+/// `/stream/logs/{id}/{node_id}/ws`). Serves two purposes: keeping idle
+/// connections alive through proxies/load balancers that reap quiet sockets,
+/// and giving each handler's `tokio::select!` loop a bounded upper bound on
+/// how long it can take to notice a dead peer (a failed ping send breaks the
+/// loop, same as any other failed send).
+///
+/// Stored per-`AppState` (see `ws_ping_interval` / `with_ws_ping_interval`)
+/// rather than used as a bare constant everywhere so integration tests can
+/// override it to something much shorter than 30 real seconds.
+pub const HEARTBEAT_PING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Application state shared across all HTTP handlers.
 ///
@@ -17,6 +31,10 @@ pub struct AppState {
     pub events_tx: broadcast::Sender<BroadcastEvent>,
     pub backend: Arc<dyn newton_types::BackendStore>,
     pub workflow_files: Option<Arc<dyn WorkflowFileStore>>,
+    /// WS ping cadence for the streaming endpoints; defaults to
+    /// `HEARTBEAT_PING_INTERVAL`. Overridable via `with_ws_ping_interval`
+    /// (test-only in practice — there is no HTTP surface to change it).
+    pub ws_ping_interval: Duration,
 }
 
 impl AppState {
@@ -30,11 +48,21 @@ impl AppState {
             events_tx,
             backend,
             workflow_files: None,
+            ws_ping_interval: HEARTBEAT_PING_INTERVAL,
         }
     }
 
     pub fn with_workflow_files(mut self, store: Arc<dyn WorkflowFileStore>) -> Self {
         self.workflow_files = Some(store);
+        self
+    }
+
+    /// Override the WS ping interval (default: `HEARTBEAT_PING_INTERVAL`,
+    /// 30s). Intended for integration tests that need to observe ping
+    /// cadence without waiting out the real interval; production code never
+    /// calls this.
+    pub fn with_ws_ping_interval(mut self, interval: Duration) -> Self {
+        self.ws_ping_interval = interval;
         self
     }
 }

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -404,6 +404,10 @@ fn should_send_event(event: &BroadcastEvent, instance_id: &str, filters: &Stream
             BroadcastEvent::HilEvent { .. } => "hilEvent",
             BroadcastEvent::PlanUpdate { .. } => "plan_update",
             BroadcastEvent::ExecutionUpdate { .. } => "execution_update",
+            BroadcastEvent::FindingUpdate { .. } => "finding_update",
+            BroadcastEvent::ChangeRequestUpdate { .. } => "change_request_update",
+            BroadcastEvent::CatalogUpdate { .. } => "catalog_update",
+            BroadcastEvent::OptimizeRunUpdate { .. } => "optimize_run_update",
         };
 
         if filter_type != event_type {
@@ -446,6 +450,16 @@ fn should_send_event(event: &BroadcastEvent, instance_id: &str, filters: &Stream
             instance_id: ref evt_id,
             ..
         } => evt_id == instance_id,
-        BroadcastEvent::PlanUpdate { .. } | BroadcastEvent::ExecutionUpdate { .. } => true,
+        // Not workflow-instance-scoped, same treatment as PlanUpdate/ExecutionUpdate:
+        // these are domain-object mutation events (Finding/ChangeRequest/Catalog/
+        // OptimizeRun), not tied to a workflow instance id, so `instance_id`
+        // filtering (handled above via `filters.instance_id`) doesn't apply to them
+        // and they pass through unconditionally here.
+        BroadcastEvent::PlanUpdate { .. }
+        | BroadcastEvent::ExecutionUpdate { .. }
+        | BroadcastEvent::FindingUpdate { .. }
+        | BroadcastEvent::ChangeRequestUpdate { .. }
+        | BroadcastEvent::CatalogUpdate { .. }
+        | BroadcastEvent::OptimizeRunUpdate { .. } => true,
     }
 }

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -25,6 +25,12 @@ use uuid::Uuid;
 
 const WELCOME_FRAME: &str = r#"{"type":"welcome"}"#;
 
+/// Default number of historical log lines replayed on a fresh logs WS
+/// connection (no `since_seq` given). Spec 074 B18: a full replay of
+/// potentially unbounded history is not an acceptable default; callers that
+/// need everything since a known point should pass `since_seq` instead.
+const DEFAULT_LOG_TAIL: i64 = 500;
+
 /// Builds the JSON payload sent to a stream consumer when the shared broadcast
 /// channel overflowed and this consumer missed `skipped` events. Same shape is
 /// used for both WS text frames and SSE `data:` payloads: `{"type":"lagged","skipped":<n>}`.
@@ -46,6 +52,10 @@ pub struct StreamFilters {
     pub node_id: Option<String>,
     /// Filter by event type (e.g. `logMessage`, `nodeStateChanged`).
     pub event_type: Option<String>,
+    /// Logs WS only (spec 074 B18): resume replay from lines with `seq >
+    /// since_seq` instead of the default tail-500. Ignored by every other
+    /// stream endpoint.
+    pub since_seq: Option<i64>,
 }
 
 /// Routes for streaming endpoints (WebSocket + SSE).
@@ -264,6 +274,9 @@ async fn handle_logs_socket(
         instance_id: instance_id.clone(),
         node_id: node_id.clone(),
         message: format!("Connected to {task_name}"),
+        // Synthetic, never persisted: 0 is a documented sentinel, not a real
+        // seq (real seqs start at 1).
+        seq: 0,
     };
     if let Ok(json) = serde_json::to_string(&connect_line) {
         if socket.send(Message::Text(json.into())).await.is_err() {
@@ -271,17 +284,31 @@ async fn handle_logs_socket(
         }
     }
 
-    // Replay historical log lines (seq > 0 returns all)
-    if let Ok(historical) = state
-        .backend
-        .list_log_lines(&instance_id, &node_id, 0)
-        .await
-    {
+    // Replay historical log lines (spec 074 B18): `since_seq` resumes from
+    // that point (everything after it); with no `since_seq`, default to the
+    // last DEFAULT_LOG_TAIL lines rather than a full, potentially unbounded
+    // replay.
+    let historical = match filters.since_seq {
+        Some(since_seq) => {
+            state
+                .backend
+                .list_log_lines(&instance_id, &node_id, since_seq)
+                .await
+        }
+        None => {
+            state
+                .backend
+                .list_log_lines_tail(&instance_id, &node_id, DEFAULT_LOG_TAIL)
+                .await
+        }
+    };
+    if let Ok(historical) = historical {
         for line in historical {
             let event = BroadcastEvent::LogMessage {
                 instance_id: line.instance_id.clone(),
                 node_id: line.node_id.clone(),
                 message: line.message.clone(),
+                seq: line.seq,
             };
             if let Ok(json) = serde_json::to_string(&event) {
                 if socket.send(Message::Text(json.into())).await.is_err() {
@@ -544,6 +571,7 @@ mod tests {
             instance_id: None,
             node_id: None,
             event_type: None,
+            since_seq: None,
         }
     }
 

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -450,16 +450,132 @@ fn should_send_event(event: &BroadcastEvent, instance_id: &str, filters: &Stream
             instance_id: ref evt_id,
             ..
         } => evt_id == instance_id,
-        // Not workflow-instance-scoped, same treatment as PlanUpdate/ExecutionUpdate:
-        // these are domain-object mutation events (Finding/ChangeRequest/Catalog/
-        // OptimizeRun), not tied to a workflow instance id, so `instance_id`
-        // filtering (handled above via `filters.instance_id`) doesn't apply to them
-        // and they pass through unconditionally here.
-        BroadcastEvent::PlanUpdate { .. }
-        | BroadcastEvent::ExecutionUpdate { .. }
-        | BroadcastEvent::FindingUpdate { .. }
+        // Plan/Execution events genuinely have an owning workflow instance
+        // once a plan is approved and executed (spec 074 B13): scope them
+        // like WorkflowInstanceUpdated/NodeStateChanged/HilEvent above so a
+        // workflow-A-scoped stream never sees workflow-B's plan/execution
+        // events.
+        BroadcastEvent::PlanUpdate {
+            instance_id: ref evt_id,
+            ..
+        } => {
+            // `None` means the plan has no linked execution/instance (still
+            // awaiting approval, or rejected without ever running). There is
+            // no instance to match against, so drop it from every
+            // instance-scoped stream rather than guessing which one wants it.
+            matches!(evt_id, Some(id) if id == instance_id)
+        }
+        BroadcastEvent::ExecutionUpdate {
+            instance_id: ref evt_id,
+            ..
+        } => evt_id == instance_id,
+        // Not workflow-instance-scoped: these are domain-object mutation
+        // events (Finding/ChangeRequest/Catalog/OptimizeRun), not tied to a
+        // workflow instance id, so `instance_id` filtering (handled above via
+        // `filters.instance_id`) doesn't apply to them and they pass through
+        // unconditionally here.
+        BroadcastEvent::FindingUpdate { .. }
         | BroadcastEvent::ChangeRequestUpdate { .. }
         | BroadcastEvent::CatalogUpdate { .. }
         | BroadcastEvent::OptimizeRunUpdate { .. } => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_filters() -> StreamFilters {
+        StreamFilters {
+            instance_id: None,
+            node_id: None,
+            event_type: None,
+        }
+    }
+
+    /// Literal T3 acceptance gate (spec 074 B13): a workflow-A-scoped stream
+    /// receives no workflow-B plan events.
+    #[test]
+    fn plan_update_is_scoped_to_its_owning_instance() {
+        let filters = no_filters();
+        let event = BroadcastEvent::PlanUpdate {
+            plan_id: "plan-b".to_string(),
+            instance_id: Some("instance-b".to_string()),
+        };
+
+        assert!(
+            !should_send_event(&event, "instance-a", &filters),
+            "a workflow-A-scoped stream must not receive a PlanUpdate owned by instance B"
+        );
+        assert!(
+            should_send_event(&event, "instance-b", &filters),
+            "a workflow-B-scoped stream must receive a PlanUpdate owned by instance B"
+        );
+    }
+
+    /// Same acceptance gate, for ExecutionUpdate.
+    #[test]
+    fn execution_update_is_scoped_to_its_owning_instance() {
+        let filters = no_filters();
+        let event = BroadcastEvent::ExecutionUpdate {
+            execution_id: "exec-b".to_string(),
+            plan_id: Some("plan-b".to_string()),
+            status: "running".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            instance_id: "instance-b".to_string(),
+        };
+
+        assert!(
+            !should_send_event(&event, "instance-a", &filters),
+            "a workflow-A-scoped stream must not receive an ExecutionUpdate owned by instance B"
+        );
+        assert!(
+            should_send_event(&event, "instance-b", &filters),
+            "a workflow-B-scoped stream must receive an ExecutionUpdate owned by instance B"
+        );
+    }
+
+    /// A PlanUpdate with no linked instance (still awaiting approval, or
+    /// rejected without ever running) has nothing to match against, so every
+    /// instance-scoped stream must drop it rather than guess.
+    #[test]
+    fn plan_update_with_no_instance_is_dropped_from_every_scoped_stream() {
+        let filters = no_filters();
+        let event = BroadcastEvent::PlanUpdate {
+            plan_id: "plan-a".to_string(),
+            instance_id: None,
+        };
+
+        assert!(!should_send_event(&event, "instance-a", &filters));
+        assert!(!should_send_event(&event, "instance-b", &filters));
+    }
+
+    /// Domain-object mutation events with no instance concept at all
+    /// (Finding/ChangeRequest/Catalog/OptimizeRun) must remain unconditional
+    /// pass-through, unaffected by B13's Plan/Execution scoping change.
+    #[test]
+    fn non_instance_scoped_events_remain_unconditional_pass_through() {
+        let filters = no_filters();
+        let events = [
+            BroadcastEvent::FindingUpdate {
+                finding_id: "finding-1".to_string(),
+            },
+            BroadcastEvent::ChangeRequestUpdate {
+                change_request_id: "cr-1".to_string(),
+            },
+            BroadcastEvent::CatalogUpdate {
+                resource: "product".to_string(),
+                id: "product-1".to_string(),
+            },
+            BroadcastEvent::OptimizeRunUpdate {
+                run_id: "run-1".to_string(),
+                cycle: None,
+            },
+        ];
+
+        for event in &events {
+            assert!(should_send_event(event, "instance-a", &filters));
+            assert!(should_send_event(event, "instance-b", &filters));
+        }
     }
 }

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -14,6 +14,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use futures::{SinkExt, StreamExt};
 use newton_types::{ApiError, BroadcastEvent};
 use serde::Deserialize;
 use std::convert::Infallible;
@@ -22,7 +23,6 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
-const HEARTBEAT_PING_INTERVAL: Duration = Duration::from_secs(30);
 const WELCOME_FRAME: &str = r#"{"type":"welcome"}"#;
 
 /// Builds the JSON payload sent to a stream consumer when the shared broadcast
@@ -84,7 +84,7 @@ async fn handle_heartbeat_socket(mut socket: WebSocket, state: Arc<AppState>) {
                 Err(broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(_) => break,
             },
-            _ = tokio::time::sleep(HEARTBEAT_PING_INTERVAL) => {
+            _ = tokio::time::sleep(state.ws_ping_interval) => {
                 if socket.send(Message::Ping(vec![].into())).await.is_err() {
                     break;
                 }
@@ -151,6 +151,7 @@ async fn handle_workflow_socket(
     filters: StreamFilters,
 ) {
     let mut rx = state.events_tx.subscribe();
+    let ping_interval = state.ws_ping_interval;
     // Not used again below: drop the AppState/Sender reference this task
     // holds so the receive loop's `RecvError::Closed` arm is actually
     // reachable once every *other* reference (router, other connections)
@@ -166,24 +167,50 @@ async fn handle_workflow_socket(
         }
     }
 
+    // Split so the loop below can `select!` over reading the client's half
+    // of the socket (to notice a client-initiated Close promptly, and to
+    // drain the socket so OS receive-buffer backpressure never stalls it)
+    // at the same time as the broadcast receiver and the ping tick (spec
+    // 074 B14).
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+
     loop {
-        match rx.recv().await {
-            Ok(event) => {
-                if should_send_event(&event, &instance_id, &filters) {
-                    if let Ok(json) = serde_json::to_string(&event) {
-                        if socket.send(Message::Text(json.into())).await.is_err() {
-                            break;
+        tokio::select! {
+            ws_msg = ws_receiver.next() => match ws_msg {
+                // Client closed the connection: stop pushing to it.
+                Some(Ok(Message::Close(_))) => break,
+                // Clients don't send meaningful data on this read-only
+                // stream, but the socket must still be drained (Pong,
+                // stray Text/Binary, etc.) or backpressure could stall it.
+                Some(Ok(_)) => continue,
+                // Socket error reading from the client.
+                Some(Err(_)) => break,
+                // Stream ended: connection dropped.
+                None => break,
+            },
+            recv_result = rx.recv() => match recv_result {
+                Ok(event) => {
+                    if should_send_event(&event, &instance_id, &filters) {
+                        if let Ok(json) = serde_json::to_string(&event) {
+                            if ws_sender.send(Message::Text(json.into())).await.is_err() {
+                                break;
+                            }
                         }
                     }
                 }
-            }
-            Err(broadcast::error::RecvError::Lagged(n)) => {
-                let frame = lagged_frame_json(n);
-                if socket.send(Message::Text(frame.into())).await.is_err() {
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    let frame = lagged_frame_json(n);
+                    if ws_sender.send(Message::Text(frame.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            _ = tokio::time::sleep(ping_interval) => {
+                if ws_sender.send(Message::Ping(vec![].into())).await.is_err() {
                     break;
                 }
             }
-            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }
@@ -230,6 +257,7 @@ async fn handle_logs_socket(
 ) {
     // Subscribe first to avoid missing events during historical replay
     let mut rx = state.events_tx.subscribe();
+    let ping_interval = state.ws_ping_interval;
 
     let task_name = resolve_task_name(&state, &instance_id, &node_id).await;
     let connect_line = BroadcastEvent::LogMessage {
@@ -270,34 +298,60 @@ async fn handle_logs_socket(
     // the shared broadcast channel open forever.
     drop(state);
 
+    // Split so the loop below can `select!` over reading the client's half
+    // of the socket (to notice a client-initiated Close promptly, and to
+    // drain the socket so OS receive-buffer backpressure never stalls it)
+    // at the same time as the broadcast receiver and the ping tick (spec
+    // 074 B14).
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+
     // Forward live broadcast events
     loop {
-        match rx.recv().await {
-            Ok(event) => {
-                if should_send_event(&event, &instance_id, &filters) {
-                    if let BroadcastEvent::LogMessage {
-                        instance_id: ref evt_inst,
-                        node_id: ref evt_node,
-                        ..
-                    } = event
-                    {
-                        if evt_inst == &instance_id && evt_node == &node_id {
-                            if let Ok(json) = serde_json::to_string(&event) {
-                                if socket.send(Message::Text(json.into())).await.is_err() {
-                                    break;
+        tokio::select! {
+            ws_msg = ws_receiver.next() => match ws_msg {
+                // Client closed the connection: stop pushing to it.
+                Some(Ok(Message::Close(_))) => break,
+                // Clients don't send meaningful data on this read-only
+                // stream, but the socket must still be drained (Pong,
+                // stray Text/Binary, etc.) or backpressure could stall it.
+                Some(Ok(_)) => continue,
+                // Socket error reading from the client.
+                Some(Err(_)) => break,
+                // Stream ended: connection dropped.
+                None => break,
+            },
+            recv_result = rx.recv() => match recv_result {
+                Ok(event) => {
+                    if should_send_event(&event, &instance_id, &filters) {
+                        if let BroadcastEvent::LogMessage {
+                            instance_id: ref evt_inst,
+                            node_id: ref evt_node,
+                            ..
+                        } = event
+                        {
+                            if evt_inst == &instance_id && evt_node == &node_id {
+                                if let Ok(json) = serde_json::to_string(&event) {
+                                    if ws_sender.send(Message::Text(json.into())).await.is_err() {
+                                        break;
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-            Err(broadcast::error::RecvError::Lagged(n)) => {
-                let frame = lagged_frame_json(n);
-                if socket.send(Message::Text(frame.into())).await.is_err() {
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    let frame = lagged_frame_json(n);
+                    if ws_sender.send(Message::Text(frame.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            _ = tokio::time::sleep(ping_interval) => {
+                if ws_sender.send(Message::Ping(vec![].into())).await.is_err() {
                     break;
                 }
             }
-            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }

--- a/crates/core/src/api/streaming.rs
+++ b/crates/core/src/api/streaming.rs
@@ -288,6 +288,15 @@ async fn handle_logs_socket(
     // that point (everything after it); with no `since_seq`, default to the
     // last DEFAULT_LOG_TAIL lines rather than a full, potentially unbounded
     // replay.
+    //
+    // Delivery note: this query runs after `rx.subscribe()` above, so a real
+    // log line persisted in that window would be visible here AND arrive
+    // again via the live-forwarding loop below — at-least-once, not
+    // exactly-once, delivery for that narrow race. No production call site
+    // appends real log lines with a broadcast today (see the module-level
+    // gap noted in spec 074 B18's commit), so this is currently unreachable;
+    // once one exists, a `seq <= last_replayed_seq` guard in the live loop
+    // would close it. Clients should dedup by `seq` regardless.
     let historical = match filters.since_seq {
         Some(since_seq) => {
             state

--- a/crates/core/src/integrations/ailoop/config.rs
+++ b/crates/core/src/integrations/ailoop/config.rs
@@ -187,8 +187,12 @@ fn load_ailoop_config(workspace_root: &Path) -> Result<AiloopConfig> {
     };
 
     // Try environment variables first (highest precedence).
-    // NEWTON_AILOOP_HTTP_URL is accepted but ignored (transport is WebSocket-only).
-    let _ = env::var("NEWTON_AILOOP_HTTP_URL").ok();
+    // NEWTON_AILOOP_HTTP_URL is accepted but ignored (transport is
+    // WebSocket-only); warn loudly rather than silently discarding it
+    // (spec 074 P10) so operators don't assume it does something.
+    if let Some(msg) = ailoop_http_url_warning() {
+        tracing::warn!("{msg}");
+    }
     let ws_url_str = env::var("NEWTON_AILOOP_WS_URL").ok();
     let channel = env::var("NEWTON_AILOOP_CHANNEL").ok();
 
@@ -280,6 +284,21 @@ fn load_ailoop_config(workspace_root: &Path) -> Result<AiloopConfig> {
         enabled,
         fail_fast: false,
     })
+}
+
+/// Returns the startup warning to log when `NEWTON_AILOOP_HTTP_URL` is set
+/// but has no effect (ailoop transport is WebSocket-only). Returns `None`
+/// when the env var is unset or empty. Extracted as a pure function so the
+/// warning text is unit-testable without capturing `tracing` output
+/// (spec 074 P10; mirrors the `check_non_loopback_bind` pattern in
+/// `cli/commands/serve.rs`).
+fn ailoop_http_url_warning() -> Option<String> {
+    match env::var("NEWTON_AILOOP_HTTP_URL") {
+        Ok(val) if !val.is_empty() => {
+            Some("NEWTON_AILOOP_HTTP_URL is set but unsupported (WebSocket-only)".to_string())
+        }
+        _ => None,
+    }
 }
 
 /// Validate a URL string and return parsed URL.
@@ -458,6 +477,35 @@ mod tests {
         assert_eq!(pair1.ws_url.unwrap(), "ws://first");
         // Second value should fill in missing
         assert_eq!(pair1.channel.unwrap(), "channel2");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ailoop_http_url_warning_none_when_unset() {
+        env::remove_var("NEWTON_AILOOP_HTTP_URL");
+        assert!(ailoop_http_url_warning().is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ailoop_http_url_warning_none_when_empty() {
+        env::set_var("NEWTON_AILOOP_HTTP_URL", "");
+        let result = ailoop_http_url_warning();
+        env::remove_var("NEWTON_AILOOP_HTTP_URL");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ailoop_http_url_warning_fires_when_set() {
+        env::set_var("NEWTON_AILOOP_HTTP_URL", "http://localhost:9999");
+        let result = ailoop_http_url_warning();
+        env::remove_var("NEWTON_AILOOP_HTTP_URL");
+        let msg = result.expect("warning should fire when NEWTON_AILOOP_HTTP_URL is set");
+        assert!(
+            msg.contains("NEWTON_AILOOP_HTTP_URL is set but unsupported (WebSocket-only)"),
+            "unexpected message: {msg}"
+        );
     }
 
     #[test]

--- a/crates/core/src/workflow/operators/git/mod.rs
+++ b/crates/core/src/workflow/operators/git/mod.rs
@@ -194,12 +194,17 @@ async fn execute_create_branch(name: &str, cwd: &Path) -> Result<Value, AppError
 async fn execute_stage(exclude: &[String], cwd: &Path) -> Result<Value, AppError> {
     run_git_ok(&["add", "-A"], cwd).await?;
 
-    for pattern in exclude {
+    if !exclude.is_empty() {
+        // Build the GlobSet once, up front — not per-line — so real glob
+        // syntax (`build/*`, `**/*.log`, `dir/*.tmp`) is matched correctly
+        // and efficiently, replacing the old hand-rolled prefix/suffix-only
+        // matcher (spec 074 P11).
+        let exclude_set = build_exclude_glob_set(exclude)?;
         let listed = run_git(&["diff", "--cached", "--name-only"], cwd).await?;
         let matching: Vec<String> = listed
             .stdout
             .lines()
-            .filter(|line| glob_matches(pattern, line))
+            .filter(|line| exclude_set.is_match(line))
             .map(|s| s.to_string())
             .collect();
         for file in &matching {
@@ -213,17 +218,31 @@ async fn execute_stage(exclude: &[String], cwd: &Path) -> Result<Value, AppError
     Ok(json!({ "has_staged": has_staged }))
 }
 
-/// Minimal glob: supports `*` as wildcard.
-/// Handles patterns like "test_results.*" or "*.log".
-fn glob_matches(pattern: &str, s: &str) -> bool {
-    if let Some(prefix) = pattern.strip_suffix(".*") {
-        let basename = s.rsplit('/').next().unwrap_or(s);
-        return basename.starts_with(&format!("{prefix}."));
+/// Builds a `globset::GlobSet` from the `exclude` pattern list, so
+/// `execute_stage` can test "does this line match any exclude pattern" in
+/// one call per line instead of re-parsing patterns per line. Uses real glob
+/// syntax (`build/*`, `**/*.log`, `dir/*.tmp`) via the `globset` crate
+/// (spec 074 P11), replacing the previous hand-rolled matcher that only
+/// understood `*.ext` / `name.*`.
+fn build_exclude_glob_set(exclude: &[String]) -> Result<globset::GlobSet, AppError> {
+    let mut builder = globset::GlobSetBuilder::new();
+    for pattern in exclude {
+        let glob = globset::Glob::new(pattern).map_err(|e| {
+            AppError::new(
+                ErrorCategory::ValidationError,
+                format!("GIT-STAGE-001: invalid exclude glob pattern {pattern:?}: {e}"),
+            )
+            .with_code("GIT-STAGE-001")
+        })?;
+        builder.add(glob);
     }
-    if let Some(suffix) = pattern.strip_prefix("*.") {
-        return s.ends_with(&format!(".{suffix}"));
-    }
-    s == pattern
+    builder.build().map_err(|e| {
+        AppError::new(
+            ErrorCategory::ValidationError,
+            format!("GIT-STAGE-002: failed to build exclude glob set: {e}"),
+        )
+        .with_code("GIT-STAGE-002")
+    })
 }
 
 /// Positive structural signature for `execute_commit`'s classification: is
@@ -553,5 +572,72 @@ impl Operator for GitOperator {
             GitParams::Diff { base, max_bytes } => execute_diff(&base, max_bytes, cwd).await,
             GitParams::CleanupMerge {} => execute_cleanup_merge(cwd).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod exclude_glob_tests {
+    use super::build_exclude_glob_set;
+
+    fn matches(patterns: &[&str], line: &str) -> bool {
+        let patterns: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        build_exclude_glob_set(&patterns)
+            .expect("valid glob set")
+            .is_match(line)
+    }
+
+    // ── Real glob forms the old hand-rolled matcher silently failed on ──────
+
+    #[test]
+    fn matches_directory_star() {
+        assert!(matches(&["build/*"], "build/output.bin"));
+        assert!(matches(&["build/*"], "build/nested/output.bin"));
+        assert!(!matches(&["build/*"], "src/output.bin"));
+    }
+
+    #[test]
+    fn matches_double_star_extension() {
+        assert!(matches(&["**/*.log"], "app.log"));
+        assert!(matches(&["**/*.log"], "logs/app.log"));
+        assert!(matches(&["**/*.log"], "a/b/c/app.log"));
+        assert!(!matches(&["**/*.log"], "app.txt"));
+    }
+
+    #[test]
+    fn matches_dir_prefixed_extension() {
+        assert!(matches(&["dir/*.tmp"], "dir/scratch.tmp"));
+        assert!(!matches(&["dir/*.tmp"], "other/scratch.tmp"));
+        assert!(!matches(&["dir/*.tmp"], "dir/scratch.log"));
+    }
+
+    // ── Regression: the two forms the old matcher already supported ────────
+
+    #[test]
+    fn matches_suffix_extension_form() {
+        assert!(matches(&["*.ext"], "file.ext"));
+        assert!(matches(&["*.ext"], "nested/file.ext"));
+        assert!(!matches(&["*.ext"], "file.txt"));
+    }
+
+    #[test]
+    fn matches_prefix_dot_star_form() {
+        assert!(matches(&["name.*"], "name.json"));
+        assert!(!matches(&["name.*"], "other.json"));
+    }
+
+    // ── Multi-pattern exclude lists (the real call shape from execute_stage) ─
+
+    #[test]
+    fn multiple_patterns_match_any() {
+        let patterns = vec!["build/*", "**/*.log", "dir/*.tmp"];
+        assert!(matches(&patterns, "build/x"));
+        assert!(matches(&patterns, "a/b.log"));
+        assert!(matches(&patterns, "dir/c.tmp"));
+        assert!(!matches(&patterns, "src/main.rs"));
+    }
+
+    #[test]
+    fn empty_pattern_list_matches_nothing() {
+        assert!(!matches(&[], "anything.txt"));
     }
 }

--- a/crates/core/src/workflow/operators/git/mod.rs
+++ b/crates/core/src/workflow/operators/git/mod.rs
@@ -227,7 +227,20 @@ async fn execute_stage(exclude: &[String], cwd: &Path) -> Result<Value, AppError
 fn build_exclude_glob_set(exclude: &[String]) -> Result<globset::GlobSet, AppError> {
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in exclude {
-        let glob = globset::Glob::new(pattern).map_err(|e| {
+        // A pattern with no path separator (e.g. `test_results.*`) is a
+        // basename pattern: it must match that name at any depth, matching
+        // the pre-globset matcher's basename-extraction behavior. `globset`
+        // anchors a bare pattern to the full relative path, so without this
+        // `**/` prefix `test_results.*` would only match a root-level file
+        // and silently stop excluding the same name inside a subdirectory —
+        // exactly the regression this repo's own `git_stage` exclude lists
+        // (e.g. `test_results.*` in develop.yaml) would hit.
+        let effective_pattern = if pattern.contains('/') {
+            pattern.clone()
+        } else {
+            format!("**/{pattern}")
+        };
+        let glob = globset::Glob::new(&effective_pattern).map_err(|e| {
             AppError::new(
                 ErrorCategory::ValidationError,
                 format!("GIT-STAGE-001: invalid exclude glob pattern {pattern:?}: {e}"),
@@ -623,6 +636,22 @@ mod exclude_glob_tests {
     fn matches_prefix_dot_star_form() {
         assert!(matches(&["name.*"], "name.json"));
         assert!(!matches(&["name.*"], "other.json"));
+    }
+
+    /// Regression: a bare `name.*` (or any pattern with no `/`) must still
+    /// match at any depth, not just at the repo root — `globset::Glob`
+    /// anchors an unmodified pattern to the full relative path, which would
+    /// otherwise silently stop `test_results.*`-style excludes (used by this
+    /// repo's own `develop.yaml` workflows) from matching nested files.
+    #[test]
+    fn bare_pattern_matches_at_any_depth() {
+        assert!(matches(&["test_results.*"], "test_results.json"));
+        assert!(matches(&["test_results.*"], "artifacts/test_results.json"));
+        assert!(matches(&["test_results.*"], "a/b/c/test_results.xml"));
+        assert!(!matches(&["test_results.*"], "other.json"));
+
+        assert!(matches(&["*.log"], "app.log"));
+        assert!(matches(&["*.log"], "logs/app.log"));
     }
 
     // ── Multi-pattern exclude lists (the real call shape from execute_stage) ─

--- a/crates/core/tests/integration/test_api.rs
+++ b/crates/core/tests/integration/test_api.rs
@@ -2150,6 +2150,55 @@ async fn test_patch_finding_broadcasts_finding_update() {
 }
 
 #[tokio::test]
+async fn test_unblock_finding_broadcasts_finding_update() {
+    let state = create_test_state().await;
+    let create_body = serde_json::json!({
+        "id": "finding-broadcast-3",
+        "source": "test",
+        "origin": "system",
+        "dimension": "quality",
+        "fingerprint": "finding-broadcast-3",
+        "title": "test finding",
+        "whyItMatters": "proves FindingUpdate broadcasts on unblock",
+        "recommendedAction": "n/a",
+        "severity": "low",
+        "risk": "low",
+    });
+    state
+        .backend
+        .create_finding(serde_json::from_value(create_body).unwrap())
+        .await
+        .expect("create_finding");
+    state
+        .backend
+        .patch_finding(
+            "finding-broadcast-3",
+            serde_json::from_value(serde_json::json!({ "status": "blocked" })).unwrap(),
+        )
+        .await
+        .expect("patch_finding to blocked");
+
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state, false);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/findings/finding-broadcast-3/unblock")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let event = rx.try_recv().expect("FindingUpdate should be sent");
+    match event {
+        BroadcastEvent::FindingUpdate { finding_id } => {
+            assert_eq!(finding_id, "finding-broadcast-3");
+        }
+        other => panic!("expected FindingUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_create_change_request_broadcasts_change_request_update() {
     let state = create_test_state().await;
     let mut rx = state.events_tx.subscribe();

--- a/crates/core/tests/integration/test_api.rs
+++ b/crates/core/tests/integration/test_api.rs
@@ -2059,3 +2059,229 @@ async fn test_workflow_files_put_new_file_without_precondition_creates() {
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 }
+
+// ── Spec 074 P3: realtime event parity ─────────────────────────────────────────
+//
+// One test per new `BroadcastEvent` variant (`FindingUpdate`,
+// `ChangeRequestUpdate`, `CatalogUpdate`), asserting the event is actually
+// sent on `events_tx` when the corresponding mutation happens. Follows the
+// same subscribe-before-triggering pattern as
+// `test_node_upsert_broadcasts_event` above. `OptimizeRunUpdate` has its own
+// direct unit tests colocated with the (currently unwired) write-and-broadcast
+// primitives in `crates/core/src/api/optimize_run.rs`.
+
+#[tokio::test]
+async fn test_create_finding_broadcasts_finding_update() {
+    let state = create_test_state().await;
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state);
+
+    let body = serde_json::json!({
+        "id": "finding-broadcast-1",
+        "source": "test",
+        "origin": "system",
+        "dimension": "quality",
+        "fingerprint": "finding-broadcast-1",
+        "title": "test finding",
+        "whyItMatters": "proves FindingUpdate broadcasts",
+        "recommendedAction": "n/a",
+        "severity": "low",
+        "risk": "low",
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/findings")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let event = rx.try_recv().expect("FindingUpdate should be sent");
+    match event {
+        BroadcastEvent::FindingUpdate { finding_id } => {
+            assert_eq!(finding_id, "finding-broadcast-1");
+        }
+        other => panic!("expected FindingUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_patch_finding_broadcasts_finding_update() {
+    let state = create_test_state().await;
+    let create_body = serde_json::json!({
+        "id": "finding-broadcast-2",
+        "source": "test",
+        "origin": "system",
+        "dimension": "quality",
+        "fingerprint": "finding-broadcast-2",
+        "title": "test finding",
+        "whyItMatters": "proves FindingUpdate broadcasts on patch",
+        "recommendedAction": "n/a",
+        "severity": "low",
+        "risk": "low",
+    });
+    state
+        .backend
+        .create_finding(serde_json::from_value(create_body).unwrap())
+        .await
+        .expect("create_finding");
+
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state);
+
+    let patch_body = serde_json::json!({ "status": "triaged" });
+    let request = Request::builder()
+        .method(Method::PATCH)
+        .uri("/findings/finding-broadcast-2")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&patch_body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let event = rx.try_recv().expect("FindingUpdate should be sent");
+    match event {
+        BroadcastEvent::FindingUpdate { finding_id } => {
+            assert_eq!(finding_id, "finding-broadcast-2");
+        }
+        other => panic!("expected FindingUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_change_request_broadcasts_change_request_update() {
+    let state = create_test_state().await;
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state);
+
+    let body = serde_json::json!({
+        "id": "cr-broadcast-1",
+        "title": "test change request",
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/change-requests")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let event = rx.try_recv().expect("ChangeRequestUpdate should be sent");
+    match event {
+        BroadcastEvent::ChangeRequestUpdate { change_request_id } => {
+            assert_eq!(change_request_id, "cr-broadcast-1");
+        }
+        other => panic!("expected ChangeRequestUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_patch_change_request_broadcasts_change_request_update() {
+    let state = create_test_state().await;
+    let app = newton_core::api::api_v1_router(state.clone());
+
+    let create_body = serde_json::json!({
+        "id": "cr-broadcast-2",
+        "title": "test change request",
+    });
+    let create_request = Request::builder()
+        .method(Method::POST)
+        .uri("/change-requests")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&create_body).unwrap()))
+        .unwrap();
+    let create_response = app.clone().oneshot(create_request).await.unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    let mut rx = state.events_tx.subscribe();
+    let patch_body = serde_json::json!({ "status": "approved" });
+    let patch_request = Request::builder()
+        .method(Method::PATCH)
+        .uri("/change-requests/cr-broadcast-2")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&patch_body).unwrap()))
+        .unwrap();
+    let patch_response = app.oneshot(patch_request).await.unwrap();
+    assert_eq!(patch_response.status(), StatusCode::OK);
+
+    let event = rx.try_recv().expect("ChangeRequestUpdate should be sent");
+    match event {
+        BroadcastEvent::ChangeRequestUpdate { change_request_id } => {
+            assert_eq!(change_request_id, "cr-broadcast-2");
+        }
+        other => panic!("expected ChangeRequestUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_product_broadcasts_catalog_update() {
+    let state = create_test_state().await;
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state);
+
+    let body = serde_json::json!({ "name": "broadcast-test-product" });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/products")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let product_id = created["id"].as_str().unwrap().to_string();
+
+    let event = rx.try_recv().expect("CatalogUpdate should be sent");
+    match event {
+        BroadcastEvent::CatalogUpdate { resource, id } => {
+            assert_eq!(resource, "product");
+            assert_eq!(id, product_id);
+        }
+        other => panic!("expected CatalogUpdate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_delete_product_broadcasts_catalog_update() {
+    let state = create_test_state().await;
+    let app = newton_core::api::api_v1_router(state.clone());
+
+    let create_body = serde_json::json!({ "name": "broadcast-delete-product" });
+    let create_request = Request::builder()
+        .method(Method::POST)
+        .uri("/products")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&create_body).unwrap()))
+        .unwrap();
+    let create_response = app.clone().oneshot(create_request).await.unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body_bytes = axum::body::to_bytes(create_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&create_body_bytes).unwrap();
+    let product_id = created["id"].as_str().unwrap().to_string();
+
+    let mut rx = state.events_tx.subscribe();
+    let delete_request = Request::builder()
+        .method(Method::DELETE)
+        .uri(format!("/products/{product_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let delete_response = app.oneshot(delete_request).await.unwrap();
+    assert_eq!(delete_response.status(), StatusCode::OK);
+
+    let event = rx.try_recv().expect("CatalogUpdate should be sent");
+    match event {
+        BroadcastEvent::CatalogUpdate { resource, id } => {
+            assert_eq!(resource, "product");
+            assert_eq!(id, product_id);
+        }
+        other => panic!("expected CatalogUpdate, got {other:?}"),
+    }
+}

--- a/crates/core/tests/integration/test_api.rs
+++ b/crates/core/tests/integration/test_api.rs
@@ -89,7 +89,7 @@ async fn insert_test_hil_event(state: &AppState, event: &HilEvent) {
 #[tokio::test]
 async fn test_list_workflows_empty() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflows")
@@ -126,7 +126,7 @@ async fn test_list_workflows_with_instances() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflows")
@@ -150,7 +150,7 @@ async fn test_list_workflows_with_instances() {
 #[tokio::test]
 async fn test_get_workflow_not_found() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance_id = Uuid::new_v4();
     let request = Request::builder()
@@ -175,7 +175,7 @@ async fn test_get_workflow_not_found() {
 #[tokio::test]
 async fn test_get_workflow_invalid_id() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflows/invalid-uuid")
@@ -219,7 +219,7 @@ async fn test_get_workflow_success() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri(format!("/workflows/{}", instance_id))
@@ -259,7 +259,7 @@ async fn test_update_workflow_success() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let update = json!({"workflow_id": "new-workflow"});
 
@@ -304,7 +304,7 @@ async fn test_update_workflow_definition_rejected() {
     insert_test_instance(&state, &instance).await;
 
     let backend = state.backend.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let update = WorkflowDefinition {
         workflow_id: "new-workflow".to_string(),
@@ -341,7 +341,7 @@ async fn test_update_workflow_definition_rejected() {
 #[tokio::test]
 async fn test_list_operators() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/operators")
@@ -364,7 +364,7 @@ async fn test_list_operators() {
 #[tokio::test]
 async fn test_list_hil_events_empty() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance_id = Uuid::new_v4();
     let request = Request::builder()
@@ -407,7 +407,7 @@ async fn test_list_hil_events_with_events() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri(format!("/hil/workflows/{}", instance_id))
@@ -451,7 +451,7 @@ async fn test_submit_hil_action_success() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("Option A".to_string()),
@@ -476,7 +476,7 @@ async fn test_submit_hil_action_success() {
 #[tokio::test]
 async fn test_submit_hil_action_not_found() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance_id = Uuid::new_v4().to_string();
     let event_id = Uuid::new_v4().to_string();
@@ -531,7 +531,7 @@ async fn test_submit_hil_action_already_resolved() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("Option A".to_string()),
@@ -578,7 +578,7 @@ async fn test_submit_hil_action_timed_out_event_conflicts() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("Option A".to_string()),
@@ -627,7 +627,7 @@ async fn test_submit_hil_action_authorization_response_rejected_for_question_kin
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: None,
@@ -675,7 +675,7 @@ async fn test_submit_hil_action_text_response_rejected_for_authorization_kind() 
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("some free text".to_string()),
@@ -722,7 +722,7 @@ async fn test_submit_hil_action_authorization_success() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: None,
@@ -773,7 +773,7 @@ async fn test_submit_hil_action_accepts_opaque_event_id() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("Option A".to_string()),
@@ -818,7 +818,7 @@ async fn test_submit_hil_action_invalid_response_type() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: Some("Option A".to_string()),
@@ -863,7 +863,7 @@ async fn test_submit_hil_action_missing_answer() {
 
     insert_test_hil_event(&state, &event).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let action = HilAction {
         answer: None,
@@ -888,7 +888,7 @@ async fn test_submit_hil_action_missing_answer() {
 #[tokio::test]
 async fn test_event_broadcasting() {
     let state = create_test_state().await;
-    let _ = newton_core::api::api_v1_router(state.clone());
+    let _ = newton_core::api::api_v1_router(state.clone(), false);
 
     let instance_id = Uuid::new_v4().to_string();
 
@@ -904,7 +904,7 @@ async fn test_event_broadcasting() {
 #[tokio::test]
 async fn test_create_workflow_success() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance_id = Uuid::new_v4().to_string();
     let instance = WorkflowInstance {
@@ -956,7 +956,7 @@ async fn test_create_workflow_duplicate_returns_409() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .method(Method::POST)
@@ -980,7 +980,7 @@ async fn test_create_workflow_duplicate_returns_409() {
 #[tokio::test]
 async fn test_create_workflow_invalid_uuid_returns_422() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance = json!({
         "instance_id": "not-a-valid-uuid",
@@ -1034,7 +1034,7 @@ async fn test_update_node_success() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let node_update = json!({
         "status": "succeeded",
@@ -1066,7 +1066,7 @@ async fn test_update_node_success() {
 #[tokio::test]
 async fn test_update_node_workflow_not_found_returns_404() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let instance_id = Uuid::new_v4().to_string();
     let node_update = json!({
@@ -1130,7 +1130,7 @@ async fn test_list_workflows_filter_by_status() {
     )
     .await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflows?status=running")
@@ -1172,7 +1172,7 @@ async fn test_list_workflows_pagination() {
         .await;
     }
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflows?limit=2&offset=1")
@@ -1209,7 +1209,7 @@ async fn test_update_workflow_status() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let update = json!({
         "status": "succeeded",
@@ -1260,7 +1260,7 @@ async fn test_update_node_upsert_creates_missing_node() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let node_update = json!({
         "status": "succeeded",
@@ -1342,7 +1342,7 @@ async fn test_workflow_definition_exposure() {
 
     insert_test_instance(&state, &instance).await;
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri(format!("/workflows/{}", instance_id))
@@ -1393,7 +1393,7 @@ async fn test_node_upsert_broadcasts_event() {
 
     let mut rx = state.events_tx.subscribe();
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let node_update = json!({
         "status": "running",
@@ -1472,7 +1472,7 @@ workflow:
 #[tokio::test]
 async fn test_workflow_files_503_when_not_configured() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflow-files")
@@ -1487,7 +1487,7 @@ async fn test_workflow_files_503_when_not_configured() {
 async fn test_workflow_files_list_empty() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflow-files")
@@ -1508,7 +1508,7 @@ async fn test_workflow_files_list_empty() {
 async fn test_workflow_files_put_and_get() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({
         "content": VALID_WORKFLOW_YAML,
@@ -1552,7 +1552,7 @@ async fn test_workflow_files_put_and_get() {
 async fn test_workflow_files_get_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .uri("/workflow-files/nonexistent")
@@ -1567,7 +1567,7 @@ async fn test_workflow_files_get_not_found() {
 async fn test_workflow_files_put_invalid_yaml() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({
         "content": "this: is: not: valid: yaml: {{{",
@@ -1589,7 +1589,7 @@ async fn test_workflow_files_put_invalid_yaml() {
 async fn test_workflow_files_delete() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create
     let body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
@@ -1624,7 +1624,7 @@ async fn test_workflow_files_delete() {
 async fn test_workflow_files_delete_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let request = Request::builder()
         .method(Method::DELETE)
@@ -1640,7 +1640,7 @@ async fn test_workflow_files_delete_not_found() {
 async fn test_workflow_files_validate_endpoint() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
 
@@ -1665,7 +1665,7 @@ async fn test_workflow_files_validate_endpoint() {
 async fn test_workflow_files_list_shows_created_files() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create two files
     for name in &["alpha", "beta"] {
@@ -1699,7 +1699,7 @@ async fn test_workflow_files_list_shows_created_files() {
 async fn test_workflow_files_slug_traversal_rejected() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // GET with traversal slug
     let get_req = Request::builder()
@@ -1725,7 +1725,7 @@ async fn test_workflow_files_slug_traversal_rejected() {
 async fn test_workflow_files_if_match_conflict() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create file first
     let body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
@@ -1764,7 +1764,7 @@ async fn test_workflow_files_if_match_conflict() {
 async fn test_workflow_files_if_match_put_after_delete_conflicts_not_recreated() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create
     let body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
@@ -1834,7 +1834,7 @@ async fn test_workflow_files_if_match_put_after_delete_conflicts_not_recreated()
 async fn test_workflow_files_validate_invalid_semantic() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body =
         serde_json::json!({ "content": INVALID_SEMANTIC_WORKFLOW_YAML, "expected_hash": null });
@@ -1870,7 +1870,7 @@ async fn test_workflow_files_validate_invalid_semantic() {
 async fn test_workflow_files_lenient_save_invalid_semantic() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body =
         serde_json::json!({ "content": INVALID_SEMANTIC_WORKFLOW_YAML, "expected_hash": null });
@@ -1923,7 +1923,7 @@ async fn test_workflow_files_lenient_save_invalid_semantic() {
 async fn test_workflow_files_put_existing_without_precondition_428() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create the file first (unconditional create is allowed).
     let create_body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
@@ -1983,7 +1983,7 @@ async fn test_workflow_files_put_existing_without_precondition_428() {
 async fn test_workflow_files_put_existing_with_correct_if_match_matches_subsequent_get() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Create.
     let create_body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
@@ -2047,7 +2047,7 @@ async fn test_workflow_files_put_existing_with_correct_if_match_matches_subseque
 async fn test_workflow_files_put_new_file_without_precondition_creates() {
     let dir = tempfile::tempdir().unwrap();
     let state = create_test_state_with_files(dir.path().to_owned()).await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({ "content": VALID_WORKFLOW_YAML, "expected_hash": null });
     let request = Request::builder()
@@ -2074,7 +2074,7 @@ async fn test_workflow_files_put_new_file_without_precondition_creates() {
 async fn test_create_finding_broadcasts_finding_update() {
     let state = create_test_state().await;
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({
         "id": "finding-broadcast-1",
@@ -2128,7 +2128,7 @@ async fn test_patch_finding_broadcasts_finding_update() {
         .expect("create_finding");
 
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let patch_body = serde_json::json!({ "status": "triaged" });
     let request = Request::builder()
@@ -2153,7 +2153,7 @@ async fn test_patch_finding_broadcasts_finding_update() {
 async fn test_create_change_request_broadcasts_change_request_update() {
     let state = create_test_state().await;
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({
         "id": "cr-broadcast-1",
@@ -2180,7 +2180,7 @@ async fn test_create_change_request_broadcasts_change_request_update() {
 #[tokio::test]
 async fn test_patch_change_request_broadcasts_change_request_update() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state.clone());
+    let app = newton_core::api::api_v1_router(state.clone(), false);
 
     let create_body = serde_json::json!({
         "id": "cr-broadcast-2",
@@ -2219,7 +2219,7 @@ async fn test_patch_change_request_broadcasts_change_request_update() {
 async fn test_create_product_broadcasts_catalog_update() {
     let state = create_test_state().await;
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let body = serde_json::json!({ "name": "broadcast-test-product" });
     let request = Request::builder()
@@ -2250,7 +2250,7 @@ async fn test_create_product_broadcasts_catalog_update() {
 #[tokio::test]
 async fn test_delete_product_broadcasts_catalog_update() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state.clone());
+    let app = newton_core::api::api_v1_router(state.clone(), false);
 
     let create_body = serde_json::json!({ "name": "broadcast-delete-product" });
     let create_request = Request::builder()

--- a/crates/core/tests/integration/test_catalog_crud.rs
+++ b/crates/core/tests/integration/test_catalog_crud.rs
@@ -26,7 +26,7 @@ async fn create_catalog_test_state() -> AppState {
 #[tokio::test]
 async fn test_get_product_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/products/prod-1")
         .body(Body::empty())
@@ -44,7 +44,7 @@ async fn test_get_product_found() {
 #[tokio::test]
 async fn test_get_product_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/products/nonexistent")
         .body(Body::empty())
@@ -61,7 +61,7 @@ async fn test_get_product_not_found() {
 #[tokio::test]
 async fn test_create_product_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"name": "New Product"});
     let req = Request::builder()
         .method(Method::POST)
@@ -82,7 +82,7 @@ async fn test_create_product_success() {
 #[tokio::test]
 async fn test_put_product_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"name": "Updated Product"});
     let req = Request::builder()
         .method(Method::PUT)
@@ -102,7 +102,7 @@ async fn test_put_product_success() {
 #[tokio::test]
 async fn test_put_product_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"name": "Ghost"});
     let req = Request::builder()
         .method(Method::PUT)
@@ -117,7 +117,7 @@ async fn test_put_product_not_found() {
 #[tokio::test]
 async fn test_patch_product_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"name": "Patched Product"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -138,7 +138,7 @@ async fn test_patch_product_success() {
 async fn test_delete_product_conflict_has_components() {
     // prod-1 has comp-1 in fixtures → expect 409
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/products/prod-1")
@@ -156,7 +156,7 @@ async fn test_delete_product_conflict_has_components() {
 #[tokio::test]
 async fn test_delete_product_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     // Create a standalone product with no components
     let create_body = json!({"name": "Orphan Product"});
     let create_req = Request::builder()
@@ -192,7 +192,7 @@ async fn test_delete_product_success() {
 #[tokio::test]
 async fn test_get_component_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/components/comp-1")
         .body(Body::empty())
@@ -209,7 +209,7 @@ async fn test_get_component_found() {
 #[tokio::test]
 async fn test_get_component_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/components/nonexistent")
         .body(Body::empty())
@@ -221,7 +221,7 @@ async fn test_get_component_not_found() {
 #[tokio::test]
 async fn test_create_component_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "name": "New Component",
         "productId": "prod-1",
@@ -252,7 +252,7 @@ async fn test_create_component_success() {
 #[tokio::test]
 async fn test_put_component_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "name": "Updated Component",
         "productId": "prod-1",
@@ -282,7 +282,7 @@ async fn test_put_component_success() {
 #[tokio::test]
 async fn test_patch_component_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"name": "Patched Component"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -303,7 +303,7 @@ async fn test_patch_component_success() {
 async fn test_delete_component_conflict_has_repos() {
     // comp-1 has repo-1 in fixtures → expect 409
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/components/comp-1")
@@ -321,7 +321,7 @@ async fn test_delete_component_conflict_has_repos() {
 #[tokio::test]
 async fn test_delete_component_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     // Create a standalone product, then a component with no repos
     let prod_body = json!({"name": "Orphan Product For Comp"});
     let prod_req = Request::builder()
@@ -382,7 +382,7 @@ async fn test_delete_component_success() {
 #[tokio::test]
 async fn test_get_repo_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/repos/repo-1")
         .body(Body::empty())
@@ -399,7 +399,7 @@ async fn test_get_repo_found() {
 #[tokio::test]
 async fn test_get_repo_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/repos/nonexistent")
         .body(Body::empty())
@@ -411,7 +411,7 @@ async fn test_get_repo_not_found() {
 #[tokio::test]
 async fn test_create_repo_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "name": "new-repo",
         "componentId": "comp-1",
@@ -443,7 +443,7 @@ async fn test_create_repo_success() {
 #[tokio::test]
 async fn test_put_repo_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     // Keep the same name (auth-api) to avoid FK violation on Regression(repoName)
     let body = json!({
         "name": "auth-api",
@@ -476,7 +476,7 @@ async fn test_put_repo_success() {
 #[tokio::test]
 async fn test_patch_repo_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"owner": "new-owner"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -497,7 +497,7 @@ async fn test_patch_repo_success() {
 async fn test_delete_repo_conflict_has_modules() {
     // repo-1 has mod-1, mod-2 in fixtures → expect 409
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/repos/repo-1")
@@ -515,7 +515,7 @@ async fn test_delete_repo_conflict_has_modules() {
 #[tokio::test]
 async fn test_delete_repo_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     // Create a repo with no modules under comp-1
     let body = json!({
         "name": "orphan-repo-for-delete",
@@ -562,7 +562,7 @@ async fn test_delete_repo_success() {
 #[tokio::test]
 async fn test_list_modules_ok() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/modules")
         .body(Body::empty())
@@ -579,7 +579,7 @@ async fn test_list_modules_ok() {
 #[tokio::test]
 async fn test_get_module_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/modules/mod-1")
         .body(Body::empty())
@@ -596,7 +596,7 @@ async fn test_get_module_found() {
 #[tokio::test]
 async fn test_get_module_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/modules/nonexistent")
         .body(Body::empty())
@@ -608,7 +608,7 @@ async fn test_get_module_not_found() {
 #[tokio::test]
 async fn test_create_module_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "name": "new-module",
         "kind": "service",
@@ -633,7 +633,7 @@ async fn test_create_module_success() {
 #[tokio::test]
 async fn test_put_module_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "name": "mod-1-updated",
         "kind": "library",
@@ -657,7 +657,7 @@ async fn test_put_module_success() {
 #[tokio::test]
 async fn test_patch_module_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"kind": "cli"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -678,7 +678,7 @@ async fn test_patch_module_success() {
 async fn test_delete_module_conflict_has_dependencies() {
     // mod-1 is part of dep-1 in fixtures → expect 409
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/modules/mod-1")
@@ -696,7 +696,7 @@ async fn test_delete_module_conflict_has_dependencies() {
 #[tokio::test]
 async fn test_delete_module_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     // Create a module with no dependencies
     let body = json!({
         "name": "orphan-module",
@@ -736,7 +736,7 @@ async fn test_delete_module_success() {
 #[tokio::test]
 async fn test_get_module_dependency_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/module-dependencies/dep-1")
         .body(Body::empty())
@@ -753,7 +753,7 @@ async fn test_get_module_dependency_found() {
 #[tokio::test]
 async fn test_get_module_dependency_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/module-dependencies/nonexistent")
         .body(Body::empty())
@@ -765,7 +765,7 @@ async fn test_get_module_dependency_not_found() {
 #[tokio::test]
 async fn test_patch_module_dependency_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"label": "updated-label"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -785,7 +785,7 @@ async fn test_patch_module_dependency_success() {
 #[tokio::test]
 async fn test_patch_module_dependency_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"label": "ghost"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -800,7 +800,7 @@ async fn test_patch_module_dependency_not_found() {
 #[tokio::test]
 async fn test_delete_module_dependency_success() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/module-dependencies/dep-1")
@@ -818,7 +818,7 @@ async fn test_delete_module_dependency_success() {
 #[tokio::test]
 async fn test_delete_module_dependency_not_found() {
     let state = create_catalog_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::DELETE)
         .uri("/module-dependencies/nonexistent")

--- a/crates/core/tests/integration/test_kpi_evalrun_grade_api.rs
+++ b/crates/core/tests/integration/test_kpi_evalrun_grade_api.rs
@@ -24,7 +24,7 @@ async fn create_test_state() -> AppState {
 #[tokio::test]
 async fn test_grade_roundtrip_get_by_id() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let run_id = "evalrun.dk-review.repo.repo-1.2026-05-26T00:00:00Z";
     let eval_run_body = json!({
@@ -85,7 +85,7 @@ async fn test_grade_roundtrip_get_by_id() {
 #[tokio::test]
 async fn test_list_grades_filters_by_run_id() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     // Two runs for the same repo (fixtures include repo-1).
     for (run_id, dimension, evaluated_at) in [

--- a/crates/core/tests/integration/test_lag_tolerant_streams.rs
+++ b/crates/core/tests/integration/test_lag_tolerant_streams.rs
@@ -87,7 +87,7 @@ async fn test_workflow_ws_delivers_lagged_frame_then_resumes() {
 
     let state = make_state(Arc::clone(&backend));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
@@ -154,7 +154,7 @@ async fn test_logs_ws_delivers_lagged_frame_then_resumes() {
 
     let state = make_state(Arc::clone(&backend));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
@@ -224,7 +224,7 @@ async fn test_workflow_sse_delivers_lagged_frame_then_resumes() {
 
     let state = make_state(Arc::clone(&backend));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let client = reqwest::Client::new();
@@ -296,7 +296,7 @@ async fn test_workflow_ws_ends_cleanly_when_broadcast_channel_closes() {
     insert_instance(&backend, &instance_id).await;
 
     let state = make_state(Arc::clone(&backend));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let server = tokio::spawn(async move {
@@ -354,7 +354,7 @@ async fn test_workflow_ws_server_survives_client_disconnect_mid_broadcast() {
 
     let state = make_state(Arc::clone(&backend));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
@@ -400,7 +400,7 @@ async fn test_logs_ws_ends_cleanly_when_broadcast_channel_closes() {
     insert_instance(&backend, &instance_id).await;
 
     let state = make_state(Arc::clone(&backend));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let server = tokio::spawn(async move {

--- a/crates/core/tests/integration/test_lag_tolerant_streams.rs
+++ b/crates/core/tests/integration/test_lag_tolerant_streams.rs
@@ -176,12 +176,14 @@ async fn test_logs_ws_delivers_lagged_frame_then_resumes() {
             instance_id: "flood-noise-instance".to_string(),
             node_id: "flood-noise-node".to_string(),
             message: "noise".to_string(),
+            seq: 0,
         });
     }
     let _ = events_tx.send(BroadcastEvent::LogMessage {
         instance_id: instance_id.clone(),
         node_id: node_id.to_string(),
         message: "marker-line".to_string(),
+        seq: 0,
     });
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {

--- a/crates/core/tests/integration/test_logs_ws_since_seq.rs
+++ b/crates/core/tests/integration/test_logs_ws_since_seq.rs
@@ -151,7 +151,7 @@ async fn logs_ws_default_replay_is_tail_not_since_seq_zero_semantics() {
     }
 
     let state = make_state(Arc::clone(&backend));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     // No since_seq query param: default tail replay.
@@ -191,7 +191,7 @@ async fn logs_ws_since_seq_resumes_after_given_seq() {
     }
 
     let state = make_state(Arc::clone(&backend));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     // Reconnect as if resuming after having already seen seq 1..=6
@@ -234,7 +234,7 @@ async fn logs_ws_since_seq_at_latest_returns_no_historical_lines() {
     }
 
     let state = make_state(Arc::clone(&backend));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url =

--- a/crates/core/tests/integration/test_logs_ws_since_seq.rs
+++ b/crates/core/tests/integration/test_logs_ws_since_seq.rs
@@ -1,0 +1,278 @@
+/// Spec 074 B18 — Logs WS accepts `since_seq`; default tail-N (500) instead
+/// of full replay.
+///
+/// Before this fix, `handle_logs_socket`'s historical replay always called
+/// `list_log_lines(instance_id, node_id, 0)` — a full, unbounded replay of
+/// every persisted log line regardless of client intent. This adds:
+///   - `LogLine::seq` / `BroadcastEvent::LogMessage::seq`, so clients can see
+///     each line's sequence number.
+///   - `BackendStore::list_log_lines_tail`, a bounded "last N lines" query.
+///   - `StreamFilters::since_seq`, threaded into `handle_logs_socket`: with
+///     `since_seq` given, replay resumes from `seq > since_seq`; with no
+///     `since_seq`, replay defaults to the last 500 lines instead of
+///     everything.
+///
+/// These tests assert the resumption contract end-to-end over a real router
+/// with a `tokio_tungstenite` WS client, following the established pattern
+/// from `test_workflow_logs_ws_select.rs` (spec 074 B14).
+use futures::StreamExt;
+use newton_backend::BackendStore;
+use newton_core::api::state::AppState;
+use newton_types::{LogLine, OperatorDescriptor, WorkflowInstance, WorkflowStatus};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use uuid::Uuid;
+
+async fn make_backend() -> Arc<dyn BackendStore> {
+    let store = newton_backend::SqliteBackendStore::new_in_memory()
+        .await
+        .expect("in-memory backend init");
+    Arc::new(store)
+}
+
+fn make_state(backend: Arc<dyn BackendStore>) -> AppState {
+    let operators = vec![OperatorDescriptor {
+        operator_type: "noop".to_string(),
+        description: "No-op".to_string(),
+        params_schema: json!({}),
+    }];
+    // Ping interval left at the (long) default: these tests only care about
+    // the historical replay frames sent before the live-forward loop, so an
+    // idle-connection ping firing mid-test would just be noise to filter.
+    AppState::new(operators, backend)
+}
+
+async fn spawn_router(app: axum::Router) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    port
+}
+
+async fn insert_instance(backend: &Arc<dyn BackendStore>, instance_id: &str) {
+    backend
+        .upsert_workflow_instance(&WorkflowInstance {
+            instance_id: instance_id.to_string(),
+            workflow_id: "wf-since-seq".to_string(),
+            status: WorkflowStatus::Running,
+            nodes: vec![],
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+            definition: None,
+            linked_plan_id: None,
+        })
+        .await
+        .unwrap();
+}
+
+fn make_log(instance_id: &str, node_id: &str, msg: &str) -> LogLine {
+    LogLine {
+        instance_id: instance_id.to_string(),
+        node_id: node_id.to_string(),
+        level: "info".to_string(),
+        message: msg.to_string(),
+        timestamp: chrono::Utc::now(),
+        // append_log_line assigns the real seq; this placeholder is never
+        // read on the write path.
+        seq: 0,
+    }
+}
+
+/// Collects `logMessage` frames off the socket until either `want` non-connect
+/// lines have been gathered or the timeout elapses. The very first logMessage
+/// frame (the synthetic "Connected to ..." line) is always skipped.
+async fn collect_log_lines(
+    ws_stream: &mut (impl futures::Stream<Item = Result<WsMessage, tokio_tungstenite::tungstenite::Error>>
+              + Unpin),
+    want: usize,
+) -> Vec<(String, i64)> {
+    let mut lines = Vec::new();
+    let mut skip_connect = true;
+
+    let _ = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(Ok(msg)) = ws_stream.next().await {
+            let WsMessage::Text(text) = msg else {
+                continue;
+            };
+            let event: serde_json::Value = serde_json::from_str(&text).unwrap();
+            if event["type"] != "logMessage" {
+                continue;
+            }
+            if skip_connect {
+                skip_connect = false;
+                continue;
+            }
+            let message = event["message"].as_str().unwrap().to_string();
+            let seq = event["seq"].as_i64().unwrap();
+            lines.push((message, seq));
+            if lines.len() == want {
+                return;
+            }
+        }
+    })
+    .await;
+
+    lines
+}
+
+/// Connecting with no `since_seq` at all replays only the tail (last N
+/// lines), not the full history: seed 12 lines, request a tail smaller than
+/// that by asserting the *default* (500) still comes back complete for a
+/// small seed, then prove the tail behavior directly by seeding more lines
+/// than a small custom limit would allow — since the production default is
+/// 500 and seeding 500+ lines in a unit-style test is wasteful, this test
+/// instead proves the *shape* of tail behavior: connecting with no
+/// `since_seq` returns every line when history is under the 500 default
+/// (sanity), while a second connection using `since_seq` proves resumption
+/// returns only the strict suffix after a given point — the two behaviors
+/// together are what the WS resumption contract requires.
+#[tokio::test]
+async fn logs_ws_default_replay_is_tail_not_since_seq_zero_semantics() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "tail-task";
+    insert_instance(&backend, &instance_id).await;
+
+    const N: usize = 12;
+    for i in 0..N {
+        let line = make_log(&instance_id, node_id, &format!("line-{i}"));
+        backend
+            .append_log_line(&instance_id, node_id, &line)
+            .await
+            .unwrap();
+    }
+
+    let state = make_state(Arc::clone(&backend));
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    // No since_seq query param: default tail replay.
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let lines = collect_log_lines(&mut ws_stream, N).await;
+    assert_eq!(
+        lines.len(),
+        N,
+        "with history under the 500-line default tail, every line should still replay"
+    );
+    for (i, (msg, seq)) in lines.iter().enumerate() {
+        assert_eq!(msg, &format!("line-{i}"));
+        assert_eq!(*seq, (i + 1) as i64, "seq must be 1-indexed and ascending");
+    }
+}
+
+/// Connecting with `since_seq=N` resumes from exactly the lines after N —
+/// the core resumption contract this work item adds.
+#[tokio::test]
+async fn logs_ws_since_seq_resumes_after_given_seq() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "resume-task";
+    insert_instance(&backend, &instance_id).await;
+
+    const N: usize = 10;
+    for i in 0..N {
+        let line = make_log(&instance_id, node_id, &format!("line-{i}"));
+        backend
+            .append_log_line(&instance_id, node_id, &line)
+            .await
+            .unwrap();
+    }
+
+    let state = make_state(Arc::clone(&backend));
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    // Reconnect as if resuming after having already seen seq 1..=6
+    // (line-0..line-5): expect only line-6..line-9 (seq 7..10).
+    let ws_url =
+        format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws?since_seq=6");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let lines = collect_log_lines(&mut ws_stream, N - 6).await;
+    assert_eq!(
+        lines.len(),
+        4,
+        "since_seq=6 must return exactly the 4 lines with seq > 6"
+    );
+    let expected: Vec<(String, i64)> = (6..N)
+        .map(|i| (format!("line-{i}"), (i + 1) as i64))
+        .collect();
+    assert_eq!(lines, expected);
+}
+
+/// A `since_seq` at or beyond the latest persisted line returns nothing —
+/// proof the resumption path doesn't fall back to a full/tail replay when
+/// there is genuinely nothing new.
+#[tokio::test]
+async fn logs_ws_since_seq_at_latest_returns_no_historical_lines() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "caught-up-task";
+    insert_instance(&backend, &instance_id).await;
+
+    const N: usize = 5;
+    for i in 0..N {
+        let line = make_log(&instance_id, node_id, &format!("line-{i}"));
+        backend
+            .append_log_line(&instance_id, node_id, &line)
+            .await
+            .unwrap();
+    }
+
+    let state = make_state(Arc::clone(&backend));
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url =
+        format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws?since_seq=5");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    // Drain the connect-line frame, then assert no further logMessage frame
+    // arrives within a short bounded wait.
+    let connect_frame = ws_stream.next().await.unwrap().unwrap();
+    let connect_frame: serde_json::Value =
+        serde_json::from_str(connect_frame.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(connect_frame["type"], "logMessage");
+    assert_eq!(
+        connect_frame["seq"], 0,
+        "the synthetic connect line uses the documented seq=0 sentinel"
+    );
+
+    let saw_more = tokio::time::timeout(Duration::from_millis(300), async {
+        loop {
+            match ws_stream.next().await {
+                Some(Ok(WsMessage::Text(text))) => {
+                    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    if v["type"] == "logMessage" {
+                        return true;
+                    }
+                }
+                Some(Ok(_)) => continue,
+                _ => return false,
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    assert!(
+        !saw_more,
+        "since_seq at the latest persisted seq must replay nothing further"
+    );
+}

--- a/crates/core/tests/integration/test_magic_tools.rs
+++ b/crates/core/tests/integration/test_magic_tools.rs
@@ -24,7 +24,7 @@ async fn create_test_state() -> AppState {
 #[tokio::test]
 async fn test_list_aitools_returns_200() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, true);
     let req = Request::builder()
         .uri("/aitools")
         .body(Body::empty())
@@ -46,7 +46,7 @@ async fn test_list_aitools_returns_200() {
 #[tokio::test]
 async fn test_ping_schema_returns_200() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, true);
     let req = Request::builder()
         .uri("/aitools/newton/ping/schema")
         .body(Body::empty())
@@ -77,7 +77,7 @@ async fn test_ping_invoke_returns_200() {
         return;
     }
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, true);
     let req = Request::builder()
         .method("POST")
         .uri("/aitools/newton/ping")
@@ -97,7 +97,7 @@ async fn test_ping_invoke_returns_200() {
 #[tokio::test]
 async fn test_ping_sessions_messages_sse_content_type() {
     let state = create_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, true);
     let req = Request::builder()
         .method("POST")
         .uri("/aitools/newton/ping/sessions/test-session/messages")

--- a/crates/core/tests/integration/test_parity_endpoints.rs
+++ b/crates/core/tests/integration/test_parity_endpoints.rs
@@ -631,10 +631,22 @@ async fn test_approve_plan_emits_canonical_execution_update() {
     // Drain the channel and verify both broadcast events are well-formed.
     let mut got_plan_update = false;
     let mut got_execution_update = false;
+    let mut plan_update_instance_id: Option<String> = None;
+    let mut execution_update_instance_id: Option<String> = None;
     while let Ok(ev) = rx.try_recv() {
         match ev {
-            newton_types::BroadcastEvent::PlanUpdate { plan_id } => {
+            newton_types::BroadcastEvent::PlanUpdate {
+                plan_id,
+                instance_id,
+            } => {
                 assert_eq!(plan_id, "plan-1");
+                // spec 074 B13: an approved plan is linked to the freshly
+                // created execution, so instance_id must be populated.
+                assert!(
+                    instance_id.is_some(),
+                    "PlanUpdate.instance_id must be populated once approval links an execution"
+                );
+                plan_update_instance_id = instance_id;
                 got_plan_update = true;
             }
             newton_types::BroadcastEvent::ExecutionUpdate {
@@ -642,6 +654,7 @@ async fn test_approve_plan_emits_canonical_execution_update() {
                 plan_id,
                 status,
                 created_at,
+                instance_id,
             } => {
                 assert!(
                     !execution_id.is_empty(),
@@ -653,6 +666,11 @@ async fn test_approve_plan_emits_canonical_execution_update() {
                 assert_eq!(plan_id.as_deref(), Some("plan-1"));
                 assert_eq!(status, "running");
                 assert!(!created_at.is_empty());
+                // spec 074 B13: every Execution carries its owning
+                // instance_id (falls back to its own id until a real
+                // workflow instance attaches).
+                assert!(!instance_id.is_empty());
+                execution_update_instance_id = Some(instance_id);
                 got_execution_update = true;
             }
             _ => {}
@@ -663,4 +681,39 @@ async fn test_approve_plan_emits_canonical_execution_update() {
         got_execution_update,
         "expected ExecutionUpdate broadcast with valid execution_id"
     );
+    // The two events describe the same newly-created execution/instance, so
+    // their instance_id must agree (this is what makes a workflow-A-scoped
+    // stream see both, and a workflow-B-scoped stream see neither).
+    assert_eq!(plan_update_instance_id, execution_update_instance_id);
+}
+
+#[tokio::test]
+async fn test_reject_plan_emits_plan_update_with_no_instance() {
+    let state = create_parity_test_state().await;
+    let mut rx = state.events_tx.subscribe();
+    let app = newton_core::api::api_v1_router(state);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/plans/plan-1/reject")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut got_plan_update = false;
+    while let Ok(ev) = rx.try_recv() {
+        if let newton_types::BroadcastEvent::PlanUpdate {
+            plan_id,
+            instance_id,
+        } = ev
+        {
+            assert_eq!(plan_id, "plan-1");
+            // spec 074 B13: rejection never links a running execution, so
+            // instance_id must be None (and scoped streams drop it).
+            assert_eq!(instance_id, None);
+            got_plan_update = true;
+        }
+    }
+    assert!(got_plan_update, "expected PlanUpdate broadcast on reject");
 }

--- a/crates/core/tests/integration/test_parity_endpoints.rs
+++ b/crates/core/tests/integration/test_parity_endpoints.rs
@@ -27,7 +27,7 @@ macro_rules! parity_test {
         #[tokio::test]
         async fn $name() {
             let state = create_parity_test_state().await;
-            let app = newton_core::api::api_v1_router(state);
+            let app = newton_core::api::api_v1_router(state, false);
             let request = Request::builder()
                 .method($method)
                 .uri($path)
@@ -120,7 +120,7 @@ parity_test!(
 #[tokio::test]
 async fn test_products_returns_array() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let request = Request::builder()
         .uri("/products")
         .body(Body::empty())
@@ -140,7 +140,7 @@ async fn test_products_returns_array() {
 #[tokio::test]
 async fn test_persistence_put_get_delete() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let put_req = Request::builder()
         .method(Method::PUT)
@@ -184,7 +184,7 @@ async fn test_persistence_put_get_delete() {
 #[tokio::test]
 async fn test_persistence_get_not_found() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/persistence/nonexistent")
         .body(Body::empty())
@@ -201,7 +201,7 @@ async fn test_persistence_get_not_found() {
 #[tokio::test]
 async fn test_create_request_success() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "id": "cr-parity-001",
         "title": "Fix auth bug",
@@ -228,7 +228,7 @@ async fn test_create_request_success() {
 #[tokio::test]
 async fn test_create_module_dependency_self_dep() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "fromModuleId": "mod-1",
         "toModuleId": "mod-1",
@@ -253,7 +253,7 @@ async fn test_create_module_dependency_self_dep() {
 #[tokio::test]
 async fn test_create_module_dependency_not_found() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "fromModuleId": "nonexistent",
         "toModuleId": "mod-1",
@@ -278,7 +278,7 @@ async fn test_create_module_dependency_not_found() {
 #[tokio::test]
 async fn test_create_module_dependency_cycle() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "fromModuleId": "mod-1",
         "toModuleId": "mod-2",
@@ -303,7 +303,7 @@ async fn test_create_module_dependency_cycle() {
 #[tokio::test]
 async fn test_create_module_dependency_success() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({
         "fromModuleId": "mod-1",
         "toModuleId": "mod-2",
@@ -323,7 +323,7 @@ async fn test_create_module_dependency_success() {
 #[tokio::test]
 async fn test_get_plan_not_found() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/plans/nonexistent")
         .body(Body::empty())
@@ -340,7 +340,7 @@ async fn test_get_plan_not_found() {
 #[tokio::test]
 async fn test_approve_reject_plan_not_found() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let approve_req = Request::builder()
         .method(Method::POST)
@@ -362,7 +362,7 @@ async fn test_approve_reject_plan_not_found() {
 #[tokio::test]
 async fn test_patch_opportunity_not_found() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"status": "triaged"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -377,7 +377,7 @@ async fn test_patch_opportunity_not_found() {
 #[tokio::test]
 async fn test_patch_opportunity_invalid_status() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let body = json!({"status": "triaged"});
     let req = Request::builder()
         .method(Method::PATCH)
@@ -444,7 +444,7 @@ async fn test_testing_reset_without_env_var_is_forbidden_and_data_intact() {
         "seed finding must be present before the reset attempt"
     );
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::POST)
         .uri("/testing/reset")
@@ -483,7 +483,7 @@ async fn test_testing_reset_with_env_var_succeeds_and_empties_seed_data() {
         "seed finding must be present before reset"
     );
 
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .method(Method::POST)
         .uri("/testing/reset")
@@ -507,7 +507,7 @@ async fn test_testing_reset_with_env_var_succeeds_and_empties_seed_data() {
 #[tokio::test]
 async fn test_repos_include_dependency_arrays() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/repos")
         .body(Body::empty())
@@ -526,7 +526,7 @@ async fn test_repos_include_dependency_arrays() {
 #[tokio::test]
 async fn test_saved_views_grouped_without_kind() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/saved-views")
         .body(Body::empty())
@@ -538,7 +538,7 @@ async fn test_saved_views_grouped_without_kind() {
 #[tokio::test]
 async fn test_recent_actions_with_limit() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/recent-actions?limit=5")
         .body(Body::empty())
@@ -550,7 +550,7 @@ async fn test_recent_actions_with_limit() {
 #[tokio::test]
 async fn test_executions_with_plan_id_filter() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/executions?planId=some-plan")
         .body(Body::empty())
@@ -562,7 +562,7 @@ async fn test_executions_with_plan_id_filter() {
 #[tokio::test]
 async fn test_opportunity_status_filter() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/findings?status=awaiting_triage")
         .body(Body::empty())
@@ -574,7 +574,7 @@ async fn test_opportunity_status_filter() {
 #[tokio::test]
 async fn test_hil_list_events_by_workflow() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let req = Request::builder()
         .uri("/hil/workflows/test-instance-id")
         .body(Body::empty())
@@ -586,7 +586,7 @@ async fn test_hil_list_events_by_workflow() {
 #[tokio::test]
 async fn test_get_workflow_not_found_parity() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let uuid = uuid::Uuid::new_v4().to_string();
     let req = Request::builder()
         .uri(format!("/workflows/{uuid}"))
@@ -599,7 +599,7 @@ async fn test_get_workflow_not_found_parity() {
 #[tokio::test]
 async fn test_delete_persistence_idempotent() {
     let state = create_parity_test_state().await;
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let del_req = Request::builder()
         .method(Method::DELETE)
         .uri("/persistence/nonexistent-key")
@@ -618,7 +618,7 @@ async fn test_delete_persistence_idempotent() {
 async fn test_approve_plan_emits_canonical_execution_update() {
     let state = create_parity_test_state().await;
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let req = Request::builder()
         .method(Method::POST)
@@ -691,7 +691,7 @@ async fn test_approve_plan_emits_canonical_execution_update() {
 async fn test_reject_plan_emits_plan_update_with_no_instance() {
     let state = create_parity_test_state().await;
     let mut rx = state.events_tx.subscribe();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
 
     let req = Request::builder()
         .method(Method::POST)

--- a/crates/core/tests/integration/test_persistence_parity.rs
+++ b/crates/core/tests/integration/test_persistence_parity.rs
@@ -152,6 +152,9 @@ async fn test_log_replay_after_restart() {
             level: "info".to_string(),
             message: format!("log-line-{i}"),
             timestamp: chrono::Utc::now(),
+            // append_log_line assigns the real seq; this placeholder is
+            // never read on the write path.
+            seq: 0,
         };
         backend
             .append_log_line(&instance_id, node_id, &line)

--- a/crates/core/tests/integration/test_persistence_parity.rs
+++ b/crates/core/tests/integration/test_persistence_parity.rs
@@ -40,7 +40,7 @@ async fn test_restart_persistence() {
     // ── Phase 1: create state and populate ───────────────────────────────────
     {
         let state = make_state(Arc::clone(&backend));
-        let app = newton_core::api::api_v1_router(state);
+        let app = newton_core::api::api_v1_router(state, false);
 
         // POST workflow
         let instance = WorkflowInstance {
@@ -88,7 +88,7 @@ async fn test_restart_persistence() {
     // ── Phase 2: new AppState over the same backend (simulate restart) ───────
     {
         let state2 = make_state(Arc::clone(&backend));
-        let app2 = newton_core::api::api_v1_router(state2);
+        let app2 = newton_core::api::api_v1_router(state2, false);
 
         let req = Request::builder()
             .uri(format!("/workflows/{}", instance_id))
@@ -164,7 +164,7 @@ async fn test_log_replay_after_restart() {
 
     // ── Simulate restart: new AppState over the same backend ─────────────────
     let state2 = make_state(Arc::clone(&backend));
-    let app2 = newton_core::api::api_v1_router(state2);
+    let app2 = newton_core::api::api_v1_router(state2, false);
 
     // Bind to an ephemeral port and spawn the axum server in the background
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -256,7 +256,7 @@ async fn test_hil_persistence_after_restart() {
     // Phase 1: insert HIL event and submit action
     {
         let state = make_state(Arc::clone(&backend));
-        let app = newton_core::api::api_v1_router(state);
+        let app = newton_core::api::api_v1_router(state, false);
 
         // Insert HIL event via backend (no HTTP endpoint for creating HIL events externally)
         backend
@@ -294,7 +294,7 @@ async fn test_hil_persistence_after_restart() {
     // Phase 2: restart — new AppState over the same backend
     {
         let state2 = make_state(Arc::clone(&backend));
-        let app2 = newton_core::api::api_v1_router(state2);
+        let app2 = newton_core::api::api_v1_router(state2, false);
 
         let req = Request::builder()
             .uri(format!("/hil/workflows/{}", instance_id))
@@ -327,7 +327,7 @@ async fn test_list_after_restart_with_filter() {
     // Phase 1: insert 3 instances
     {
         let state = make_state(Arc::clone(&backend));
-        let app = newton_core::api::api_v1_router(state);
+        let app = newton_core::api::api_v1_router(state, false);
 
         for (id, status) in [
             (id_running1.clone(), "running"),
@@ -356,7 +356,7 @@ async fn test_list_after_restart_with_filter() {
     // Phase 2: restart — new AppState, check filtered list
     {
         let state2 = make_state(Arc::clone(&backend));
-        let app2 = newton_core::api::api_v1_router(state2);
+        let app2 = newton_core::api::api_v1_router(state2, false);
 
         let req = Request::builder()
             .uri("/workflows?status=running")
@@ -381,7 +381,7 @@ async fn test_list_after_restart_with_filter() {
             .body(Body::empty())
             .unwrap();
         let state3 = make_state(Arc::clone(&backend));
-        let app3 = newton_core::api::api_v1_router(state3);
+        let app3 = newton_core::api::api_v1_router(state3, false);
         let resp = app3.oneshot(req).await.unwrap();
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await

--- a/crates/core/tests/integration/test_workflow_logs_ws_select.rs
+++ b/crates/core/tests/integration/test_workflow_logs_ws_select.rs
@@ -1,0 +1,250 @@
+/// Spec 074 B14 — Workflow/logs WS: `tokio::select!` over recv / socket read
+/// half / 30s ping.
+///
+/// Before this fix, `handle_workflow_socket` and `handle_logs_socket` only
+/// ever `match rx.recv().await { ... }`: they never read from the client's
+/// half of the socket. That meant (a) no periodic ping keepalive on these
+/// two endpoints (unlike `/ws`, which already selects over a ping tick), and
+/// (b) a client-initiated WebSocket Close frame was never observed
+/// server-side — the handler task only noticed disconnection on its next
+/// `socket.send(...)`, which for an instance/node with no further broadcast
+/// traffic could never happen, leaving the task (and its broadcast
+/// subscription) alive forever.
+///
+/// These tests assert both halves of the fix:
+///   1. Ping cadence: with `AppState::with_ws_ping_interval` shrunk to a few
+///      milliseconds, the server sends a `Message::Ping` within a bounded,
+///      short wait on both endpoints.
+///   2. Close detection: after the client sends a WS Close frame, the
+///      server-side handler task exits promptly, observed via
+///      `broadcast::Sender::receiver_count()` dropping to 0 (proof the task
+///      dropped its subscription and returned, not just that the client's
+///      own socket closed).
+use futures::{SinkExt, StreamExt};
+use newton_backend::BackendStore;
+use newton_core::api::state::AppState;
+use newton_types::{OperatorDescriptor, WorkflowInstance, WorkflowStatus};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use uuid::Uuid;
+
+async fn make_backend() -> Arc<dyn BackendStore> {
+    let store = newton_backend::SqliteBackendStore::new_in_memory()
+        .await
+        .expect("in-memory backend init");
+    Arc::new(store)
+}
+
+fn make_state(backend: Arc<dyn BackendStore>, ping_interval: Duration) -> AppState {
+    let operators = vec![OperatorDescriptor {
+        operator_type: "noop".to_string(),
+        description: "No-op".to_string(),
+        params_schema: json!({}),
+    }];
+    AppState::new(operators, backend).with_ws_ping_interval(ping_interval)
+}
+
+async fn spawn_router(app: axum::Router) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    port
+}
+
+async fn insert_instance(backend: &Arc<dyn BackendStore>, instance_id: &str) {
+    backend
+        .upsert_workflow_instance(&WorkflowInstance {
+            instance_id: instance_id.to_string(),
+            workflow_id: "wf-select".to_string(),
+            status: WorkflowStatus::Running,
+            nodes: vec![],
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+            definition: None,
+            linked_plan_id: None,
+        })
+        .await
+        .unwrap();
+}
+
+/// Test 1: `/stream/workflow/{id}/ws` sends a `Ping` frame within a bounded,
+/// short wait when the ping interval is shrunk — proof the select loop's
+/// ping-tick branch fires on an otherwise-idle connection (no broadcast
+/// traffic at all).
+#[tokio::test]
+async fn workflow_ws_sends_ping_on_idle_connection() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend), Duration::from_millis(50));
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    // Drain the connect-time snapshot frame first.
+    let snapshot = ws_stream.next().await.unwrap().unwrap();
+    assert!(matches!(snapshot, WsMessage::Text(_)));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws_stream.next().await.unwrap().unwrap() {
+                WsMessage::Ping(_) => return,
+                _ => continue,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "expected a Ping frame on an idle workflow WS connection within the timeout"
+    );
+}
+
+/// Same ping-cadence contract for `/stream/logs/{id}/{node_id}/ws`.
+#[tokio::test]
+async fn logs_ws_sends_ping_on_idle_connection() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "ping-task";
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend), Duration::from_millis(50));
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    // Drain the "Connected to ..." connect-line frame first.
+    let connect_frame = ws_stream.next().await.unwrap().unwrap();
+    assert!(matches!(connect_frame, WsMessage::Text(_)));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws_stream.next().await.unwrap().unwrap() {
+                WsMessage::Ping(_) => return,
+                _ => continue,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "expected a Ping frame on an idle logs WS connection within the timeout"
+    );
+}
+
+/// Test 2: `/stream/workflow/{id}/ws` — a client-sent Close frame must make
+/// the server-side handler task exit promptly, proven by
+/// `events_tx.receiver_count()` dropping to 0 shortly after (rather than the
+/// task lingering, subscribed forever, until some unrelated future broadcast
+/// send happens to fail).
+#[tokio::test]
+async fn workflow_ws_exits_promptly_on_client_close() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    insert_instance(&backend, &instance_id).await;
+
+    // Ping interval deliberately left long (the default) so the only way
+    // this test can observe prompt task exit is via the socket-read half of
+    // the select loop noticing the Close frame — not a ping-driven send
+    // failure.
+    let state = make_state(Arc::clone(&backend), Duration::from_secs(30));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let snapshot = ws_stream.next().await.unwrap().unwrap();
+    assert!(matches!(snapshot, WsMessage::Text(_)));
+
+    // The handler's subscription is the only receiver in this test.
+    assert_eq!(events_tx.receiver_count(), 1);
+
+    ws_stream
+        .send(WsMessage::Close(None))
+        .await
+        .expect("send client Close frame");
+
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if events_tx.receiver_count() == 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "expected the workflow WS handler task to drop its broadcast \
+         subscription promptly after a client Close frame"
+    );
+}
+
+/// Same client-Close contract for `/stream/logs/{id}/{node_id}/ws`.
+#[tokio::test]
+async fn logs_ws_exits_promptly_on_client_close() {
+    let backend = make_backend().await;
+    let instance_id = Uuid::new_v4().to_string();
+    let node_id = "close-task";
+    insert_instance(&backend, &instance_id).await;
+
+    let state = make_state(Arc::clone(&backend), Duration::from_secs(30));
+    let events_tx = state.events_tx.clone();
+    let app = newton_core::api::api_v1_router(state);
+    let port = spawn_router(app).await;
+
+    let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("WebSocket connect");
+
+    let connect_frame = ws_stream.next().await.unwrap().unwrap();
+    assert!(matches!(connect_frame, WsMessage::Text(_)));
+
+    assert_eq!(events_tx.receiver_count(), 1);
+
+    ws_stream
+        .send(WsMessage::Close(None))
+        .await
+        .expect("send client Close frame");
+
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if events_tx.receiver_count() == 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "expected the logs WS handler task to drop its broadcast \
+         subscription promptly after a client Close frame"
+    );
+}

--- a/crates/core/tests/integration/test_workflow_logs_ws_select.rs
+++ b/crates/core/tests/integration/test_workflow_logs_ws_select.rs
@@ -86,7 +86,7 @@ async fn workflow_ws_sends_ping_on_idle_connection() {
     insert_instance(&backend, &instance_id).await;
 
     let state = make_state(Arc::clone(&backend), Duration::from_millis(50));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
@@ -123,7 +123,7 @@ async fn logs_ws_sends_ping_on_idle_connection() {
     insert_instance(&backend, &instance_id).await;
 
     let state = make_state(Arc::clone(&backend), Duration::from_millis(50));
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");
@@ -168,7 +168,7 @@ async fn workflow_ws_exits_promptly_on_client_close() {
     // failure.
     let state = make_state(Arc::clone(&backend), Duration::from_secs(30));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/workflow/{instance_id}/ws");
@@ -214,7 +214,7 @@ async fn logs_ws_exits_promptly_on_client_close() {
 
     let state = make_state(Arc::clone(&backend), Duration::from_secs(30));
     let events_tx = state.events_tx.clone();
-    let app = newton_core::api::api_v1_router(state);
+    let app = newton_core::api::api_v1_router(state, false);
     let port = spawn_router(app).await;
 
     let ws_url = format!("ws://127.0.0.1:{port}/stream/logs/{instance_id}/{node_id}/ws");

--- a/crates/core/tests/workflow_graph/test_git_operator.rs
+++ b/crates/core/tests/workflow_graph/test_git_operator.rs
@@ -410,3 +410,63 @@ async fn git_commit_empty_message_after_cleanup_strip_is_hard_err() {
         "only the fixture's initial commit should exist, got: {log_text}"
     );
 }
+
+/// `stage` with a real glob `exclude` pattern (spec 074 P11) actually
+/// excludes matching staged files end-to-end: `git add -A` stages
+/// everything, then the exclude pass unstages the ones matching `build/*`,
+/// leaving unrelated files staged. This is the behavior the old hand-rolled
+/// `glob_matches` silently failed to provide for anything but `*.ext`/
+/// `name.*` patterns.
+#[tokio::test]
+async fn git_stage_with_glob_exclude_unstages_matching_files() {
+    use newton_core::workflow::operators::git::GitOperator;
+
+    let repo = init_repo();
+    std::fs::create_dir_all(repo.path().join("build")).unwrap();
+    std::fs::write(repo.path().join("build").join("output.bin"), "bin\n").unwrap();
+    std::fs::write(repo.path().join("kept.txt"), "keep me\n").unwrap();
+
+    let op = GitOperator::new();
+    let ctx = make_git_ctx(&repo);
+    let params = serde_json::json!({ "operation": "stage", "exclude": ["build/*"] });
+    let result = op.execute(params, ctx).await.expect("stage must succeed");
+    assert_eq!(result["has_staged"], Value::Bool(true));
+
+    let staged = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+    let staged_text = String::from_utf8_lossy(&staged.stdout);
+    assert!(
+        staged_text.lines().any(|l| l == "kept.txt"),
+        "kept.txt should remain staged, got: {staged_text}"
+    );
+    assert!(
+        !staged_text.lines().any(|l| l.starts_with("build/")),
+        "build/* must be unstaged by the exclude pattern, got: {staged_text}"
+    );
+}
+
+/// An invalid glob `exclude` pattern is a hard `Err` (`GIT-STAGE-001`), not a
+/// silent no-op or a panic — the workflow author gets a clear, actionable
+/// failure instead of excludes quietly not applying.
+#[tokio::test]
+async fn git_stage_with_invalid_glob_pattern_is_hard_err() {
+    use newton_core::workflow::operators::git::GitOperator;
+
+    let repo = init_repo();
+    std::fs::write(repo.path().join("a.txt"), "hello\n").unwrap();
+    run_git_sync(repo.path(), &["add", "a.txt"]);
+
+    let op = GitOperator::new();
+    let ctx = make_git_ctx(&repo);
+    // Unterminated character class: not a valid glob.
+    let params = serde_json::json!({ "operation": "stage", "exclude": ["[invalid"] });
+    let err = op
+        .execute(params, ctx)
+        .await
+        .expect_err("invalid glob pattern must be a hard Err");
+
+    assert_eq!(err.code, "GIT-STAGE-001");
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -92,6 +92,11 @@ pub struct LogLine {
     pub level: String,
     pub message: String,
     pub timestamp: DateTime<Utc>,
+    /// Monotonic sequence number, unique per (instance_id, node_id), assigned
+    /// by `BackendStore::append_log_line` (`MAX(seq)+1`, starting at 1).
+    /// Clients reconnecting to the logs WS pass the highest `seq` they've
+    /// seen as `since_seq` to resume without a full replay (spec 074 B18).
+    pub seq: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -116,6 +121,12 @@ pub enum BroadcastEvent {
         instance_id: String,
         node_id: String,
         message: String,
+        /// The log line's persisted `seq` (spec 074 B18), or `0` for
+        /// synthetic, non-persisted lines (e.g. the "Connected to <task>"
+        /// frame sent on logs WS connect). Lets a client track the latest
+        /// seq it has seen across the live-forwarding portion of a logs WS
+        /// connection, to pass as `since_seq` on a future reconnect.
+        seq: i64,
     },
     #[serde(rename = "hilEvent")]
     HilEvent {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -131,6 +131,28 @@ pub enum BroadcastEvent {
         status: String,
         created_at: String,
     },
+    /// Emitted after a Finding is created, patched, or unblocked. Id-only,
+    /// same shape as `PlanUpdate`/`ExecutionUpdate`: clients re-fetch the
+    /// authoritative record from `GET /findings/{id}` on receipt.
+    #[serde(rename = "finding_update")]
+    FindingUpdate { finding_id: String },
+    /// Emitted after a Change Request is created or patched. Id-only; clients
+    /// re-fetch from `GET /change-requests/{id}` on receipt.
+    #[serde(rename = "change_request_update")]
+    ChangeRequestUpdate { change_request_id: String },
+    /// Emitted after any catalog resource (Product, Component, Repo, Module,
+    /// ModuleDependency, Kpi, EvalRun, Grade) is created, replaced, patched,
+    /// or deleted. `resource` names the kind (e.g. `"product"`, `"module"`)
+    /// so clients can route the id to the right re-fetch endpoint.
+    #[serde(rename = "catalog_update")]
+    CatalogUpdate { resource: String, id: String },
+    /// Emitted when an `OptimizeRun`'s status changes or a `Cycle` is
+    /// appended, closing the ADR-0013 event commitment. `cycle` is `Some`
+    /// when the update accompanies a Cycle append, `None` for a bare Run
+    /// status/field change. Published by the in-process optimize driver
+    /// (spec 073) via the same `events_tx` Plans/HIL already use.
+    #[serde(rename = "optimize_run_update")]
+    OptimizeRunUpdate { run_id: String, cycle: Option<i64> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -123,13 +123,30 @@ pub enum BroadcastEvent {
         event_id: String,
     },
     #[serde(rename = "plan_update")]
-    PlanUpdate { plan_id: String },
+    PlanUpdate {
+        plan_id: String,
+        /// Owning workflow instance id, when this plan is currently linked to
+        /// one (e.g. immediately after approval, which creates the
+        /// `ExecutionRecord` that becomes the plan's running instance).
+        /// `None` when no instance is linked (e.g. still awaiting approval,
+        /// or rejected without ever having run) — instance-scoped streams
+        /// treat `None` as "not addressable to any instance" and drop the
+        /// event rather than guessing (see `should_send_event`).
+        instance_id: Option<String>,
+    },
     #[serde(rename = "execution_update")]
     ExecutionUpdate {
         execution_id: String,
         plan_id: Option<String>,
         status: String,
         created_at: String,
+        /// Owning workflow instance id. Every Execution has one: until a real
+        /// workflow instance attaches to the `ExecutionRecord`, this falls
+        /// back to the execution's own id, mirroring
+        /// `ExecutionItem::instance_id`'s existing NULL-fallback convention
+        /// (see `list_executions_db`) so scoped streams can filter on it
+        /// unconditionally.
+        instance_id: String,
     },
     /// Emitted after a Finding is created, patched, or unblocked. Id-only,
     /// same shape as `PlanUpdate`/`ExecutionUpdate`: clients re-fetch the

--- a/crates/types/src/models.rs
+++ b/crates/types/src/models.rs
@@ -624,6 +624,12 @@ pub struct PlanApproverItem {
 pub struct ApprovedPlan {
     pub plan: PlanItem,
     pub execution_id: String,
+    /// Owning workflow instance id for the freshly-inserted ExecutionRecord.
+    /// No workflow instance has attached to it yet at approval time (its
+    /// `instanceId` column is NULL), so this mirrors `execution_id` per the
+    /// same NULL-fallback convention `list_executions_db` applies when
+    /// building `ExecutionItem::instance_id`.
+    pub instance_id: String,
     pub created_at: String,
 }
 

--- a/crates/types/src/store.rs
+++ b/crates/types/src/store.rs
@@ -300,4 +300,15 @@ pub trait BackendStore: Send + Sync {
         node_id: &str,
         since_seq: i64,
     ) -> Result<Vec<LogLine>, ApiError>;
+
+    /// Returns the last `limit` log lines (by seq), ordered ascending by seq
+    /// (i.e. oldest-of-the-tail first, matching `list_log_lines`'s ordering).
+    /// Used as the logs WS default replay (spec 074 B18): a fresh connection
+    /// with no `since_seq` gets the tail instead of the full history.
+    async fn list_log_lines_tail(
+        &self,
+        instance_id: &str,
+        node_id: &str,
+        limit: i64,
+    ) -> Result<Vec<LogLine>, ApiError>;
 }

--- a/docs/draft/048-newton-migrate-ailoop-tool-client-to-ailoop-core.md
+++ b/docs/draft/048-newton-migrate-ailoop-tool-client-to-ailoop-core.md
@@ -1,5 +1,12 @@
 # 048 - Migrate Newton ailoop integration from HTTP `ToolClient` to `ailoop-core` crate
 
+> **Status: COMPLETE.** This migration landed in commit `60a53cb4` ("fix(core):
+> migrate ailoop integration to ailoop-core WebSocket transport"); the HTTP
+> `ToolClient` (`tool_client.rs`) described below no longer exists. Ailoop
+> transport is WebSocket-only. `NEWTON_AILOOP_HTTP_URL` is read and ignored
+> (with a startup warning, spec 074 P10) — the "Recent revert" trailing-slash
+> guidance below no longer applies. Kept for historical context only.
+
 ## Purpose
 
 Newton's human-in-the-loop and tooling integration today uses an in-tree **HTTP REST** client (`crates/core/src/integrations/ailoop/tool_client.rs`, `reqwest`) against paths such as `/questions/{channel}`, `/authorization/{channel}`, and `/notifications/{channel}`.

--- a/openapi/newton-realtime.asyncapi.yaml
+++ b/openapi/newton-realtime.asyncapi.yaml
@@ -47,6 +47,14 @@ channels:
         $ref: '#/components/messages/PlanUpdate'
       executionUpdate:
         $ref: '#/components/messages/ExecutionUpdate'
+      findingUpdate:
+        $ref: '#/components/messages/FindingUpdate'
+      changeRequestUpdate:
+        $ref: '#/components/messages/ChangeRequestUpdate'
+      catalogUpdate:
+        $ref: '#/components/messages/CatalogUpdate'
+      optimizeRunUpdate:
+        $ref: '#/components/messages/OptimizeRunUpdate'
 
   workflowInstanceWs:
     address: /api/v1/stream/workflow/{instanceId}/ws
@@ -87,6 +95,14 @@ channels:
         $ref: '#/components/messages/PlanUpdate'
       executionUpdate:
         $ref: '#/components/messages/ExecutionUpdate'
+      findingUpdate:
+        $ref: '#/components/messages/FindingUpdate'
+      changeRequestUpdate:
+        $ref: '#/components/messages/ChangeRequestUpdate'
+      catalogUpdate:
+        $ref: '#/components/messages/CatalogUpdate'
+      optimizeRunUpdate:
+        $ref: '#/components/messages/OptimizeRunUpdate'
       lagged:
         $ref: '#/components/messages/Lagged'
 
@@ -157,6 +173,14 @@ channels:
         $ref: '#/components/messages/PlanUpdate'
       executionUpdate:
         $ref: '#/components/messages/ExecutionUpdate'
+      findingUpdate:
+        $ref: '#/components/messages/FindingUpdate'
+      changeRequestUpdate:
+        $ref: '#/components/messages/ChangeRequestUpdate'
+      catalogUpdate:
+        $ref: '#/components/messages/CatalogUpdate'
+      optimizeRunUpdate:
+        $ref: '#/components/messages/OptimizeRunUpdate'
       lagged:
         $ref: '#/components/messages/Lagged'
 
@@ -221,6 +245,52 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ExecutionUpdatePayload'
+
+    FindingUpdate:
+      name: FindingUpdate
+      title: Finding Update
+      description: |
+        Emitted after a Finding is created, patched, or unblocked. Id-only,
+        same shape as PlanUpdate/ExecutionUpdate: clients re-fetch the
+        authoritative record from `GET /findings/{id}` on receipt.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/FindingUpdatePayload'
+
+    ChangeRequestUpdate:
+      name: ChangeRequestUpdate
+      title: Change Request Update
+      description: |
+        Emitted after a Change Request is created or patched. Id-only;
+        clients re-fetch from `GET /change-requests/{id}` on receipt.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ChangeRequestUpdatePayload'
+
+    CatalogUpdate:
+      name: CatalogUpdate
+      title: Catalog Update
+      description: |
+        Emitted after any catalog resource (product, component, repo, module,
+        module-dependency, kpi, eval-run, grade) is created, replaced,
+        patched, or deleted. `resource` names the kind so clients can route
+        `id` to the matching read endpoint.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/CatalogUpdatePayload'
+
+    OptimizeRunUpdate:
+      name: OptimizeRunUpdate
+      title: Optimize Run Update
+      description: |
+        Emitted when an OptimizeRun's status changes or a Cycle is appended
+        (closes the ADR-0013 event commitment). `cycle` is present when the
+        update accompanies a Cycle append, absent for a bare Run status/field
+        change. Published by the in-process optimize driver via the same
+        `events_tx` Plans/HIL already use.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/OptimizeRunUpdatePayload'
 
     Lagged:
       name: Lagged
@@ -350,6 +420,70 @@ components:
         plan_id: null
         status: running
         created_at: "2026-01-01T00:00:00Z"
+
+    FindingUpdatePayload:
+      type: object
+      required: [type, finding_id]
+      properties:
+        type:
+          type: string
+          enum: [finding_update]
+        finding_id:
+          type: string
+      example:
+        type: finding_update
+        finding_id: finding-abc
+
+    ChangeRequestUpdatePayload:
+      type: object
+      required: [type, change_request_id]
+      properties:
+        type:
+          type: string
+          enum: [change_request_update]
+        change_request_id:
+          type: string
+      example:
+        type: change_request_update
+        change_request_id: cr-abc
+
+    CatalogUpdatePayload:
+      type: object
+      required: [type, resource, id]
+      properties:
+        type:
+          type: string
+          enum: [catalog_update]
+        resource:
+          type: string
+          description: |
+            Catalog resource kind: product | component | repo | module |
+            module-dependency | kpi | eval-run | grade.
+        id:
+          type: string
+      example:
+        type: catalog_update
+        resource: component
+        id: component-abc
+
+    OptimizeRunUpdatePayload:
+      type: object
+      required: [type, run_id]
+      properties:
+        type:
+          type: string
+          enum: [optimize_run_update]
+        run_id:
+          type: string
+        cycle:
+          type: integer
+          format: int64
+          nullable: true
+          description: Present (cycle number) when this update accompanies a Cycle append; null for a bare Run status/field change.
+      example:
+        type: optimize_run_update
+        run_id: run-001
+        cycle: 3
 
     LaggedPayload:
       type: object

--- a/openapi/newton-realtime.asyncapi.yaml
+++ b/openapi/newton-realtime.asyncapi.yaml
@@ -393,13 +393,27 @@ components:
           enum: [plan_update]
         plan_id:
           type: string
+        instance_id:
+          type: string
+          nullable: true
+          description: |
+            Owning workflow instance id, when this plan is currently linked
+            to one (e.g. immediately after approval, which creates the
+            ExecutionRecord that becomes the plan's running instance). Null
+            when no instance is linked (e.g. still awaiting approval, or
+            rejected without ever having run). Instance-scoped streams
+            (`/stream/workflow/{id}/ws`, `/stream/workflow/{id}/sse`) only
+            deliver this event when `instance_id` matches the stream's bound
+            instance; a null `instance_id` is dropped from every
+            instance-scoped stream.
       example:
         type: plan_update
         plan_id: plan-abc
+        instance_id: 550e8400-e29b-41d4-a716-446655440000
 
     ExecutionUpdatePayload:
       type: object
-      required: [type, execution_id, status, created_at]
+      required: [type, execution_id, status, created_at, instance_id]
       properties:
         type:
           type: string
@@ -414,12 +428,21 @@ components:
         created_at:
           type: string
           format: date-time
+        instance_id:
+          type: string
+          description: |
+            Owning workflow instance id. Every Execution has one: until a
+            real workflow instance attaches to the ExecutionRecord, this
+            falls back to the execution's own id. Instance-scoped streams
+            only deliver this event when `instance_id` matches the stream's
+            bound instance.
       example:
         type: execution_update
         execution_id: exec-001
         plan_id: null
         status: running
         created_at: "2026-01-01T00:00:00Z"
+        instance_id: exec-001
 
     FindingUpdatePayload:
       type: object

--- a/openapi/newton-realtime.asyncapi.yaml
+++ b/openapi/newton-realtime.asyncapi.yaml
@@ -21,9 +21,11 @@ x-connection-lifecycle:
     keepalive_interval_seconds: 10
     lag_handling: 'on broadcast Lagged(n), emits lagged then continues (never closes)'
   logs_ws:
-    connect_confirmation: 'logMessage "Connected to <task_name>"'
+    connect_confirmation: 'logMessage "Connected to <task_name>" (seq: 0, sentinel — not persisted)'
     close_codes: [1000, 1001]
     lag_handling: 'on broadcast Lagged(n), emits lagged then continues (never closes)'
+    replay_default: 'no since_seq query param: last 500 lines (tail), not full history (spec 074 B18)'
+    replay_resumption: 'since_seq=N query param: all persisted lines with seq > N, ascending'
 
 channels:
   heartbeat:
@@ -110,10 +112,17 @@ channels:
     address: /api/v1/stream/logs/{instanceId}/{nodeId}/ws
     description: |
       Per-instance, per-node log WebSocket. Emits a synthetic
-      `logMessage "Connected to <task_name>"` frame immediately on connect.
-      Task name is resolved from `WorkflowInstance.definition["tasks"][nodeId]["name"]`,
+      `logMessage "Connected to <task_name>"` frame immediately on connect
+      (with `seq: 0`, a sentinel — it is not a persisted line). Task name is
+      resolved from `WorkflowInstance.definition["tasks"][nodeId]["name"]`,
       falling back to `nodeId` when unavailable. Forwards only `LogMessage`
       events matching the given instance and node.
+
+      Historical replay (spec 074 B18): with no `since_seq` query param, the
+      default replay is the last 500 lines (`seq` ascending), not the full
+      history. Pass `since_seq=<N>` (the highest `seq` already seen, e.g. from
+      a prior connection) to instead replay every persisted line with
+      `seq > N`, for lossless resumption after a reconnect.
     parameters:
       instanceId:
         description: UUID of the workflow instance.
@@ -130,6 +139,15 @@ channels:
               type: string
             event_type:
               type: string
+            since_seq:
+              type: integer
+              format: int64
+              description: |
+                Resume replay from log lines with `seq` greater than this
+                value, instead of the default last-500-lines tail. Pass the
+                highest `seq` observed on a prior connection to this same
+                (instanceId, nodeId) pair to resume without gaps or
+                re-delivery.
     messages:
       connectConfirmation:
         $ref: '#/components/messages/LogMessage'
@@ -349,7 +367,7 @@ components:
 
     LogMessagePayload:
       type: object
-      required: [type, instance_id, node_id, message]
+      required: [type, instance_id, node_id, message, seq]
       properties:
         type:
           type: string
@@ -361,11 +379,22 @@ components:
           type: string
         message:
           type: string
+        seq:
+          type: integer
+          format: int64
+          description: |
+            The log line's persisted sequence number (spec 074 B18), unique
+            and monotonic per (instance_id, node_id), starting at 1. `0` is a
+            documented sentinel for synthetic, non-persisted lines (e.g. the
+            "Connected to <task_name>" frame sent on logs WS connect) — it is
+            never a real persisted seq. Track the highest `seq` seen to pass
+            as `since_seq` on a future reconnect.
       example:
         type: logMessage
         instance_id: 550e8400-e29b-41d4-a716-446655440000
         node_id: build-task
         message: Connected to build-task
+        seq: 0
 
     HilEventPayload:
       type: object

--- a/packages/newton-dsl-py/src/newton/__init__.py
+++ b/packages/newton-dsl-py/src/newton/__init__.py
@@ -10,12 +10,34 @@ Public API:
     human_approval  — HumanApprovalOperator constructor
     human_decision  — HumanDecisionOperator constructor
     sub_workflow    — WorkflowOperator constructor
+    barrier         — barrier operator constructor
+    set_context     — SetContextOperator constructor
+    noop            — NoOpOperator constructor
+    grader_command  — GraderCommandOperator constructor
+    reconcile       — ReconcileOperator constructor
+    change_request  — ChangeRequestOperator constructor
+    grader_agent    — GraderAgentOperator constructor
     when            — guard helper for .then(when=...)
     expr            — opaque Rhai expression passthrough
 """
 
 from .workflow import Workflow
-from .operators import command, agent, gh, git, human_approval, human_decision, sub_workflow
+from .operators import (
+    command,
+    agent,
+    gh,
+    git,
+    human_approval,
+    human_decision,
+    sub_workflow,
+    barrier,
+    set_context,
+    noop,
+    grader_command,
+    reconcile,
+    change_request,
+    grader_agent,
+)
 from .refs import when, expr
 
 __all__ = [
@@ -27,6 +49,13 @@ __all__ = [
     "human_approval",
     "human_decision",
     "sub_workflow",
+    "barrier",
+    "set_context",
+    "noop",
+    "grader_command",
+    "reconcile",
+    "change_request",
+    "grader_agent",
     "when",
     "expr",
 ]

--- a/packages/newton-dsl-py/src/newton/operators.py
+++ b/packages/newton-dsl-py/src/newton/operators.py
@@ -166,6 +166,144 @@ def sub_workflow(
     return OperatorCall("WorkflowOperator", params)
 
 
+def barrier(*, expected: list[str] | None = None) -> OperatorCall:
+    """barrier — waits for multiple tasks to complete before proceeding."""
+    params: dict[str, Any] = {}
+    if expected is not None:
+        params["expected"] = expected
+    return OperatorCall("barrier", params)
+
+
+def set_context(patch: dict[str, Any]) -> OperatorCall:
+    """SetContextOperator — applies a JSON-merge patch to the workflow context."""
+    return OperatorCall("SetContextOperator", {"patch": patch})
+
+
+def noop() -> OperatorCall:
+    """NoOpOperator — does nothing; useful as a graph placeholder/join point."""
+    return OperatorCall("NoOpOperator", {})
+
+
+def grader_command(
+    cmd: str,
+    grader: str,
+    scope: Any,
+    scope_id: Any,
+    *,
+    shell: str | None = None,
+    cwd: str | None = None,
+    timeout_seconds: int | None = None,
+    env: dict[str, Any] | None = None,
+    state: dict[str, Any] | None = None,
+) -> OperatorCall:
+    """GraderCommandOperator constructor — spec 062. Runs a shell command Grader."""
+    params: dict[str, Any] = {
+        "cmd": cmd,
+        "grader": grader,
+        "scope": scope,
+        "scope_id": scope_id,
+    }
+    if shell is not None:
+        params["shell"] = shell
+    if cwd is not None:
+        params["cwd"] = cwd
+    if timeout_seconds is not None:
+        params["timeout_seconds"] = timeout_seconds
+    if env is not None:
+        params["env"] = env
+    if state is not None:
+        params["state"] = state
+    return OperatorCall("GraderCommandOperator", params)
+
+
+def reconcile(
+    scope: Any,
+    scope_id: Any,
+    assessment: Any,
+    *,
+    grader: str | None = None,
+    engine: Any = None,
+    model: Any = None,
+    adjudication_timeout_seconds: int | None = None,
+) -> OperatorCall:
+    """ReconcileOperator constructor — spec 063 + 067.
+
+    Reconciles Observations from `assessment` (typically bound to a prior
+    grader task's output) with stored Findings for the given scope.
+    """
+    params: dict[str, Any] = {
+        "scope": scope,
+        "scope_id": scope_id,
+        "assessment": assessment,
+    }
+    if grader is not None:
+        params["grader"] = grader
+    if engine is not None:
+        params["engine"] = engine
+    if model is not None:
+        params["model"] = model
+    if adjudication_timeout_seconds is not None:
+        params["adjudication_timeout_seconds"] = adjudication_timeout_seconds
+    return OperatorCall("ReconcileOperator", params)
+
+
+def change_request(
+    scope: Any,
+    scope_id: Any,
+    *,
+    max_findings: int | None = None,
+    min_severity: str | None = None,
+    engine: Any = None,
+    model: Any = None,
+    synthesis_timeout_seconds: int | None = None,
+) -> OperatorCall:
+    """ChangeRequestOperator constructor — spec 064 + 067.
+
+    Synthesizes a ChangeRequest from open Findings for the given scope.
+    """
+    params: dict[str, Any] = {
+        "scope": scope,
+        "scope_id": scope_id,
+    }
+    if max_findings is not None:
+        params["max_findings"] = max_findings
+    if min_severity is not None:
+        params["min_severity"] = min_severity
+    if engine is not None:
+        params["engine"] = engine
+    if model is not None:
+        params["model"] = model
+    if synthesis_timeout_seconds is not None:
+        params["synthesis_timeout_seconds"] = synthesis_timeout_seconds
+    return OperatorCall("ChangeRequestOperator", params)
+
+
+def grader_agent(
+    grader: str,
+    scope: Any,
+    scope_id: Any,
+    rubric: Any,
+    *,
+    model: Any = None,
+    engine: Any = None,
+    timeout_seconds: int | None = None,
+) -> OperatorCall:
+    """GraderAgentOperator constructor — spec 065 + 067. Rubric-based AI grader."""
+    params: dict[str, Any] = {
+        "grader": grader,
+        "scope": scope,
+        "scope_id": scope_id,
+        "rubric": rubric,
+    }
+    if model is not None:
+        params["model"] = model
+    if engine is not None:
+        params["engine"] = engine
+    if timeout_seconds is not None:
+        params["timeout_seconds"] = timeout_seconds
+    return OperatorCall("GraderAgentOperator", params)
+
+
 class gh:
     """GitHub operator sub-constructors — one per operation (ADR 0006)."""
 

--- a/packages/newton-dsl-py/tests/roundtrip/conftest.py
+++ b/packages/newton-dsl-py/tests/roundtrip/conftest.py
@@ -13,12 +13,43 @@ import pytest
 import yaml
 
 
+def _is_truthy(value: str | None) -> bool:
+    """
+    Truthy check for env-var flags in this suite: unset, "", and "0" are
+    falsy; everything else (e.g. "1", "true") is truthy.
+    """
+    return value is not None and value != "" and value != "0"
+
+
+def _resolve_newton_bin() -> Path:
+    """
+    Resolve the path to the newton binary under the debug profile.
+
+    Honors CARGO_TARGET_DIR so this matches whatever cargo/nextest actually
+    produced: scripts/run-tests.sh overrides CARGO_TARGET_DIR (to
+    /tmp/newton-target by default) to keep cargo artifacts on one
+    filesystem, so a hardcoded repo-relative "target/debug" path would miss
+    the binary entirely when tests are invoked through that script (or by
+    any developer with CARGO_TARGET_DIR set in their shell).
+    """
+    cargo_target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if cargo_target_dir:
+        return Path(cargo_target_dir) / "debug" / "newton"
+    # tests/roundtrip/conftest.py -> tests/roundtrip -> tests -> newton-dsl-py -> packages -> repo_root
+    return Path(__file__).parents[4] / "target" / "debug" / "newton"
+
+
 # Path to the newton binary
-# tests/roundtrip/conftest.py -> tests/roundtrip -> tests -> newton-dsl-py -> packages -> repo_root
-NEWTON_BIN = Path(__file__).parents[4] / "target" / "debug" / "newton"
+NEWTON_BIN = _resolve_newton_bin()
 # Path to conformance fixtures
 # tests/roundtrip -> tests -> newton-dsl-py -> packages -> workflow-schema
 CONFORMANCE_DIR = Path(__file__).parents[3] / "workflow-schema" / "conformance"
+
+# Count of roundtrip validations skipped because the newton binary was
+# missing (and NEWTON_REQUIRE_BINARY was not set) — surfaced as a prominent
+# banner at the end of the run via pytest_terminal_summary below, so a
+# fully-skipped roundtrip suite can't quietly look like a passing run.
+_skipped_missing_binary_count = 0
 
 
 def normalize_yaml(doc: Any) -> Any:
@@ -52,7 +83,14 @@ def validate_with_newton(yaml_content: str) -> tuple[bool, str]:
     Write yaml_content to a temp file and run `newton workflow validate`.
     Returns (success, output).
     """
+    global _skipped_missing_binary_count
     if not NEWTON_BIN.exists():
+        if _is_truthy(os.environ.get("NEWTON_REQUIRE_BINARY")):
+            pytest.fail(
+                f"NEWTON_REQUIRE_BINARY is set but newton binary not found "
+                f"at {NEWTON_BIN}"
+            )
+        _skipped_missing_binary_count += 1
         pytest.skip(f"newton binary not found at {NEWTON_BIN}")
 
     with tempfile.NamedTemporaryFile(
@@ -157,3 +195,31 @@ def tasks_semantic_equal(
     if diffs:
         return False, "\n".join(diffs)
     return True, ""
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """
+    Pytest hook (auto-discovered from conftest.py): print a prominent,
+    impossible-to-miss banner at the very end of the run if any roundtrip
+    tests skipped because the newton binary was missing. Per-test skip
+    reasons scroll past in normal output; this hook runs after pytest's own
+    summary so it's always the last thing printed.
+
+    Set NEWTON_REQUIRE_BINARY=1 (as CI does) to turn these into hard
+    failures instead of skips.
+    """
+    if _skipped_missing_binary_count:
+        terminalreporter.write_sep("=", "ROUNDTRIP SUITE SKIPPED", red=True, bold=True)
+        terminalreporter.write_line(
+            f"{_skipped_missing_binary_count} roundtrip validation(s) SKIPPED: "
+            f"newton binary not found at {NEWTON_BIN}",
+            red=True,
+            bold=True,
+        )
+        terminalreporter.write_line(
+            "Build it first (e.g. `cargo build -p newton` from the repo root, "
+            "or via scripts/run-tests.sh), or set NEWTON_REQUIRE_BINARY=1 to "
+            "fail instead of skip (this is what CI does).",
+            yellow=True,
+        )
+        terminalreporter.write_sep("=", red=True, bold=True)

--- a/packages/newton-dsl-py/tests/roundtrip/test_require_binary.py
+++ b/packages/newton-dsl-py/tests/roundtrip/test_require_binary.py
@@ -1,0 +1,86 @@
+"""
+Tests for the NEWTON_REQUIRE_BINARY hard-fail gate and NEWTON_BIN path
+resolution in conftest.py (spec 074 P15).
+
+These monkeypatch the module-level NEWTON_BIN / env vars rather than
+relying on the real newton binary being absent (or present) in the
+developer's own environment, so they're deterministic either way.
+"""
+from __future__ import annotations
+
+import pytest
+
+from . import conftest as rt_conftest
+from .conftest import validate_with_newton
+
+
+@pytest.fixture(autouse=True)
+def _missing_binary_path(monkeypatch):
+    """
+    Point NEWTON_BIN at a path that is guaranteed not to exist, and isolate
+    the module-level skip counter so these intentional skip/fail exercises
+    don't pollute the real pytest_terminal_summary banner for the rest of
+    the suite.
+    """
+    monkeypatch.setattr(
+        rt_conftest, "NEWTON_BIN", rt_conftest.Path("/nonexistent/newton-binary-for-test")
+    )
+    monkeypatch.setattr(rt_conftest, "_skipped_missing_binary_count", 0)
+
+
+def test_require_binary_hard_fails_when_binary_missing(monkeypatch):
+    """NEWTON_REQUIRE_BINARY=1 + missing binary must FAIL, not skip."""
+    monkeypatch.setenv("NEWTON_REQUIRE_BINARY", "1")
+
+    with pytest.raises(pytest.fail.Exception, match="NEWTON_REQUIRE_BINARY is set"):
+        validate_with_newton("name: test\n")
+
+
+def test_missing_binary_without_require_flag_still_skips(monkeypatch):
+    """Without NEWTON_REQUIRE_BINARY set, missing binary keeps skipping."""
+    monkeypatch.delenv("NEWTON_REQUIRE_BINARY", raising=False)
+
+    with pytest.raises(pytest.skip.Exception, match="newton binary not found"):
+        validate_with_newton("name: test\n")
+
+
+@pytest.mark.parametrize(
+    "value,expect_fail",
+    [
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("0", False),
+        ("", False),
+    ],
+)
+def test_require_binary_truthy_values(monkeypatch, value, expect_fail):
+    monkeypatch.setenv("NEWTON_REQUIRE_BINARY", value)
+
+    if expect_fail:
+        with pytest.raises(pytest.fail.Exception):
+            validate_with_newton("name: test\n")
+    else:
+        with pytest.raises(pytest.skip.Exception):
+            validate_with_newton("name: test\n")
+
+
+def test_require_binary_unset_skips(monkeypatch):
+    monkeypatch.delenv("NEWTON_REQUIRE_BINARY", raising=False)
+    with pytest.raises(pytest.skip.Exception):
+        validate_with_newton("name: test\n")
+
+
+class TestResolveNewtonBin:
+    """CARGO_TARGET_DIR must be honored so run-tests.sh's override (and any
+    developer's custom target dir) resolves to the actual build output."""
+
+    def test_respects_cargo_target_dir(self, monkeypatch):
+        monkeypatch.setenv("CARGO_TARGET_DIR", "/tmp/some-target-dir")
+        resolved = rt_conftest._resolve_newton_bin()
+        assert resolved == rt_conftest.Path("/tmp/some-target-dir") / "debug" / "newton"
+
+    def test_defaults_to_repo_target_debug_without_cargo_target_dir(self, monkeypatch):
+        monkeypatch.delenv("CARGO_TARGET_DIR", raising=False)
+        resolved = rt_conftest._resolve_newton_bin()
+        assert resolved.parts[-3:] == ("target", "debug", "newton")

--- a/packages/newton-dsl-py/tests/test_operators.py
+++ b/packages/newton-dsl-py/tests/test_operators.py
@@ -1,0 +1,164 @@
+"""Tests for the operator builders added in spec 074 P8:
+barrier, set_context, noop, grader_command, reconcile, change_request, grader_agent.
+"""
+from newton.operators import (
+    barrier,
+    set_context,
+    noop,
+    grader_command,
+    reconcile,
+    change_request,
+    grader_agent,
+)
+
+
+def test_barrier_defaults_to_no_params():
+    call = barrier()
+    assert call.operator_type == "barrier"
+    assert call.params == {}
+
+
+def test_barrier_includes_expected_task_ids():
+    call = barrier(expected=["t1", "t2"])
+    assert call.operator_type == "barrier"
+    assert call.params == {"expected": ["t1", "t2"]}
+
+
+def test_set_context_produces_patch():
+    call = set_context({"foo": "bar"})
+    assert call.operator_type == "SetContextOperator"
+    assert call.params == {"patch": {"foo": "bar"}}
+
+
+def test_noop_has_no_params():
+    call = noop()
+    assert call.operator_type == "NoOpOperator"
+    assert call.params == {}
+
+
+def test_grader_command_required_params():
+    call = grader_command("./grade.sh", "test-coverage-grader", "module", "mod-001")
+    assert call.operator_type == "GraderCommandOperator"
+    assert call.params == {
+        "cmd": "./grade.sh",
+        "grader": "test-coverage-grader",
+        "scope": "module",
+        "scope_id": "mod-001",
+    }
+
+
+def test_grader_command_optional_params():
+    call = grader_command(
+        "./grade.sh",
+        "test-coverage-grader",
+        "module",
+        "mod-001",
+        shell="zsh",
+        cwd="sub/dir",
+        timeout_seconds=30,
+        env={"FOO": "bar"},
+        state={"key": "value"},
+    )
+    assert call.params == {
+        "cmd": "./grade.sh",
+        "grader": "test-coverage-grader",
+        "scope": "module",
+        "scope_id": "mod-001",
+        "shell": "zsh",
+        "cwd": "sub/dir",
+        "timeout_seconds": 30,
+        "env": {"FOO": "bar"},
+        "state": {"key": "value"},
+    }
+
+
+def test_reconcile_required_params():
+    call = reconcile("module", "mod-001", {"overall_score": 90})
+    assert call.operator_type == "ReconcileOperator"
+    assert call.params == {
+        "scope": "module",
+        "scope_id": "mod-001",
+        "assessment": {"overall_score": 90},
+    }
+
+
+def test_reconcile_optional_params():
+    call = reconcile(
+        "module",
+        "mod-001",
+        {"overall_score": 90},
+        grader="test-grader",
+        engine="codex",
+        model="gpt-5",
+        adjudication_timeout_seconds=45,
+    )
+    assert call.params == {
+        "scope": "module",
+        "scope_id": "mod-001",
+        "assessment": {"overall_score": 90},
+        "grader": "test-grader",
+        "engine": "codex",
+        "model": "gpt-5",
+        "adjudication_timeout_seconds": 45,
+    }
+
+
+def test_change_request_required_params():
+    call = change_request("module", "mod-001")
+    assert call.operator_type == "ChangeRequestOperator"
+    assert call.params == {"scope": "module", "scope_id": "mod-001"}
+
+
+def test_change_request_optional_params():
+    call = change_request(
+        "module",
+        "mod-001",
+        max_findings=5,
+        min_severity="high",
+        engine="codex",
+        model="gpt-5",
+        synthesis_timeout_seconds=30,
+    )
+    assert call.params == {
+        "scope": "module",
+        "scope_id": "mod-001",
+        "max_findings": 5,
+        "min_severity": "high",
+        "engine": "codex",
+        "model": "gpt-5",
+        "synthesis_timeout_seconds": 30,
+    }
+
+
+def test_grader_agent_required_params():
+    call = grader_agent(
+        "docs-quality-grader", "repo", "repo-001", "Grade the docs for clarity."
+    )
+    assert call.operator_type == "GraderAgentOperator"
+    assert call.params == {
+        "grader": "docs-quality-grader",
+        "scope": "repo",
+        "scope_id": "repo-001",
+        "rubric": "Grade the docs for clarity.",
+    }
+
+
+def test_grader_agent_optional_params():
+    call = grader_agent(
+        "docs-quality-grader",
+        "repo",
+        "repo-001",
+        "Grade the docs for clarity.",
+        model="gpt-5",
+        engine="codex",
+        timeout_seconds=90,
+    )
+    assert call.params == {
+        "grader": "docs-quality-grader",
+        "scope": "repo",
+        "scope_id": "repo-001",
+        "rubric": "Grade the docs for clarity.",
+        "model": "gpt-5",
+        "engine": "codex",
+        "timeout_seconds": 90,
+    }

--- a/packages/newton-dsl-ts/src/index.ts
+++ b/packages/newton-dsl-ts/src/index.ts
@@ -28,6 +28,13 @@ export {
   subWorkflow,
   git,
   gh,
+  barrier,
+  setContext,
+  noop,
+  graderCommand,
+  reconcile,
+  changeRequest,
+  graderAgent,
   OperatorCall,
 } from "./operators.js";
 export {

--- a/packages/newton-dsl-ts/src/operators.ts
+++ b/packages/newton-dsl-ts/src/operators.ts
@@ -162,6 +162,160 @@ export function subWorkflow(opts: SubWorkflowOpts): OperatorCall {
 }
 
 // --------------------------------------------------------------------------
+// barrier
+// --------------------------------------------------------------------------
+
+export interface BarrierOpts {
+  /** Task ids that must all complete before this barrier passes. */
+  expected?: string[];
+}
+
+export function barrier(opts: BarrierOpts = {}): OperatorCall {
+  const params: Record<string, AnyValue> = {};
+  if (opts.expected != null) params.expected = opts.expected;
+  return new OperatorCall("barrier", params);
+}
+
+// --------------------------------------------------------------------------
+// SetContextOperator
+// --------------------------------------------------------------------------
+
+export interface SetContextOpts {
+  /** JSON-merge patch applied to the workflow context. */
+  patch: Record<string, AnyValue>;
+}
+
+export function setContext(opts: SetContextOpts): OperatorCall {
+  return new OperatorCall("SetContextOperator", { patch: opts.patch });
+}
+
+// --------------------------------------------------------------------------
+// NoOpOperator
+// --------------------------------------------------------------------------
+
+export function noop(): OperatorCall {
+  return new OperatorCall("NoOpOperator", {});
+}
+
+// --------------------------------------------------------------------------
+// GraderCommandOperator — spec 062. Runs a shell command Grader.
+// --------------------------------------------------------------------------
+
+export interface GraderCommandOpts {
+  cmd: string;
+  grader: string;
+  scope: AnyValue;
+  scopeId: AnyValue;
+  shell?: string;
+  cwd?: string | Ref;
+  timeoutSeconds?: number;
+  env?: Record<string, string | Ref | Guard>;
+  state?: Record<string, string | Ref | Guard>;
+}
+
+export function graderCommand(opts: GraderCommandOpts): OperatorCall {
+  const params: Record<string, AnyValue> = {
+    cmd: opts.cmd,
+    grader: opts.grader,
+    scope: opts.scope,
+    scope_id: opts.scopeId,
+  };
+  if (opts.shell != null) params.shell = opts.shell;
+  if (opts.cwd != null) params.cwd = opts.cwd;
+  if (opts.timeoutSeconds != null) params.timeout_seconds = opts.timeoutSeconds;
+  if (opts.env != null) params.env = opts.env;
+  if (opts.state != null) params.state = opts.state;
+  return new OperatorCall("GraderCommandOperator", params);
+}
+
+// --------------------------------------------------------------------------
+// ReconcileOperator — spec 063 + 067. Reconciles Observations into Findings.
+// --------------------------------------------------------------------------
+
+export interface ReconcileOpts {
+  scope: AnyValue;
+  scopeId: AnyValue;
+  /** Assessment JSON — typically bound via a prior grader task's output. */
+  assessment: AnyValue;
+  grader?: string;
+  engine?: AnyValue;
+  model?: AnyValue;
+  adjudicationTimeoutSeconds?: number;
+}
+
+export function reconcile(opts: ReconcileOpts): OperatorCall {
+  const params: Record<string, AnyValue> = {
+    scope: opts.scope,
+    scope_id: opts.scopeId,
+    assessment: opts.assessment,
+  };
+  if (opts.grader != null) params.grader = opts.grader;
+  if (opts.engine != null) params.engine = opts.engine;
+  if (opts.model != null) params.model = opts.model;
+  if (opts.adjudicationTimeoutSeconds != null) {
+    params.adjudication_timeout_seconds = opts.adjudicationTimeoutSeconds;
+  }
+  return new OperatorCall("ReconcileOperator", params);
+}
+
+// --------------------------------------------------------------------------
+// ChangeRequestOperator — spec 064 + 067. Synthesizes a ChangeRequest from
+// open Findings.
+// --------------------------------------------------------------------------
+
+export interface ChangeRequestOpts {
+  scope: AnyValue;
+  scopeId: AnyValue;
+  maxFindings?: number;
+  minSeverity?: string;
+  engine?: AnyValue;
+  model?: AnyValue;
+  synthesisTimeoutSeconds?: number;
+}
+
+export function changeRequest(opts: ChangeRequestOpts): OperatorCall {
+  const params: Record<string, AnyValue> = {
+    scope: opts.scope,
+    scope_id: opts.scopeId,
+  };
+  if (opts.maxFindings != null) params.max_findings = opts.maxFindings;
+  if (opts.minSeverity != null) params.min_severity = opts.minSeverity;
+  if (opts.engine != null) params.engine = opts.engine;
+  if (opts.model != null) params.model = opts.model;
+  if (opts.synthesisTimeoutSeconds != null) {
+    params.synthesis_timeout_seconds = opts.synthesisTimeoutSeconds;
+  }
+  return new OperatorCall("ChangeRequestOperator", params);
+}
+
+// --------------------------------------------------------------------------
+// GraderAgentOperator — spec 065 + 067. Rubric-based AI grader.
+// --------------------------------------------------------------------------
+
+export interface GraderAgentOpts {
+  grader: string;
+  scope: AnyValue;
+  scopeId: AnyValue;
+  rubric: AnyValue;
+  model?: AnyValue;
+  engine?: AnyValue;
+  timeoutSeconds?: number;
+}
+
+export function graderAgent(opts: GraderAgentOpts): OperatorCall {
+  const params: Record<string, AnyValue> = {
+    grader: opts.grader,
+    scope: opts.scope,
+    scope_id: opts.scopeId,
+    rubric: opts.rubric,
+  };
+  if (opts.model != null) params.model = opts.model;
+  if (opts.engine != null) params.engine = opts.engine;
+  if (opts.timeoutSeconds != null) params.timeout_seconds = opts.timeoutSeconds;
+  return new OperatorCall("GraderAgentOperator", params);
+}
+
+// --------------------------------------------------------------------------
 // GhOperator sub-constructors
 // --------------------------------------------------------------------------
 

--- a/packages/newton-dsl-ts/test/operators.test.ts
+++ b/packages/newton-dsl-ts/test/operators.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the operator builders added in spec 074 P8:
+ * barrier, setContext, noop, graderCommand, reconcile, changeRequest, graderAgent.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  barrier,
+  setContext,
+  noop,
+  graderCommand,
+  reconcile,
+  changeRequest,
+  graderAgent,
+} from "../src/index.js";
+
+describe("barrier", () => {
+  it("produces the barrier operator tag with no params by default", () => {
+    const call = barrier();
+    expect(call.operatorType).toBe("barrier");
+    expect(call.params).toEqual({});
+  });
+
+  it("includes expected task ids when provided", () => {
+    const call = barrier({ expected: ["t1", "t2"] });
+    expect(call.operatorType).toBe("barrier");
+    expect(call.params).toEqual({ expected: ["t1", "t2"] });
+  });
+});
+
+describe("setContext", () => {
+  it("produces SetContextOperator with a patch object", () => {
+    const call = setContext({ patch: { foo: "bar" } });
+    expect(call.operatorType).toBe("SetContextOperator");
+    expect(call.params).toEqual({ patch: { foo: "bar" } });
+  });
+});
+
+describe("noop", () => {
+  it("produces NoOpOperator with no params", () => {
+    const call = noop();
+    expect(call.operatorType).toBe("NoOpOperator");
+    expect(call.params).toEqual({});
+  });
+});
+
+describe("graderCommand", () => {
+  it("produces GraderCommandOperator with required params", () => {
+    const call = graderCommand({
+      cmd: "./grade.sh",
+      grader: "test-coverage-grader",
+      scope: "module",
+      scopeId: "mod-001",
+    });
+    expect(call.operatorType).toBe("GraderCommandOperator");
+    expect(call.params).toEqual({
+      cmd: "./grade.sh",
+      grader: "test-coverage-grader",
+      scope: "module",
+      scope_id: "mod-001",
+    });
+  });
+
+  it("includes optional params when provided", () => {
+    const call = graderCommand({
+      cmd: "./grade.sh",
+      grader: "test-coverage-grader",
+      scope: "module",
+      scopeId: "mod-001",
+      shell: "zsh",
+      cwd: "sub/dir",
+      timeoutSeconds: 30,
+      env: { FOO: "bar" },
+      state: { key: "value" },
+    });
+    expect(call.params).toEqual({
+      cmd: "./grade.sh",
+      grader: "test-coverage-grader",
+      scope: "module",
+      scope_id: "mod-001",
+      shell: "zsh",
+      cwd: "sub/dir",
+      timeout_seconds: 30,
+      env: { FOO: "bar" },
+      state: { key: "value" },
+    });
+  });
+});
+
+describe("reconcile", () => {
+  it("produces ReconcileOperator with required params", () => {
+    const call = reconcile({
+      scope: "module",
+      scopeId: "mod-001",
+      assessment: { overall_score: 90 },
+    });
+    expect(call.operatorType).toBe("ReconcileOperator");
+    expect(call.params).toEqual({
+      scope: "module",
+      scope_id: "mod-001",
+      assessment: { overall_score: 90 },
+    });
+  });
+
+  it("includes optional params when provided", () => {
+    const call = reconcile({
+      scope: "module",
+      scopeId: "mod-001",
+      assessment: { overall_score: 90 },
+      grader: "test-grader",
+      engine: "codex",
+      model: "gpt-5",
+      adjudicationTimeoutSeconds: 45,
+    });
+    expect(call.params).toEqual({
+      scope: "module",
+      scope_id: "mod-001",
+      assessment: { overall_score: 90 },
+      grader: "test-grader",
+      engine: "codex",
+      model: "gpt-5",
+      adjudication_timeout_seconds: 45,
+    });
+  });
+});
+
+describe("changeRequest", () => {
+  it("produces ChangeRequestOperator with required params", () => {
+    const call = changeRequest({ scope: "module", scopeId: "mod-001" });
+    expect(call.operatorType).toBe("ChangeRequestOperator");
+    expect(call.params).toEqual({ scope: "module", scope_id: "mod-001" });
+  });
+
+  it("includes optional params when provided", () => {
+    const call = changeRequest({
+      scope: "module",
+      scopeId: "mod-001",
+      maxFindings: 5,
+      minSeverity: "high",
+      engine: "codex",
+      model: "gpt-5",
+      synthesisTimeoutSeconds: 30,
+    });
+    expect(call.params).toEqual({
+      scope: "module",
+      scope_id: "mod-001",
+      max_findings: 5,
+      min_severity: "high",
+      engine: "codex",
+      model: "gpt-5",
+      synthesis_timeout_seconds: 30,
+    });
+  });
+});
+
+describe("graderAgent", () => {
+  it("produces GraderAgentOperator with required params", () => {
+    const call = graderAgent({
+      grader: "docs-quality-grader",
+      scope: "repo",
+      scopeId: "repo-001",
+      rubric: "Grade the docs for clarity.",
+    });
+    expect(call.operatorType).toBe("GraderAgentOperator");
+    expect(call.params).toEqual({
+      grader: "docs-quality-grader",
+      scope: "repo",
+      scope_id: "repo-001",
+      rubric: "Grade the docs for clarity.",
+    });
+  });
+
+  it("includes optional params when provided", () => {
+    const call = graderAgent({
+      grader: "docs-quality-grader",
+      scope: "repo",
+      scopeId: "repo-001",
+      rubric: "Grade the docs for clarity.",
+      model: "gpt-5",
+      engine: "codex",
+      timeoutSeconds: 90,
+    });
+    expect(call.params).toEqual({
+      grader: "docs-quality-grader",
+      scope: "repo",
+      scope_id: "repo-001",
+      rubric: "Grade the docs for clarity.",
+      model: "gpt-5",
+      engine: "codex",
+      timeout_seconds: 90,
+    });
+  });
+});

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Newton Test Runner Script
-# Runs fmt check, clippy, then tests with cargo-nextest; captures results and emits report to stdout (text or JSON).
+# Runs fmt check, clippy, then tests with cargo-nextest, then the
+# newton-dsl-ts (pnpm) and newton-dsl-py (uv/pytest, NEWTON_REQUIRE_BINARY=1)
+# suites; captures results and emits report to stdout (text or JSON).
 #
 # Usage: ./run-tests.sh [OPTIONS]
 #
@@ -69,7 +71,9 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             echo "Newton Test Runner Script"
             echo ""
-            echo "Runs fmt check, clippy, then tests with cargo-nextest; captures results and emits report to stdout (text or JSON)."
+            echo "Runs fmt check, clippy, then tests with cargo-nextest, then the"
+            echo "newton-dsl-ts (pnpm) and newton-dsl-py (uv/pytest, NEWTON_REQUIRE_BINARY=1)"
+            echo "suites; captures results and emits report to stdout (text or JSON)."
             echo ""
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -84,10 +88,14 @@ while [[ $# -gt 0 ]]; do
             echo "Requirements:"
             echo "  - cargo-nextest: Fast test runner for Rust"
             echo "  - cargo-clippy: Rust linter (included with rustup)"
+            echo "  - pnpm: for packages/newton-dsl-ts tests"
+            echo "  - uv: for packages/newton-dsl-py tests"
             echo ""
             echo "Install requirements:"
             echo "  cargo install cargo-nextest"
             echo "  rustup component add clippy"
+            echo "  # pnpm: https://pnpm.io/installation"
+            echo "  # uv: https://docs.astral.sh/uv/getting-started/installation/"
             exit 0
             ;;
         *)
@@ -102,6 +110,8 @@ echo -e "${YELLOW}Checking dependencies...${NC}" >&2
 check_command "cargo" "Cargo (Rust package manager)"
 check_command "cargo-nextest" "cargo-nextest (install with: cargo install cargo-nextest)"
 check_command "cargo-clippy" "cargo-clippy (install with: rustup component add clippy)"
+check_command "pnpm" "pnpm (needed for packages/newton-dsl-ts tests)"
+check_command "uv" "uv (needed for packages/newton-dsl-py tests)"
 
 echo -e "${GREEN}All dependencies found!${NC}" >&2
 echo "" >&2
@@ -158,6 +168,58 @@ else
     echo -e "${RED}Some tests failed!${NC}" >&2
 fi
 
+echo "" >&2
+
+# --- DSL package test suites (spec 074 P15) --------------------------------
+# newton-dsl-ts (pnpm/vitest) and newton-dsl-py (uv/pytest) previously had
+# no signal in this script at all — a developer running run-tests.sh got no
+# indication the DSL suites even existed, let alone whether the roundtrip
+# suite was silently skipping (see conftest.py's NEWTON_REQUIRE_BINARY gate).
+# NEWTON_REQUIRE_BINARY=1 here matches CI: a missing newton binary turns
+# roundtrip skips into hard failures instead of a quiet, all-green no-op.
+# The `cargo nextest run` above (with CARGO_TARGET_DIR honored) already
+# builds the newton bin target at $CARGO_TARGET_DIR/debug/newton.
+#
+# Scope note: DSL suite results are reported as a simple pass/fail addendum
+# below, not folded into the detailed statistics parsing (PASSED/FAILED/
+# SKIPPED counts, progress bar, etc.) a few lines down — that machinery
+# greps cargo-nextest's specific summary line format, and adapting it to
+# two more, unrelated test runners' output formats is out of scope for this
+# item. Their exit status IS folded into the script's overall EXIT_CODE /
+# OVERALL_STATUS and therefore the final process exit code.
+DSL_TS_STATUS="SKIPPED"
+DSL_PY_STATUS="SKIPPED"
+
+echo -e "${YELLOW}Running newton-dsl-ts tests (pnpm)...${NC}" >&2
+set +e
+(cd "$NEWTON_DIR/packages/newton-dsl-ts" && pnpm install --frozen-lockfile && pnpm test) >&2
+DSL_TS_EXIT=$?
+set -e
+if [ "$DSL_TS_EXIT" -eq 0 ]; then
+    DSL_TS_STATUS="PASSED"
+    echo -e "${GREEN}newton-dsl-ts tests passed!${NC}" >&2
+else
+    DSL_TS_STATUS="FAILED"
+    EXIT_CODE=1
+    OVERALL_STATUS="FAILED"
+    echo -e "${RED}newton-dsl-ts tests failed!${NC}" >&2
+fi
+echo "" >&2
+
+echo -e "${YELLOW}Running newton-dsl-py tests (uv/pytest, NEWTON_REQUIRE_BINARY=1)...${NC}" >&2
+set +e
+(cd "$NEWTON_DIR/packages/newton-dsl-py" && uv sync && NEWTON_REQUIRE_BINARY=1 uv run pytest) >&2
+DSL_PY_EXIT=$?
+set -e
+if [ "$DSL_PY_EXIT" -eq 0 ]; then
+    DSL_PY_STATUS="PASSED"
+    echo -e "${GREEN}newton-dsl-py tests passed!${NC}" >&2
+else
+    DSL_PY_STATUS="FAILED"
+    EXIT_CODE=1
+    OVERALL_STATUS="FAILED"
+    echo -e "${RED}newton-dsl-py tests failed!${NC}" >&2
+fi
 echo "" >&2
 
 # Parse test results from output
@@ -236,6 +298,16 @@ if [ "${FAILED:-0}" -gt 0 ]; then
     FAILED_TESTS=$(echo "$TEST_OUTPUT" | grep -A 5 -B 1 "FAIL\|✗" | grep "^\s*[^-]*test.*" | sed 's/.*--- \(.*\) ---.*/\1/' | grep -v "^\s*$" | head -10)
 fi
 
+# DSL suite results as a simple pass/fail addendum (see scope note above —
+# not folded into test_statistics, which is nextest-specific).
+DSL_SUITES_JSON=$(cat << EOF
+  "dsl_suites": {
+    "newton_dsl_ts": "$DSL_TS_STATUS",
+    "newton_dsl_py": "$DSL_PY_STATUS"
+  }
+EOF
+)
+
 # Build JSON content (for stdout and/or file)
 if [ "$COMPILATION_FAILED" = true ]; then
     JSON_CONTENT=$(cat << EOF
@@ -250,7 +322,8 @@ if [ "$COMPILATION_FAILED" = true ]; then
     "failed": 0,
     "skipped": 0,
     "passing_percentage": 0
-  }
+  },
+$DSL_SUITES_JSON
 }
 EOF
 )
@@ -267,7 +340,8 @@ else
     "failed": ${FAILED:-0},
     "skipped": ${SKIPPED:-0},
     "passing_percentage": $PASSING_PERCENTAGE
-  }
+  },
+$DSL_SUITES_JSON
 }
 EOF
 )
@@ -321,6 +395,14 @@ else
             echo "- Skipped: ${SKIPPED:-0}"
             echo "- Passing Rate: ${PASSING_PERCENTAGE}%"
         fi
+        echo ""
+
+        # DSL package suites (spec 074 P15) — simple pass/fail addendum,
+        # deliberately not merged into "Test Statistics" above (see scope
+        # note near where these suites are run).
+        echo "## DSL Package Suites"
+        echo "- newton-dsl-ts (pnpm test): $DSL_TS_STATUS"
+        echo "- newton-dsl-py (uv run pytest, NEWTON_REQUIRE_BINARY=1): $DSL_PY_STATUS"
         echo ""
 
         if [ "$COMPILATION_FAILED" = true ]; then
@@ -400,6 +482,10 @@ else
     echo "  Passed: ${PASSED:-0} (${PASSING_PERCENTAGE}%)" >&2
     echo "  Failed: ${FAILED:-0}" >&2
     echo "  Skipped: ${SKIPPED:-0}" >&2
+    echo "" >&2
+    echo "DSL Suites:" >&2
+    echo "  newton-dsl-ts: $DSL_TS_STATUS" >&2
+    echo "  newton-dsl-py: $DSL_PY_STATUS" >&2
     echo "" >&2
 
     if [ "$EXIT_CODE" -eq 0 ]; then


### PR DESCRIPTION
Implements Tranche 3 ("realtime & DSL parity") of the audit remediation spec (074, local), following tranches 1 (#491) and 2 (#493). Seven work items plus a 9-angle review pass with fixes.

## Changes

- **Realtime event parity (P3)**: `BroadcastEvent::{FindingUpdate, ChangeRequestUpdate, CatalogUpdate, OptimizeRunUpdate}` now emit from every mutating Finding/ChangeRequest/Catalog handler (fire-and-forget, mirroring the existing Plan/Execution pattern). Closes the ADR-0013 event-parity gap for those three resources. **OptimizeRunUpdate**: investigation found no code path in the repo mutates OptimizeRun/Cycle state in-process today — the only mutator is the CLI's `data` command, which runs in a separate OS process with no access to `serve`'s `events_tx` (the real in-process driver is spec 073, still draft). Shipped the tested write-and-broadcast primitives (`optimize_run.rs`) as public, unmounted functions ready for that spec, documented in-file.
- **Instance-scoped Plan/Execution events (B13)**: `PlanUpdate`/`ExecutionUpdate` now carry `instance_id` and are filtered by it on scoped streams — previously a `/stream/workflow/{id}/ws` listener received *every* plan/execution event system-wide, not just its own instance's. `ExecutionUpdate.instance_id` is always populated; `PlanUpdate.instance_id` is `Option` (`None` when a plan has no linked execution yet, e.g. on reject) and is filtered out of scoped streams accordingly.
- **WS ping + close-detection (B14)**: `handle_workflow_socket`/`handle_logs_socket` now `tokio::select!` over the client's read half (Close/error/EOF → exit promptly) alongside the broadcast receiver and a 30s ping tick — previously neither read the client socket at all, so a vanished client with no broadcast traffic held its server task open indefinitely.
- **Logs WS resumption (B18)**: accepts `since_seq` for resumption; defaults to the last 500 lines instead of a full, unbounded replay. `LogLine`/`BroadcastEvent::LogMessage` gained a `seq` field (previously fetched from SQL and discarded). Investigation confirmed no production code path appends real log lines during task execution yet — a genuine pre-existing gap, documented as a follow-up, out of scope here.
- **DSL operator builders (P8)**: hand-added `barrier`/`setContext`/`noop` plus the four tranche-2 loop operators (`graderCommand`/`reconcile`/`changeRequest`/`graderAgent`) to both `newton-dsl-ts` and `newton-dsl-py`, verified against the Rust operators' actual param structs. `AssertCompletedOperator`/`ReadControlFileOperator` deliberately excluded (not in spec's list, no evidence of author-facing demand).
- **Small fixes (P9-P12)**: magictool router now gated behind `newton serve --with-magic-tools` (default off) until Part B registers real tools; a startup warning when `NEWTON_AILOOP_HTTP_URL` is set but has no effect (WebSocket-only transport); git `stage.exclude` replaced its hand-rolled matcher with the `globset` crate; `data delete` gives a documented, resource-specific rejection (not a generic error) for the 8 lifecycle-managed/append-only resources that don't support it, `data get optimize-cycle <id>` now does a real lookup instead of always erroring, and findings/change-requests/plans list filters are exposed as `--status`/`--scope`/`--scope-id` flags.
- **Local/CI hard-fail on missing binary (P15)**: `NEWTON_REQUIRE_BINARY=1` turns the DSL roundtrip suite's silent skip into a hard failure (set in CI); found and fixed a real gap this exposed — the `newton-dsl-py` CI job downloaded the release binary to `/usr/local/bin` but the roundtrip tests look for it at `target/debug/newton`, so the suite had been silently skipping in CI too, not just locally. `scripts/run-tests.sh` now runs both DSL packages' test suites after the Rust suite.

## Review (9-angle, high effort)

8 finder angles (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, conventions) plus a 9th angle specifically hunting for integration bugs between this tranche's 7 sequentially-landed work items. Verified findings, fixed:

- **Glob basename-matching regression** (P11): confirmed independently by 3 separate finder angles with reproducible evidence. The `globset` migration anchors an unmodified pattern to the full relative path, so a bare `test_results.*`-style exclude pattern stopped matching nested files (`artifacts/test_results.json`) — exactly the pattern shape this repo's own `develop.yaml` workflows use. Fixed by prefixing separator-free patterns with `**/` before compiling; regression test added.
- **Error code collision** (P12): the 8 "DELETE unsupported" rejection messages reused `DATA-009`, already assigned to an unrelated `--status` flag-validation error, defeating programmatic error discrimination. Split to `DATA-010`.
- **Documented (not fixed) at-least-once delivery race**: logs WS's subscribe-then-replay ordering means a real log line persisted in that narrow window could theoretically be delivered twice. Currently unreachable (no production path appends real log lines yet, per B18's own investigation above); added a code comment for whoever wires that path next.
- Two other candidates were investigated and closed as non-issues: the `OptimizeRunUpdate` wrapper functions' unreachability from the CLI is the same pre-existing, already-documented structural limitation described above (not new); a logs-WS `node_id` double-filter (query param vs. path segment) is real but predates this branch entirely — noted as a pre-existing follow-up, not touched here.

## Verification

- All suites green across newton-types/backend/core/cli; fmt + clippy `-D warnings` clean; pre-commit/pre-push hooks passed on every commit; DSL suites green (pnpm, pytest with `NEWTON_REQUIRE_BINARY=1` against a real binary).
- **Diff coverage 97.27%** (1103/1134 instrumented added lines vs main); two coverage gaps found during the initial pass (an untested `unblock_finding` broadcast path, an untested `git stage --exclude` end-to-end wiring path) were closed with targeted regression tests before the review pass.
- Full 9-angle review with adversarial verification on ambiguous findings; the glob-exclude regression, the error-code collision, and the delivery-race documentation were fixed on-branch.

## Known follow-ups (documented, not blocking)

- Pre-existing (not introduced by this branch): logs WS's `node_id` double-filter between the query-string `StreamFilters.node_id` and the URL path segment can silently drop live log frames if a client sends conflicting values.
- No production code path appends real log lines during task execution yet — `list_log_lines`/`list_log_lines_tail` currently only ever replay whatever a test harness seeded. B18 delivers the resumption *contract*; wiring real log persistence is separate work.
- `OptimizeRunUpdate`'s write-and-broadcast primitives are unmounted, waiting on spec 073's in-process driver.
- Broadcast-send boilerplate (`let _ = state.events_tx.send(...)` after a successful mutation) is duplicated across findings.rs/change_requests.rs/optimize_run.rs/catalog.rs (catalog.rs factored its own local helper; the others didn't) — a shared `broadcast()` helper would collapse ~29 call sites.
- The WS `tokio::select!` scaffolding (split socket, ping tick, close-detection) is duplicated near-verbatim between `handle_workflow_socket` and `handle_logs_socket` — a generic `run_ws_loop` helper would collapse both.
- P8's 7 new DSL operator builders are hand-written, matching the existing pattern — spec 074's own text names schema-generated builders as the eventual end-state; each hand-add is technical debt against that goal.
- `data delete`'s capability matrix (8 resources documented as DELETE-unsupported) is expressed as imperative per-arm match rejections in 3 unsynchronized places (dispatch match, validation gates, help text) rather than one declarative capability table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
