### PR TITLE
fix(cli): validate numeric arg bounds and reject bad --format

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -261,3 +261,7 @@ path = "tests/integration/test_run_input_file_verbose.rs"
 [[test]]
 name = "doctor_workspace_resolution"
 path = "tests/integration/doctor_workspace_resolution.rs"
+
+[[test]]
+name = "arg_validation_bounds"
+path = "tests/integration/arg_validation_bounds.rs"

--- a/crates/cli/src/cli/framework_setup/commands/optimize.rs
+++ b/crates/cli/src/cli/framework_setup/commands/optimize.rs
@@ -58,6 +58,7 @@ pub(crate) fn optimize_command() -> Command {
                     value_type: ArgValueType::Int,
                     cardinality: Cardinality::Optional,
                     help: "Seconds to wait when the Plan queue is empty (default: 60)",
+                    min: Some(1),
                     ..Default::default()
                 },
             ],

--- a/crates/cli/src/cli/framework_setup/commands/serve.rs
+++ b/crates/cli/src/cli/framework_setup/commands/serve.rs
@@ -41,6 +41,8 @@ pub(crate) fn serve_command() -> Command {
                     value_type: ArgValueType::Int,
                     cardinality: Cardinality::Optional,
                     help: "Port to listen on (default: 8080)",
+                    min: Some(1),
+                    max: Some(65535),
                     ..Default::default()
                 },
                 ArgSpec {

--- a/crates/cli/src/cli/framework_setup/commands/workflow.rs
+++ b/crates/cli/src/cli/framework_setup/commands/workflow.rs
@@ -168,6 +168,7 @@ pub(crate) fn workflow_command() -> Command {
                     value_type: ArgValueType::Int,
                     cardinality: Cardinality::Optional,
                     help: "Limit list to N most recent executions (runs list)",
+                    min: Some(1),
                     ..Default::default()
                 },
                 ArgSpec {
@@ -205,6 +206,7 @@ pub(crate) fn workflow_command() -> Command {
                     value_type: ArgValueType::Int,
                     cardinality: Cardinality::Optional,
                     help: "Runtime override for bounded task concurrency (workflow run)",
+                    min: Some(1),
                     ..Default::default()
                 },
                 ArgSpec {
@@ -214,6 +216,7 @@ pub(crate) fn workflow_command() -> Command {
                     value_type: ArgValueType::Int,
                     cardinality: Cardinality::Optional,
                     help: "Runtime wall-clock limit override in seconds (workflow run)",
+                    min: Some(1),
                     ..Default::default()
                 },
                 ArgSpec {
@@ -270,7 +273,7 @@ pub(crate) fn workflow_command() -> Command {
                         })?;
                         commands::lint(LintArgs {
                             workflow,
-                            format: parse_output_format(&args),
+                            format: parse_output_format(&args)?,
                         })
                         .map_err(anyhow::Error::from)
                     }
@@ -288,7 +291,7 @@ pub(crate) fn workflow_command() -> Command {
                             workspace: get_opt_path(&args, "workspace"),
                             context,
                             trigger,
-                            format: parse_output_format(&args),
+                            format: parse_output_format(&args)?,
                             parameters_json: get_opt_path(&args, "parameters-json"),
                         })
                         .map_err(anyhow::Error::from)
@@ -392,14 +395,9 @@ pub(crate) fn workflow_command() -> Command {
                             .unwrap_or_default();
                         match subcmd2.as_str() {
                             "list" => {
+                                // framework enforces min=1, so the value is >= 1 and the cast is safe
                                 let last = if let Some(ArgValue::Int(n)) = args.get("last") {
-                                    let n = *n as usize;
-                                    if n == 0 {
-                                        return Err(anyhow!(
-                                            "LOG-003: runs list --last must be a positive integer"
-                                        ));
-                                    }
-                                    Some(n)
+                                    Some(*n as usize)
                                 } else {
                                     None
                                 };

--- a/crates/cli/src/cli/framework_setup/mod.rs
+++ b/crates/cli/src/cli/framework_setup/mod.rs
@@ -97,11 +97,16 @@ pub(crate) fn get_opt_str(map: &HashMap<String, ArgValue>, key: &str) -> Option<
     }
 }
 
-pub(crate) fn parse_output_format(map: &HashMap<String, ArgValue>) -> OutputFormat {
+pub(crate) fn parse_output_format(map: &HashMap<String, ArgValue>) -> anyhow::Result<OutputFormat> {
     match get_opt_str(map, "format").as_deref() {
-        Some("json") => OutputFormat::Json,
-        Some("prose") => OutputFormat::Prose,
-        _ => OutputFormat::Text,
+        Some("text") | None => Ok(OutputFormat::Text),
+        Some("json") => Ok(OutputFormat::Json),
+        Some("prose") => Ok(OutputFormat::Prose),
+        Some(other) => Err(anyhow!(
+            "{}: unknown format '{}' (supported: text, json, prose)",
+            error_codes::CLI_MIG_002,
+            other
+        )),
     }
 }
 
@@ -255,11 +260,13 @@ impl RunArgs {
         let parameters_json = get_opt_path(map, "parameters-json");
         let emit_completion_json = get_bool(map, "emit-completion-json");
         let parallel_limit = if let Some(ArgValue::Int(n)) = map.get("parallel-limit") {
+            // framework enforces min=1, so the value is >= 1 and the cast is safe
             Some(*n as usize)
         } else {
             None
         };
         let timeout_seconds = if let Some(ArgValue::Int(n)) = map.get("timeout") {
+            // framework enforces min=1, so the value is >= 1 and the cast is safe
             Some(*n as u64)
         } else {
             None
@@ -305,6 +312,7 @@ impl FromArgValueMap for OptimizeArgs {
         let project_id = get_opt_str(map, "project-id")
             .unwrap_or_else(|| panic!("fw bug: project-id is required"));
         let poll_interval_seconds = if let Some(ArgValue::Int(n)) = map.get("poll-interval") {
+            // framework enforces min=1, so the value is >= 1 and the cast is safe
             *n as u64
         } else {
             60
@@ -322,7 +330,8 @@ impl FromArgValueMap for ServeArgs {
     fn from_arg_value_map(map: &HashMap<String, ArgValue>) -> Self {
         let host = get_opt_str(map, "host").unwrap_or_else(|| "127.0.0.1".to_string());
         let port = if let Some(ArgValue::Int(n)) = map.get("port") {
-            u16::try_from(*n).unwrap_or(8080)
+            // framework enforces min=1/max=65535, so the value always fits u16
+            u16::try_from(*n).expect("port ArgSpec enforces 1..=65535")
         } else {
             8080
         };

--- a/crates/cli/tests/integration/arg_validation_bounds.rs
+++ b/crates/cli/tests/integration/arg_validation_bounds.rs
@@ -1,0 +1,189 @@
+//! Regression coverage for CLI numeric-bound and `--format` validation.
+//!
+//! These guard pre-existing bugs where out-of-range numeric args silently
+//! wrapped / fell back to a default (via unchecked `as` casts) and an unknown
+//! `--format` value silently defaulted to Text. The fix adds declarative
+//! `min`/`max` bounds to the ArgSpecs (enforced by the framework's
+//! `validate_typed_args` before any constructor runs, emitting `E004`) and
+//! makes `parse_output_format` reject unknown formats with `CLI-MIG-002`.
+
+#[path = "../support/mod.rs"]
+mod support;
+
+use support::{fixture_path, newton, TempWorkspace};
+
+/// Combined lowercased stdout+stderr for assertion convenience.
+fn combined_lower(out: &std::process::Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+    .to_lowercase()
+}
+
+// ── serve --port bounds (min=1, max=65535) ───────────────────────────────────
+
+#[test]
+fn serve_port_above_max_is_rejected() {
+    let out = newton()
+        .args(["serve", "--port", "99999"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "port 99999 must be rejected");
+    let msg = combined_lower(&out);
+    assert!(
+        msg.contains("maximum") || msg.contains("65535"),
+        "expected an above-maximum message, got: {msg}"
+    );
+}
+
+#[test]
+fn serve_port_below_min_is_rejected() {
+    let out = newton().args(["serve", "--port", "0"]).output().unwrap();
+    assert!(!out.status.success(), "port 0 must be rejected");
+    let msg = combined_lower(&out);
+    assert!(
+        msg.contains("minimum") || msg.contains("--port"),
+        "expected a below-minimum message, got: {msg}"
+    );
+}
+
+/// Positive control: a valid port passes arg validation. We pair it with an
+/// invalid bind host so the process fails fast *after* validation rather than
+/// leaving a server running — the point is that the failure is NOT an E004
+/// range violation, proving 9000 was accepted by the port bounds.
+#[test]
+fn serve_valid_port_passes_bound_validation() {
+    let out = newton()
+        .args(["serve", "--port", "9000", "--host", "999.999.999.999"])
+        .output()
+        .unwrap();
+    let msg = combined_lower(&out);
+    assert!(
+        !msg.contains("e004") && !msg.contains("maximum") && !msg.contains("minimum"),
+        "port 9000 must pass range validation; got: {msg}"
+    );
+}
+
+// ── workflow run --parallel-limit / --timeout (min=1) ─────────────────────────
+
+#[test]
+fn workflow_run_parallel_limit_negative_is_rejected() {
+    let wf = fixture_path("workflows/minimal_smoke.yaml");
+    let out = newton()
+        .args([
+            "workflow",
+            "run",
+            &wf.to_string_lossy(),
+            "--parallel-limit",
+            "-1",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "--parallel-limit -1 must be rejected"
+    );
+}
+
+#[test]
+fn workflow_run_timeout_zero_is_rejected() {
+    let wf = fixture_path("workflows/minimal_smoke.yaml");
+    let out = newton()
+        .args(["workflow", "run", &wf.to_string_lossy(), "--timeout", "0"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "--timeout 0 must be rejected");
+    let msg = combined_lower(&out);
+    assert!(
+        msg.contains("minimum") || msg.contains("--timeout"),
+        "expected a below-minimum message, got: {msg}"
+    );
+}
+
+// ── optimize --poll-interval (min=1) ──────────────────────────────────────────
+
+#[test]
+fn optimize_poll_interval_negative_is_rejected() {
+    let out = newton()
+        .args(["optimize", "some-project", "--poll-interval", "-1"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "--poll-interval -1 must be rejected");
+}
+
+// ── workflow runs list --last (min=1) ─────────────────────────────────────────
+
+/// `--last 0` is now rejected by the framework bound (E004), NOT by the removed
+/// handler-level `LOG-003` branch. Assert the failure and that the message is
+/// the framework's below-minimum message rather than the old LOG-003 text.
+#[test]
+fn runs_list_last_zero_is_rejected_by_framework() {
+    let out = newton()
+        .args(["workflow", "runs", "list", "--last", "0"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "--last 0 must be rejected");
+    let msg = combined_lower(&out);
+    assert!(
+        !msg.contains("log-003"),
+        "should no longer surface LOG-003 for --last 0; got: {msg}"
+    );
+    assert!(
+        msg.contains("minimum") || msg.contains("--last"),
+        "expected a below-minimum message, got: {msg}"
+    );
+}
+
+/// Positive control: a valid `--last` value parses and the command succeeds
+/// against an (empty) seeded workspace.
+#[test]
+fn runs_list_last_valid_positive_control() {
+    let ws = TempWorkspace::new();
+    newton()
+        .args([
+            "workflow",
+            "runs",
+            "list",
+            "--last",
+            "5",
+            "--workspace",
+            &ws.path().to_string_lossy(),
+        ])
+        .assert()
+        .success();
+}
+
+// ── --format rejection (lint / preview) ───────────────────────────────────────
+
+#[test]
+fn workflow_lint_unknown_format_is_rejected() {
+    let wf = fixture_path("workflows/minimal_smoke.yaml");
+    let out = newton()
+        .args(["workflow", "lint", &wf.to_string_lossy(), "--format", "xml"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "--format xml must be rejected");
+    let msg = combined_lower(&out);
+    assert!(
+        msg.contains("unknown format") && msg.contains("cli-mig-002"),
+        "expected an unknown-format CLI-MIG-002 message, got: {msg}"
+    );
+}
+
+/// Positive control: a valid `--format` value still parses and works.
+#[test]
+fn workflow_lint_valid_format_json_succeeds() {
+    let wf = fixture_path("workflows/minimal_smoke.yaml");
+    newton()
+        .args([
+            "workflow",
+            "lint",
+            &wf.to_string_lossy(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
Fixes three pre-existing CLI argument-validation bugs (present on `main`, surfaced incidentally during the tranche-4 review of PR #497 but out of scope there). Five numeric args accepted out-of-range/negative values that silently wrapped or fell back to a default instead of erroring, and `--format` silently swallowed unknown values.

## The bugs

- **`newton serve --port`** — an out-of-`u16`-range value (`--port 99999`) silently fell back to the default `8080` via `u16::try_from(*n).unwrap_or(8080)`; the operator gets a server on an unexpected port with no diagnostic.
- **`newton workflow run --parallel-limit` / `--timeout`, `newton workflow runs list --last`, `newton optimize --poll-interval`** — a negative value cast via `*n as usize` / `*n as u64` two's-complement-wrapped to a huge number (e.g. `--parallel-limit=-1` → `usize::MAX`), silently producing effectively-unbounded concurrency / an effectively-infinite timeout or poll interval instead of an error. (`--poll-interval` was not in the reviewed diff — it's the same latent bug, found and swept in here.)
- **`newton workflow lint` / `preview --format`** — an unrecognized value (`--format xml`) was silently coerced to `Text` by `parse_output_format`'s catch-all arm, so a typo'd `--format json` in a CI pipeline would get human-readable text and fail downstream with a confusing parse error far from the cause. (`graph --format` already validated correctly and is untouched.)

## The fix

- **Numeric bounds — declarative.** The `cli-framework` `ArgSpec` already supports `min`/`max` for `Int` args, enforced by `validate_typed_args` (as `E004`) *before* any DTO constructor runs — newton just wasn't using it. Added bounds to the ArgSpecs in newton's own command definitions: `--port` `min=1, max=65535`; `--parallel-limit`, `--timeout`, `--last`, `--poll-interval` each `min=1`. This is the framework's intended mechanism, produces a clear message, and propagates the constraint to the MCP/JSON-schema surface. No cli-framework change needed.
- **Now-safe casts simplified.** With the values guaranteed in range, the `unwrap_or(8080)` fallback is dead (removed; `port` now `u16::try_from(*n).expect(...)` with a comment) and the `*n as usize`/`as u64` casts are documented as framework-enforced.
- **Dead `LOG-003` branch removed.** `runs list --last 0` was validated in two places; the handler-level `if n == 0 → LOG-003` branch is now dead (the framework's `min=1` rejects `0`/negatives first) and was removed. The separate inner `LOG-003` guard in `commands/log.rs` — which protects programmatic callers of `commands::log()` and is what the two existing `LOG-003` tests actually exercise — is kept, and those tests pass unchanged. (CLI users passing a bad `--last` now get the uniform `E004` "below minimum 1" message instead of `LOG-003`; deliberate, consistent with the other four args.)
- **`--format` — imperative.** `--format` is shared across `lint`/`preview`/`graph` with *different* valid sets (text|json, text|json|prose, dot), so it can't be a single declarative Enum. `parse_output_format` now returns `Result` and errors with `CLI-MIG-002` on anything outside `{text, json, prose}` (matching `graph`'s existing rejection style); `lint`/`preview` callers propagate it.

## Verification

End-to-end against the built binary — every bad input now exits non-zero with a clear message, including the negatives via the `=-1` equals form (the original wraparound trigger, which proves the `min` bound — not just clap's flag handling — is what closes the bug):

```
serve --port 99999            → error[E004]: value 99999 for '--port' is above maximum 65535   (exit 1)
serve --port 0                → error[E004]: value 0 for '--port' is below minimum 1           (exit 1)
workflow run <wf> --parallel-limit=-1 → error[E004]: value -1 for '--parallel-limit' is below minimum 1 (exit 1)
workflow run <wf> --timeout=-1        → error[E004]: value -1 for '--timeout' is below minimum 1        (exit 1)
optimize <id> --poll-interval=-1      → error[E004]: value -1 for '--poll-interval' is below minimum 1  (exit 1)
workflow runs list --last 0           → error[E004]: value 0 for '--last' is below minimum 1     (exit 1)
workflow lint <wf> --format xml       → CLI-MIG-002: unknown format 'xml' (supported: text, json, prose) (exit 1)
```
Valid values (`--port 9000`, `--last 5`, `--format json`) still accepted.

- 10 new regression tests in `crates/cli/tests/integration/arg_validation_bounds.rs` covering each of the 5 numeric args (min and, for port, max) plus the `--format` rejection and positive controls.
- The two existing `LOG-003` tests pass unchanged.
- `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full `cargo test --workspace` green (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
